### PR TITLE
Add shared socket tuning helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,12 @@ else()
         ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
+    add_executable(socket_tuning_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/socket_tuning_test.cpp
+    )
     enable_testing()
     add_test(NAME h2_test COMMAND h2_test)
+    add_test(NAME socket_tuning_test COMMAND socket_tuning_test)
     add_test(
         NAME nvml_ecc_exports
         COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter"

--- a/client.cpp
+++ b/client.cpp
@@ -8887,15 +8887,13 @@ int rpc_open() {
       continue;
     }
 
-    int flag = 1;
     int sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
     if (sockfd == -1) {
       printf("socket creation failed...\n");
       continue;
     }
 
-    int opts = setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
-                          sizeof(int));
+    lupine_socket_configure_stream(sockfd);
     if (connect(sockfd, res->ai_addr, res->ai_addrlen) < 0) {
       LUPINE_LOG_ERROR("Connecting to " << host << " port " << port
                                         << " failed: " << strerror(errno));

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -112,6 +112,17 @@ inline int lupine_socket_set_reuseaddr(lupine_socket_t socket) {
   return setsockopt(socket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
 }
 
+inline int lupine_socket_configure_stream(lupine_socket_t socket) {
+  const char enable = 1;
+  if (setsockopt(socket, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable)) !=
+          0 ||
+      setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, &enable, sizeof(enable)) !=
+          0) {
+    return -1;
+  }
+  return 0;
+}
+
 inline ssize_t lupine_socket_recv(lupine_socket_t socket, void *data,
                                   size_t size) {
   int chunk = static_cast<int>(std::min<size_t>(size, INT_MAX));
@@ -155,6 +166,8 @@ inline int lupine_fd_fileno(FILE *file) { return _fileno(file); }
 #include <algorithm>
 #include <cerrno>
 #include <cstdio>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
@@ -171,6 +184,30 @@ inline int lupine_socket_close(lupine_socket_t socket) { return close(socket); }
 inline int lupine_socket_set_reuseaddr(lupine_socket_t socket) {
   const int enable = 1;
   return setsockopt(socket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+}
+inline int lupine_socket_configure_stream(lupine_socket_t socket) {
+  const int enable = 1;
+  if (setsockopt(socket, IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable)) !=
+          0 ||
+      setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, &enable, sizeof(enable)) !=
+          0) {
+    return -1;
+  }
+
+#ifdef TCP_KEEPIDLE
+  const int keepidle = 60;
+  setsockopt(socket, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle));
+#endif
+#ifdef TCP_KEEPINTVL
+  const int keepintvl = 10;
+  setsockopt(socket, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl,
+             sizeof(keepintvl));
+#endif
+#ifdef TCP_KEEPCNT
+  const int keepcnt = 12;
+  setsockopt(socket, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt));
+#endif
+  return 0;
 }
 inline ssize_t lupine_socket_recv(lupine_socket_t socket, void *data,
                                   size_t size) {

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -116,8 +116,7 @@ int open_connection() {
 
     int sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
     if (sockfd >= 0) {
-      int flag = 1;
-      setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+      lupine_socket_configure_stream(sockfd);
       if (connect(sockfd, res->ai_addr, res->ai_addrlen) == 0) {
         if (nconns >= static_cast<int>(sizeof(conns) / sizeof(conns[0]))) {
           close(sockfd);

--- a/server.cpp
+++ b/server.cpp
@@ -294,10 +294,7 @@ int main() {
       continue;
     }
 
-#ifndef _WIN32
-    int flag = 1;
-    setsockopt(connfd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
-#endif
+    lupine_socket_configure_stream(connfd);
 
 #ifndef _WIN32
     // fork a process per connection so each client gets its own CUDA driver

--- a/socket_tuning_test.cpp
+++ b/socket_tuning_test.cpp
@@ -1,0 +1,75 @@
+#include "lupine_platform.h"
+
+#include <arpa/inet.h>
+#include <cstdlib>
+#include <iostream>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace {
+
+void require(bool condition, const char *message) {
+  if (!condition) {
+    std::cerr << message << "\n";
+    std::exit(1);
+  }
+}
+
+int get_int_sockopt(int fd, int level, int optname) {
+  int value = 0;
+  socklen_t len = sizeof(value);
+  require(getsockopt(fd, level, optname, &value, &len) == 0,
+          "getsockopt failed");
+  return value;
+}
+
+} // namespace
+
+int main() {
+  int server = socket(AF_INET, SOCK_STREAM, 0);
+  require(server >= 0, "server socket failed");
+  require(lupine_socket_set_reuseaddr(server) == 0, "reuseaddr failed");
+
+  sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  require(bind(server, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0,
+          "bind failed");
+  require(listen(server, 1) == 0, "listen failed");
+
+  socklen_t addr_len = sizeof(addr);
+  require(getsockname(server, reinterpret_cast<sockaddr *>(&addr), &addr_len) ==
+              0,
+          "getsockname failed");
+
+  int client = socket(AF_INET, SOCK_STREAM, 0);
+  require(client >= 0, "client socket failed");
+  require(lupine_socket_configure_stream(client) == 0,
+          "socket configure failed");
+  require(connect(client, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) ==
+              0,
+          "connect failed");
+
+  int accepted = accept(server, nullptr, nullptr);
+  require(accepted >= 0, "accept failed");
+  require(lupine_socket_configure_stream(accepted) == 0,
+          "accepted socket configure failed");
+
+  require(get_int_sockopt(client, IPPROTO_TCP, TCP_NODELAY) != 0,
+          "TCP_NODELAY was not enabled");
+  require(get_int_sockopt(client, SOL_SOCKET, SO_KEEPALIVE) != 0,
+          "SO_KEEPALIVE was not enabled");
+  require(get_int_sockopt(accepted, IPPROTO_TCP, TCP_NODELAY) != 0,
+          "accepted TCP_NODELAY was not enabled");
+  require(get_int_sockopt(accepted, SOL_SOCKET, SO_KEEPALIVE) != 0,
+          "accepted SO_KEEPALIVE was not enabled");
+
+  close(accepted);
+  close(client);
+  close(server);
+  std::cout << "socket_tuning_test: PASS\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add lupine_socket_configure_stream() for shared stream socket setup
- enable TCP_NODELAY and SO_KEEPALIVE, plus Linux keepalive interval/count/idle tuning when available
- use the helper from CUDA client, NVML client, and server accepted sockets
- add a loopback socket option regression test

## Tests
- cmake --build build --target socket_tuning_test h2_test lupine_nvml -j$(nproc)
- ctest --test-dir build --output-on-failure