### PR TITLE
Answer with an error when a worker result cannot be encoded

### DIFF
--- a/python/lupine/worker.py
+++ b/python/lupine/worker.py
@@ -187,6 +187,15 @@ def handle(request, input_stream, descriptions, output_tensors):
         input_tensors.clear()
 
 
+def response_header(response, output_tensors):
+    # Called inside the operation try block so a result JSON cannot encode
+    # answers with an error instead of stopping the worker.
+    response["tensor_streams"] = [
+        _tensor_stream_metadata(tensor, dtype) for tensor, dtype in output_tensors
+    ]
+    return json.dumps(response).encode("utf-8") + b"\n"
+
+
 def main():
     input_stream = sys.stdin.buffer
     output_stream = sys.stdout.buffer
@@ -211,29 +220,32 @@ def main():
             traceback.print_exc(file=sys.stderr)
             break
         try:
-            response = {
-                "ok": True,
-                "result": handle(
-                    request,
-                    input_stream,
-                    descriptions,
-                    output_tensors,
-                ),
-            }
+            header = response_header(
+                {
+                    "ok": True,
+                    "result": handle(
+                        request,
+                        input_stream,
+                        descriptions,
+                        output_tensors,
+                    ),
+                },
+                output_tensors,
+            )
         except TensorStreamError:
             traceback.print_exc(file=sys.stderr)
             break
         except Exception as exc:
             output_tensors = []
-            response = {
-                "ok": False,
-                "error": str(exc),
-                "traceback": traceback.format_exc(),
-            }
-        response["tensor_streams"] = [
-            _tensor_stream_metadata(tensor, dtype) for tensor, dtype in output_tensors
-        ]
-        _write_all(output_stream, json.dumps(response).encode("utf-8") + b"\n")
+            header = response_header(
+                {
+                    "ok": False,
+                    "error": str(exc),
+                    "traceback": traceback.format_exc(),
+                },
+                output_tensors,
+            )
+        _write_all(output_stream, header)
         for tensor, dtype in output_tensors:
             if tensor.device.type == "cpu":
                 _write_tensor(output_stream, tensor)

--- a/python/tests/sidecar_test.py
+++ b/python/tests/sidecar_test.py
@@ -400,6 +400,27 @@ def test_sidecar_keeps_handles_of_live_tensors(monkeypatch):
     assert tensor._lupine_handle == 7
 
 
+def test_sidecar_worker_survives_an_unserializable_result():
+    proc = subprocess.Popen(
+        [sys.executable, "-u", "-c", sidecar._worker_source()],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    session = sidecar.SidecarSession(server="host-a:14833")
+    session._proc = proc
+    session._lock = threading.Lock()
+    try:
+        with pytest.raises(sidecar.SidecarError, match="JSON serializable"):
+            session.forward(torch.ops.aten.item.default, (torch.tensor(1 + 2j),), {})
+
+        assert "torch" in session._request({"op": "ping"})
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+        proc.wait(timeout=5)
+
+
 def test_sidecar_worker_consumes_tensor_stream_before_operation_error(tmp_path):
     worker_source = sidecar._worker_source()
     isolated_source = (


### PR DESCRIPTION
`main()` serialized the response after the operation try block, so a result that JSON cannot encode ended the worker with an uncaught `TypeError`.

Driving the worker directly with `item()` on a complex tensor:

```
response line: b''
exit code: 1
TypeError: Object of type complex is not JSON serializable
```

`aten._local_scalar_dense` on a complex tensor returns a Python complex, so `x.item()` closes the worker and the client only sees a transport failure. The session is gone even though the operation itself ran fine.

Build the response header inside the try block, so an encoding failure becomes a normal `ok: false` reply and the worker keeps serving. `_tensor_stream_metadata` moves under the same guard.

New test runs the real worker over pipes, asks for a complex `item()`, and pings afterwards. It fails without the fix.