### PR TITLE
Harden client connection setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ else()
         ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
+
     enable_testing()
     add_test(NAME h2_test COMMAND h2_test)
     add_test(

--- a/client.cpp
+++ b/client.cpp
@@ -56,6 +56,8 @@ pthread_mutex_t conn_mutex;
 conn_t conns[16];
 int nconns = 0;
 static bool lupine_rpc_shutting_down = false;
+static constexpr int LUPINE_MAX_CLIENT_CONNS =
+    static_cast<int>(sizeof(conns) / sizeof(conns[0]));
 
 const char *DEFAULT_PORT = "14833";
 
@@ -8684,7 +8686,7 @@ void rpc_close(conn_t *conn) {
 }
 
 static void lupine_rpc_shutdown() {
-  if (pthread_mutex_lock(&conn_mutex) < 0) {
+  if (pthread_mutex_lock(&conn_mutex) != 0) {
     return;
   }
   if (lupine_rpc_shutting_down) {
@@ -8844,25 +8846,39 @@ void *rpc_client_dispatch_thread(void *arg) {
 }
 
 int rpc_open() {
-  if (pthread_mutex_lock(&conn_mutex) < 0)
+  if (pthread_mutex_lock(&conn_mutex) != 0)
     return -1;
 
   if (nconns > 0) {
-    if (pthread_mutex_unlock(&conn_mutex) < 0)
+    if (pthread_mutex_unlock(&conn_mutex) != 0)
       return -1;
     return 0;
   }
 
   char *server_ips = getenv("LUPINE_SERVER");
   if (server_ips == NULL) {
-    if (pthread_mutex_unlock(&conn_mutex) < 0)
+    if (pthread_mutex_unlock(&conn_mutex) != 0)
       return -1;
     return -1;
   }
 
-  char *server_ip = strdup(server_ips);
+  char *server_ip_storage = strdup(server_ips);
+  if (server_ip_storage == nullptr) {
+    if (pthread_mutex_unlock(&conn_mutex) != 0)
+      return -1;
+    return -1;
+  }
+
+  char *server_ip = server_ip_storage;
   char *token;
   while ((token = strsep(&server_ip, ","))) {
+    if (token[0] == '\0') {
+      continue;
+    }
+    if (nconns >= LUPINE_MAX_CLIENT_CONNS) {
+      break;
+    }
+
     char *host;
     char *port;
 
@@ -8891,6 +8907,7 @@ int rpc_open() {
     int sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
     if (sockfd == -1) {
       printf("socket creation failed...\n");
+      freeaddrinfo(res);
       continue;
     }
 
@@ -8900,6 +8917,7 @@ int rpc_open() {
       LUPINE_LOG_ERROR("Connecting to " << host << " port " << port
                                         << " failed: " << strerror(errno));
       close(sockfd);
+      freeaddrinfo(res);
       continue;
     }
 
@@ -8908,22 +8926,35 @@ int rpc_open() {
     conns[nconns].request_id = 0;
     conns[nconns].closed = 0;
     conns[nconns].local_request_parity = conns[nconns].request_id & 1;
-    if (pthread_mutex_init(&conns[nconns].read_mutex, NULL) < 0 ||
-        pthread_mutex_init(&conns[nconns].write_mutex, NULL) < 0 ||
-        pthread_mutex_init(&conns[nconns].call_mutex, NULL) < 0 ||
-        pthread_cond_init(&conns[nconns].read_cond, NULL) < 0 ||
+    if (pthread_mutex_init(&conns[nconns].read_mutex, NULL) != 0 ||
+        pthread_mutex_init(&conns[nconns].write_mutex, NULL) != 0 ||
+        pthread_mutex_init(&conns[nconns].call_mutex, NULL) != 0 ||
+        pthread_cond_init(&conns[nconns].read_cond, NULL) != 0 ||
         rpc_http2_client_init(&conns[nconns]) < 0) {
       close(sockfd);
+      freeaddrinfo(res);
+      free(server_ip_storage);
+      pthread_mutex_unlock(&conn_mutex);
       return -1;
     }
 
-    pthread_create(&conns[nconns].read_thread, NULL, rpc_client_dispatch_thread,
-                   (void *)&conns[nconns]);
+    if (pthread_create(&conns[nconns].read_thread, NULL,
+                       rpc_client_dispatch_thread,
+                       (void *)&conns[nconns]) != 0) {
+      close(sockfd);
+      freeaddrinfo(res);
+      free(server_ip_storage);
+      pthread_mutex_unlock(&conn_mutex);
+      return -1;
+    }
 
     nconns++;
+    freeaddrinfo(res);
   }
 
-  if (pthread_mutex_unlock(&conn_mutex) < 0)
+  free(server_ip_storage);
+
+  if (pthread_mutex_unlock(&conn_mutex) != 0)
     return -1;
   if (nconns == 0)
     return -1;
@@ -8937,6 +8968,11 @@ conn_t *rpc_client_get_connection(unsigned int index) {
 }
 
 int rpc_size() { return nconns; }
+
+#ifdef LUPINE_CONNECTION_SETUP_TEST
+extern "C" int lupine_test_rpc_open() { return rpc_open(); }
+extern "C" int lupine_test_rpc_size() { return rpc_size(); }
+#endif
 
 #ifdef cuGetProcAddress
 #undef cuGetProcAddress

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -70,7 +70,7 @@ void *rpc_client_dispatch_thread(void *p) {
 }
 
 int open_connection() {
-  if (pthread_mutex_lock(&conn_mutex) < 0) {
+  if (pthread_mutex_lock(&conn_mutex) != 0) {
     return -1;
   }
   if (connected) {
@@ -135,13 +135,13 @@ int open_connection() {
         c->connfd = sockfd;
         c->request_id = 0;
         c->local_request_parity = c->request_id & 1;
-        if (pthread_mutex_init(&c->read_mutex, nullptr) < 0 ||
-            pthread_mutex_init(&c->write_mutex, nullptr) < 0 ||
-            pthread_mutex_init(&c->call_mutex, nullptr) < 0 ||
-            pthread_cond_init(&c->read_cond, nullptr) < 0 ||
+        if (pthread_mutex_init(&c->read_mutex, nullptr) != 0 ||
+            pthread_mutex_init(&c->write_mutex, nullptr) != 0 ||
+            pthread_mutex_init(&c->call_mutex, nullptr) != 0 ||
+            pthread_cond_init(&c->read_cond, nullptr) != 0 ||
             rpc_http2_client_init(c) < 0 ||
             pthread_create(&c->read_thread, nullptr, rpc_client_dispatch_thread,
-                           c) < 0) {
+                           c) != 0) {
           close(sockfd);
           freeaddrinfo(res);
           continue;

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -6,7 +6,7 @@
 void *_rpc_read_id_dispatch(void *p) {
   conn_t *conn = (conn_t *)p;
 
-  if (pthread_mutex_lock(&conn->read_mutex) < 0)
+  if (pthread_mutex_lock(&conn->read_mutex) != 0)
     return NULL;
 
   while (!conn->closed) {
@@ -23,7 +23,7 @@ void *_rpc_read_id_dispatch(void *p) {
       pthread_cond_broadcast(&conn->read_cond);
       break;
     }
-    if (pthread_cond_broadcast(&conn->read_cond) < 0)
+    if (pthread_cond_broadcast(&conn->read_cond) != 0)
       break;
   }
   pthread_mutex_unlock(&conn->read_mutex);
@@ -41,11 +41,11 @@ void *_rpc_read_id_dispatch(void *p) {
 int rpc_dispatch(conn_t *conn, int parity) {
   if (conn->rpc_thread == 0 &&
       pthread_create(&conn->rpc_thread, nullptr, _rpc_read_id_dispatch,
-                     (void *)conn) < 0) {
+                     (void *)conn) != 0) {
     return -1;
   }
 
-  if (pthread_mutex_lock(&conn->read_mutex) < 0) {
+  if (pthread_mutex_lock(&conn->read_mutex) != 0) {
     return -1;
   }
 
@@ -74,12 +74,12 @@ int rpc_dispatch(conn_t *conn, int parity) {
 // it is not necessary to call rpc_read_start() if it is the first call in
 // the sequence because by convention, the handler owns the read lock on entry.
 int rpc_read_start(conn_t *conn, int write_id) {
-  if (pthread_mutex_lock(&conn->read_mutex) < 0)
+  if (pthread_mutex_lock(&conn->read_mutex) != 0)
     return -1;
 
   // wait for the active read id to be the request id we are waiting for
   while (!conn->closed && conn->read_id != write_id)
-    if (pthread_cond_wait(&conn->read_cond, &conn->read_mutex) < 0)
+    if (pthread_cond_wait(&conn->read_cond, &conn->read_mutex) != 0)
       return -1;
 
   if (conn->closed) {
@@ -113,10 +113,10 @@ int rpc_read_end(conn_t *conn) {
   bool completes_local_request =
       read_id >= 2 && (read_id % 2) == conn->local_request_parity;
   conn->read_id = 0;
-  if (pthread_cond_broadcast(&conn->read_cond) < 0 ||
-      pthread_mutex_unlock(&conn->read_mutex) < 0)
+  if (pthread_cond_broadcast(&conn->read_cond) != 0 ||
+      pthread_mutex_unlock(&conn->read_mutex) != 0)
     return -1;
-  if (completes_local_request && pthread_mutex_unlock(&conn->call_mutex) < 0)
+  if (completes_local_request && pthread_mutex_unlock(&conn->call_mutex) != 0)
     return -1;
   return read_id;
 }
@@ -142,14 +142,14 @@ int rpc_write_start_request(conn_t *conn, const int op) {
   if (conn->closed) {
     return -1;
   }
-  if (pthread_mutex_lock(&conn->call_mutex) < 0) {
+  if (pthread_mutex_lock(&conn->call_mutex) != 0) {
     return -1;
   }
   if (conn->closed) {
     pthread_mutex_unlock(&conn->call_mutex);
     return -1;
   }
-  if (pthread_mutex_lock(&conn->write_mutex) < 0) {
+  if (pthread_mutex_lock(&conn->write_mutex) != 0) {
 #ifdef VERBOSE
     std::cout << "rpc_write_start failed due to rpc_open() < 0 || "
                  "conns[index].write_mutex lock"
@@ -174,7 +174,7 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
   if (conn->closed) {
     return -1;
   }
-  if (pthread_mutex_lock(&conn->write_mutex) < 0) {
+  if (pthread_mutex_lock(&conn->write_mutex) != 0) {
 #ifdef VERBOSE
     std::cout << "rpc_write_start failed due to rpc_open() < 0 || "
                  "conns[index].write_mutex lock"

--- a/server.cpp
+++ b/server.cpp
@@ -187,10 +187,10 @@ void client_handler(lupine_socket_t connfd) {
   conn_t conn = {connfd, 1};
   conn.request_id = 1;
   conn.local_request_parity = conn.request_id & 1;
-  if (pthread_mutex_init(&conn.read_mutex, NULL) < 0 ||
-      pthread_mutex_init(&conn.write_mutex, NULL) < 0 ||
-      pthread_mutex_init(&conn.call_mutex, NULL) < 0 ||
-      pthread_cond_init(&conn.read_cond, NULL) < 0 ||
+  if (pthread_mutex_init(&conn.read_mutex, NULL) != 0 ||
+      pthread_mutex_init(&conn.write_mutex, NULL) != 0 ||
+      pthread_mutex_init(&conn.call_mutex, NULL) != 0 ||
+      pthread_cond_init(&conn.read_cond, NULL) != 0 ||
       rpc_http2_server_init(&conn) < 0) {
     LUPINE_LOG_ERROR("Error initializing mutex.");
     return;
@@ -227,8 +227,8 @@ void client_handler(lupine_socket_t connfd) {
     }
   }
 
-  if (pthread_mutex_destroy(&conn.read_mutex) < 0 ||
-      pthread_mutex_destroy(&conn.write_mutex) < 0)
+  if (pthread_mutex_destroy(&conn.read_mutex) != 0 ||
+      pthread_mutex_destroy(&conn.write_mutex) != 0)
     LUPINE_LOG_ERROR("Error destroying mutex.");
 
   lupine_socket_close(connfd);

--- a/test/run_custom_tests.sh
+++ b/test/run_custom_tests.sh
@@ -23,6 +23,7 @@ LUPINE_LIB_DIR="$(cd "$(dirname "$LUPINE_LIB")" && pwd)"
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 CUDA_LIB_DIR="${CUDA_LIB_DIR:-/usr/local/cuda/lib64}"
 NVCC="${NVCC:-$CUDA_HOME/bin/nvcc}"
+CXX="${CXX:-g++}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-120}"
 if [[ -n "${BUILD_DIR:-}" ]]; then
   owns_build_dir=0
@@ -33,6 +34,58 @@ fi
 
 for f in "$SERVER_LOCAL_BIN" "$LUPINE_LIB"; do
   [[ -e "$f" ]] || { echo "missing build artifact: $f (build lupine first)" >&2; exit 1; }
+done
+
+pass=0 fail=0
+
+shopt -s nullglob
+host_tests=("$repo_root"/test/test_*.cpp)
+for src in "${host_tests[@]}"; do
+  name="$(basename "$src" .cpp)"
+  exe="$BUILD_DIR/$name"
+  echo "=== building $name ==="
+  build_ok=1
+  if [[ "$name" == "test_client_connection_setup" ]]; then
+    test_lib="$BUILD_DIR/lib${name}_client.so"
+    if ! "$CXX" -std=c++17 -shared -fPIC \
+         -fsanitize=address -fno-omit-frame-pointer \
+         -DLUPINE_CONNECTION_SETUP_TEST \
+         -I"$repo_root" -I"$repo_root/codegen" -I"$CUDA_HOME/include" \
+         "$repo_root/h2.cpp" \
+         "$repo_root/rpc.cpp" \
+         "$repo_root/compress.cpp" \
+         "$repo_root/client.cpp" \
+         "$repo_root/client_routing.cpp" \
+         "$repo_root/codegen/gen_client.cpp" \
+         "$repo_root/third_party/lz4/lz4.c" \
+         -o "$test_lib" \
+         -lnghttp2 -ldl -pthread \
+         -Wl,--version-script="$repo_root/test/test_client_connection_setup.exports" 2>&1; then
+      build_ok=0
+    elif ! "$CXX" -std=c++17 -fsanitize=address -fno-omit-frame-pointer \
+         "$src" -o "$exe" \
+         -L"$BUILD_DIR" -l"${name}_client" -pthread \
+         -Wl,-rpath,"$BUILD_DIR" 2>&1; then
+      build_ok=0
+    fi
+  else
+    if ! "$CXX" -std=c++17 "$src" -o "$exe" -pthread 2>&1; then
+      build_ok=0
+    fi
+  fi
+  if [[ "$build_ok" != "1" ]]; then
+    echo "BUILD FAILED: $name" >&2
+    fail=$((fail + 1))
+    continue
+  fi
+  echo "=== running $name ==="
+  if timeout --kill-after=5s "$TEST_TIMEOUT" "$exe"; then
+    echo "PASS: $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $name (exit $?)" >&2
+    fail=$((fail + 1))
+  fi
 done
 
 server_pid=""
@@ -51,8 +104,6 @@ server_pid="$(ssh "${SSH_ARGS[@]}" "$SERVER_SSH_TARGET" \
   "LUPINE_PORT=$SERVER_PORT nohup '$SERVER_REMOTE_BIN' >/tmp/lupine-custom-server.log 2>&1 </dev/null & echo \$!")"
 sleep 1
 
-pass=0 fail=0
-shopt -s nullglob
 tests=("$repo_root"/test/test_*.cu)
 if [[ ${#tests[@]} -eq 0 ]]; then
   echo "no test/test_*.cu found" >&2

--- a/test/test_client_connection_setup.cpp
+++ b/test/test_client_connection_setup.cpp
@@ -1,0 +1,99 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+extern "C" int lupine_test_rpc_open();
+extern "C" int lupine_test_rpc_size();
+
+namespace {
+
+constexpr int kEndpointCount = 17;
+constexpr int kExpectedConnectionCount = 16;
+
+int fail(const std::string &message) {
+  std::cerr << message << std::endl;
+  return 1;
+}
+
+int listen_on_loopback(uint16_t *port) {
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    return -1;
+  }
+
+  int reuse = 1;
+  setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+  sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  if (bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0 ||
+      listen(fd, kEndpointCount) < 0) {
+    close(fd);
+    return -1;
+  }
+
+  socklen_t addr_len = sizeof(addr);
+  if (getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &addr_len) < 0) {
+    close(fd);
+    return -1;
+  }
+
+  *port = ntohs(addr.sin_port);
+  return fd;
+}
+
+} // namespace
+
+int main() {
+  std::vector<int> listeners;
+  listeners.reserve(kEndpointCount);
+
+  std::ostringstream servers;
+  for (int i = 0; i < kEndpointCount; ++i) {
+    uint16_t port = 0;
+    int fd = listen_on_loopback(&port);
+    if (fd < 0) {
+      return fail(std::string("failed to create listener: ") +
+                  std::strerror(errno));
+    }
+    listeners.push_back(fd);
+    if (i != 0) {
+      servers << ',';
+    }
+    servers << "127.0.0.1:" << port;
+  }
+
+  std::string server_list = servers.str();
+  if (setenv("LUPINE_SERVER", server_list.c_str(), 1) != 0) {
+    return fail("failed to set LUPINE_SERVER");
+  }
+
+  int open_result = lupine_test_rpc_open();
+  int connection_count = lupine_test_rpc_size();
+
+  for (int fd : listeners) {
+    close(fd);
+  }
+
+  if (open_result != 0) {
+    return fail("rpc_open failed for local listeners");
+  }
+  if (connection_count != kExpectedConnectionCount) {
+    return fail("rpc_open opened " + std::to_string(connection_count) +
+                " connections; expected " +
+                std::to_string(kExpectedConnectionCount));
+  }
+
+  return 0;
+}

--- a/test/test_client_connection_setup.exports
+++ b/test/test_client_connection_setup.exports
@@ -1,0 +1,7 @@
+{
+  global:
+    lupine_test_rpc_open;
+    lupine_test_rpc_size;
+  local:
+    *;
+};


### PR DESCRIPTION
## Summary
- cap CUDA client connections before writing conns[16]
- free strdup/addrinfo state across rpc_open success and failure paths
- check pthread return values with != 0 and handle pthread_create failures
- move the 17-endpoint ASAN regression into the existing test/test_* integration suite via test/test_client_connection_setup.cpp

## Tests
- script-style ASAN build/run of test/test_client_connection_setup.cpp using the run_custom_tests.sh compile path
- cmake --build build --target h2_test lupine_driver lupine_nvml -j$(nproc)
- ctest --test-dir build --output-on-failure