### PR TITLE
clear the warning: variable "dependencies" is used before its value is set

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -4937,6 +4937,7 @@ cudaError_t cudaStreamGetCaptureInfo_v2(
     unsigned long long *id_out, cudaGraph_t *graph_out,
     const cudaGraphNode_t **dependencies_out, size_t *numDependencies_out);
 /**
+ * @disabled
  * @param stream SEND_ONLY
  * @param numDependencies SEND_ONLY
  * @param dependencies SEND_ONLY LENGTH:numDependencies

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -83,7 +83,8 @@ MANUAL_IMPLEMENTATIONS = [
     "cudaGraphAddHostNode",
     "cudaGraphAddMemFreeNode",
     "cudaGraphAddMemAllocNode",
-    "cudaDeviceGetGraphMemAttribute"
+    "cudaDeviceGetGraphMemAttribute",
+    "cudaStreamUpdateCaptureDependencies"
 ]
 
 

--- a/codegen/manual_client.cpp
+++ b/codegen/manual_client.cpp
@@ -1322,3 +1322,42 @@ cudaError_t cudaDeviceGetGraphMemAttribute(int device,
     return cudaErrorDevicesUnavailable;
   return return_value;
 }
+
+cudaError_t cudaStreamUpdateCaptureDependencies(cudaStream_t stream, cudaGraphNode_t* dependencies,
+    size_t numDependencies, unsigned int flags)
+{
+    conn_t *conn = rpc_client_get_connection(0);
+    if (maybe_copy_unified_arg(conn, (void*)&stream, cudaMemcpyHostToDevice) < 0)
+      return cudaErrorDevicesUnavailable;
+    if (maybe_copy_unified_arg(conn, (void*)&numDependencies, cudaMemcpyHostToDevice) < 0)
+      return cudaErrorDevicesUnavailable;
+    if (maybe_copy_unified_arg(conn, (void*)dependencies, cudaMemcpyHostToDevice) < 0)
+      return cudaErrorDevicesUnavailable;
+    for (int i = 0; i < static_cast<int>(numDependencies) && is_unified_pointer(conn, (void*)dependencies); i++)
+      if (maybe_copy_unified_arg(conn, (void*)&dependencies[i], cudaMemcpyHostToDevice) < 0)
+        return cudaErrorDevicesUnavailable;
+    if (maybe_copy_unified_arg(conn, (void*)&flags, cudaMemcpyHostToDevice) < 0)
+      return cudaErrorDevicesUnavailable;
+    cudaError_t return_value;
+    if (rpc_write_start_request(conn, RPC_cudaStreamUpdateCaptureDependencies) < 0 ||
+        rpc_write(conn, &stream, sizeof(cudaStream_t)) < 0 ||
+        rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
+        rpc_write(conn, dependencies, numDependencies * sizeof(cudaGraphNode_t)) < 0 ||
+        rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(cudaError_t)) < 0 ||
+        rpc_read_end(conn) < 0)
+        return cudaErrorDevicesUnavailable;
+    if (maybe_copy_unified_arg(conn, (void*)&stream, cudaMemcpyDeviceToHost) < 0)
+      return cudaErrorDevicesUnavailable;
+    if (maybe_copy_unified_arg(conn, (void*)&numDependencies, cudaMemcpyDeviceToHost) < 0)
+      return cudaErrorDevicesUnavailable;
+    if (maybe_copy_unified_arg(conn, (void*)dependencies, cudaMemcpyDeviceToHost) < 0)
+      return cudaErrorDevicesUnavailable;
+    for (int i = 0; i < static_cast<int>(numDependencies) && is_unified_pointer(conn, (void*)dependencies); i++)
+      if (maybe_copy_unified_arg(conn, (void*)&dependencies[i], cudaMemcpyDeviceToHost) < 0)
+        return cudaErrorDevicesUnavailable;
+    if (maybe_copy_unified_arg(conn, (void*)&flags, cudaMemcpyDeviceToHost) < 0)
+      return cudaErrorDevicesUnavailable;
+    return return_value;
+}

--- a/codegen/manual_client.h
+++ b/codegen/manual_client.h
@@ -3,11 +3,15 @@
 #include <nvml.h>
 #include <cuda_runtime_api.h>
 
-cudaError_t cudaGraphAddKernelNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, const cudaGraphNode_t *pDependencies, size_t numDependencies, const struct cudaKernelNodeParams *pNodeParams);
-cudaError_t cudaGraphAddMemAllocNode(cudaGraphNode_t* pGraphNode, cudaGraph_t graph, const cudaGraphNode_t* pDependencies, size_t numDependencies, struct cudaMemAllocNodeParams* nodeParams);
+cudaError_t cudaGraphAddKernelNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph, 
+    const cudaGraphNode_t *pDependencies, size_t numDependencies, const struct cudaKernelNodeParams *pNodeParams);
+cudaError_t cudaGraphAddMemAllocNode(cudaGraphNode_t* pGraphNode, cudaGraph_t graph, 
+    const cudaGraphNode_t* pDependencies, size_t numDependencies, struct cudaMemAllocNodeParams* nodeParams);
 cudaError_t cudaGraphAddMemFreeNode(cudaGraphNode_t* pGraphNode, cudaGraph_t graph,
-                                    const cudaGraphNode_t* pDependencies, size_t numDependencies, void* dptr);
+    const cudaGraphNode_t* pDependencies, size_t numDependencies, void* dptr);
 cudaError_t cudaDeviceGetGraphMemAttribute(int device, enum cudaGraphMemAttributeType attr, void* value);
+cudaError_t cudaStreamUpdateCaptureDependencies(cudaStream_t stream, cudaGraphNode_t* dependencies,
+    size_t numDependencies, unsigned int flags);
 cudaError_t cudaFree(void *devPtr);
 cudaError_t cudaMallocHost(void **ptr, size_t size);
 cudaError_t cudaMallocManaged(void **devPtr, size_t size, unsigned int flags);

--- a/codegen/manual_server.h
+++ b/codegen/manual_server.h
@@ -11,6 +11,7 @@ int handle_cudaGraphAddKernelNode(conn_t *conn);
 int handle_cudaGraphGetNodes(conn_t *conn);
 int handle_cudaGraphAddMemAllocNode(conn_t *conn);
 int handle_cudaDeviceGetGraphMemAttribute(conn_t *conn);
+int handle_cudaStreamUpdateCaptureDependencies(conn_t *conn);
 int handle_cudaGraphAddMemFreeNode(conn_t *conn);
 int handle_cudaFree(conn_t *conn);
 int handle_cudaMemcpy(conn_t *conn);


### PR DESCRIPTION
…arning:

codegen/gen_server.cpp(9786): warning #549-D: variable "dependencies" is used before its value is set
          rpc_read(conn, dependencies, numDependencies * sizeof(cudaGraphNode_t)) < 0 ||