### PR TITLE
clear the warning: variable "size" is used before its value is set

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -1307,7 +1307,7 @@ nvmlReturn_t nvmlDeviceGetCreatableVgpus(nvmlDevice_t device,
                                          nvmlVgpuTypeId_t *vgpuTypeIds);
 /**
  * @param vgpuTypeId SEND_ONLY
- * @param size RECV_ONLY
+ * @param size SEND_RECV
  * @param vgpuTypeClass RECV_ONLY LENGTH:size
  */
 nvmlReturn_t nvmlVgpuTypeGetClass(nvmlVgpuTypeId_t vgpuTypeId,


### PR DESCRIPTION
codegen/gen_server.cpp(5531): warning #549-D: variable "size" is used before its value is set
      vgpuTypeClass = (char*)malloc(size * sizeof(char));

ref: https://docs.nvidia.com/deploy/nvml-api/group__nvmlVgpu.html nvmlVgpuTypeGetClass(nvmlVgpuTypeId_t vgpuTypeId, char* vgpuTypeClass, unsigned int* size), size is in&out param