### PR TITLE
Stabilize the TCP transport against transient connection loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,34 +118,17 @@ far sooner than the kernel's default 2-hour keepalive. The next RPC then fails
 fatally. Lupine keeps these connections alive and resilient without retrying
 RPCs (which would break CUDA semantics):
 
-- **TCP keepalive** is enabled by default on every connection (client *and*
-  server). Probes are sent only while the connection is idle, so active
-  transfers pay no latency cost. Disable or tune with:
-  - `LUPINE_TCP_KEEPALIVE` — `1` (default) to enable, `0` to disable.
-  - `LUPINE_TCP_KEEPIDLE` — seconds idle before the first probe (default `60`).
-  - `LUPINE_TCP_KEEPINTVL` — seconds between probes (default `15`).
-  - `LUPINE_TCP_KEEPCNT` — probes before declaring the peer dead (default `3`).
-    With the defaults a dead peer is detected in ~105s instead of hanging on
-    the TCP retransmit timer.
-- **Socket buffer sizing** is available for high-bandwidth, high-BDP transfers
-  (the transport streams multi-MB GPU payloads). Defaults are left to the OS:
-  - `LUPINE_TCP_SNDBUF` — send buffer bytes (0 = OS default).
-  - `LUPINE_TCP_RCVBUF` — receive buffer bytes (0 = OS default).
-- **Connect retry and timeout** make startup robust when the server is still
-  being provisioned or a port is packet-filtered. Each is opt-in:
-  - `LUPINE_CONNECT_RETRIES` — extra connect attempts after the first
-    (default `0`, i.e. fail fast as before).
-  - `LUPINE_CONNECT_BACKOFF_MS` — initial backoff, doubling up to 30s
-    (default `1000`).
-  - `LUPINE_CONNECT_TIMEOUT_MS` — per-attempt deadline so a black-holed port
-    cannot stall the loop for minutes (default `0` = blocking connect).
+- **TCP keepalive** is enabled on every connection (client *and* server) with a
+  60s idle interval, 15s between probes, and 3 unanswered probes before giving
+  up. Probes are sent only while idle, so active transfers pay no latency cost,
+  and a dead peer is detected in ~105s instead of hanging on the TCP
+  retransmit timer.
+- **Connect retry** rides out a server that is not reachable yet (e.g. still
+  provisioning): a connection is attempted a few times with exponential
+  backoff, and each attempt is bounded by a deadline so a packet-filtered port
+  is detected quickly rather than blocking for the full SYN-retransmit window.
 
-For example, to ride out a slow server start and keep NAT entries warm:
-
-```bash
-export LUPINE_CONNECT_RETRIES=10 LUPINE_CONNECT_TIMEOUT_MS=5000
-export LUPINE_TCP_KEEPIDLE=30 LUPINE_TCP_KEEPINTVL=10
-```
+Socket buffer sizes are left to the OS, which auto-tunes on modern kernels.
 
 ## Trace Logging
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,45 @@ policy for unkeyed connections; Lupine does not select a checkpoint directory.
 `LUPINE_CHECKPOINT_LIBRARY` can override the provider library path for a
 private deployment.
 
+## Connection Stability
+
+Each client/server connection is a single long-lived TCP stream. Long-running
+workloads sit idle for long stretches (between training steps, during host-side
+data loading, inside long kernels), and stateful middleboxes — cloud load
+balancers, NAT gateways, conntrack tables, firewalls — silently reap idle flows
+far sooner than the kernel's default 2-hour keepalive. The next RPC then fails
+fatally. Lupine keeps these connections alive and resilient without retrying
+RPCs (which would break CUDA semantics):
+
+- **TCP keepalive** is enabled by default on every connection (client *and*
+  server). Probes are sent only while the connection is idle, so active
+  transfers pay no latency cost. Disable or tune with:
+  - `LUPINE_TCP_KEEPALIVE` — `1` (default) to enable, `0` to disable.
+  - `LUPINE_TCP_KEEPIDLE` — seconds idle before the first probe (default `60`).
+  - `LUPINE_TCP_KEEPINTVL` — seconds between probes (default `15`).
+  - `LUPINE_TCP_KEEPCNT` — probes before declaring the peer dead (default `3`).
+    With the defaults a dead peer is detected in ~105s instead of hanging on
+    the TCP retransmit timer.
+- **Socket buffer sizing** is available for high-bandwidth, high-BDP transfers
+  (the transport streams multi-MB GPU payloads). Defaults are left to the OS:
+  - `LUPINE_TCP_SNDBUF` — send buffer bytes (0 = OS default).
+  - `LUPINE_TCP_RCVBUF` — receive buffer bytes (0 = OS default).
+- **Connect retry and timeout** make startup robust when the server is still
+  being provisioned or a port is packet-filtered. Each is opt-in:
+  - `LUPINE_CONNECT_RETRIES` — extra connect attempts after the first
+    (default `0`, i.e. fail fast as before).
+  - `LUPINE_CONNECT_BACKOFF_MS` — initial backoff, doubling up to 30s
+    (default `1000`).
+  - `LUPINE_CONNECT_TIMEOUT_MS` — per-attempt deadline so a black-holed port
+    cannot stall the loop for minutes (default `0` = blocking connect).
+
+For example, to ride out a slow server start and keep NAT entries warm:
+
+```bash
+export LUPINE_CONNECT_RETRIES=10 LUPINE_CONNECT_TIMEOUT_MS=5000
+export LUPINE_TCP_KEEPIDLE=30 LUPINE_TCP_KEEPINTVL=10
+```
+
 ## Trace Logging
 
 Set `LUPINE_TRACE` on the client, server, or both to enable trace logging.

--- a/client.cpp
+++ b/client.cpp
@@ -504,26 +504,12 @@ static int lupine_connect_endpoint(conn_t *conn,
     return -1;
   }
 
-  addrinfo hints, *res = nullptr;
-  int sockfd = -1;
-  int flag = 1;
-  int gai_status = 0;
-  memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_INET;
-  hints.ai_socktype = SOCK_STREAM;
-  if ((gai_status = getaddrinfo(endpoint.host.c_str(), endpoint.port.c_str(),
-                                &hints, &res)) != 0 ||
-      (sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) <
-          0 ||
-      setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
-                 sizeof(flag)) < 0 ||
-      connect(sockfd, res->ai_addr, res->ai_addrlen) < 0) {
-    LUPINE_LOG_ERROR("Connecting to "
-                     << endpoint.host << " port " << endpoint.port
-                     << " failed: "
-                     << (gai_status != 0 ? gai_strerror(gai_status)
-                                         : strerror(errno)));
-    goto error;
+  lupine_socket_t sockfd =
+      lupine_tcp_connect(endpoint.host.c_str(), endpoint.port.c_str());
+  if (sockfd == LUPINE_INVALID_SOCKET) {
+    LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
+                     << endpoint.port << " failed");
+    return -1;
   }
 
   rpc_write_queue_free(conn);
@@ -558,16 +544,16 @@ static int lupine_connect_endpoint(conn_t *conn,
         SSL_free(ssl);
       }
       LUPINE_LOG_ERROR("TLS handshake with " << endpoint.host << " failed");
-      close(sockfd);
-      goto error;
+      lupine_socket_close(sockfd);
+      return -1;
     }
 #else
     LUPINE_LOG_ERROR("LUPINE_SERVER entry "
                      << endpoint.host << ":" << endpoint.port
                      << " uses https:// but this client was built "
                         "without TLS support");
-    close(sockfd);
-    goto error;
+    lupine_socket_close(sockfd);
+    return -1;
 #endif
   }
   if (pthread_mutex_init(&conn->read_mutex, NULL) != 0 ||
@@ -577,20 +563,11 @@ static int lupine_connect_endpoint(conn_t *conn,
       rpc_http2_client_init(conn) < 0 ||
       pthread_create(&conn->read_thread, NULL, rpc_client_dispatch_thread,
                      (void *)conn) != 0) {
-    goto error;
+    lupine_socket_close(sockfd);
+    return -1;
   }
 
-  freeaddrinfo(res);
   return 0;
-
-error:
-  if (res != nullptr) {
-    freeaddrinfo(res);
-  }
-  if (sockfd != -1) {
-    close(sockfd);
-  }
-  return -1;
 }
 
 static void lupine_join_connection_threads(conn_t *conn) {

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -162,18 +162,14 @@ inline int lupine_fd_truncate(int fd, long length) {
 
 #include <algorithm>
 #include <cerrno>
-#include <chrono>
 #include <cstdio>
-#include <cstdlib>
 #include <fcntl.h>
-#include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <poll.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
-#include <thread>
 #include <unistd.h>
 
 using lupine_socket_t = int;
@@ -222,21 +218,6 @@ inline int lupine_fd_truncate(int fd, off_t length) {
 
 #endif
 
-// Parses a non-negative integer environment variable, returning `fallback`
-// when unset, empty, or invalid. Used by the transport-option helpers below.
-inline int lupine_env_int(const char *name, int fallback) {
-  const char *value = getenv(name);
-  if (value == nullptr || value[0] == '\0') {
-    return fallback;
-  }
-  char *end = nullptr;
-  long parsed = strtol(value, &end, 10);
-  if (end == value || *end != '\0' || parsed < 0) {
-    return fallback;
-  }
-  return static_cast<int>(parsed);
-}
-
 // lupine_socket_apply_transport_options sets the TCP options every lupine
 // connection uses:
 //
@@ -247,44 +228,34 @@ inline int lupine_env_int(const char *name, int fallback) {
 //     flows far sooner than the kernel's default 2-hour keepalive; a transient
 //     blip then surfaces as a fatal RPC error. Keepalive probes are emitted
 //     only while the connection is idle, so active transfers pay no latency.
-//   * Optional SO_SNDBUF/SO_RCVBUF for high-bandwidth, high-BDP transfers
-//     (the transport streams multi-MB GPU memcpy payloads).
+//     With the defaults a dead peer is detected in ~105s instead of hanging on
+//     the retransmit timer. Socket buffer sizing is left to the OS, which
+//     auto-tunes on modern kernels.
 //
-// Configure or disable with the LUPINE_TCP_* environment variables documented
-// in the README. Returns 0 on success, -1 on an invalid descriptor.
+// Returns 0 on success, -1 on an invalid descriptor.
 inline int lupine_socket_apply_transport_options(lupine_socket_t fd) {
   if (fd == LUPINE_INVALID_SOCKET) {
     return -1;
   }
 
+  // Seconds a connection may sit idle before the first keepalive probe, the
+  // interval between probes, and how many unanswered probes declare the peer
+  // dead. Chosen to keep NAT/load-balancer conntrack entries warm (60s is
+  // shorter than every common middlebox idle timeout) while bounding dead-peer
+  // detection to ~105s.
+  constexpr int kKeepidleSec = 60;
+  constexpr int kKeepintvlSec = 15;
+  constexpr int kKeepcnt = 3;
+
   int enabled = 1;
-  setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char *>(&enabled),
-             sizeof(enabled));
-
-  int sndbuf = lupine_env_int("LUPINE_TCP_SNDBUF", 0);
-  if (sndbuf > 0) {
-    setsockopt(fd, SOL_SOCKET, SO_SNDBUF,
-               reinterpret_cast<const char *>(&sndbuf), sizeof(sndbuf));
-  }
-  int rcvbuf = lupine_env_int("LUPINE_TCP_RCVBUF", 0);
-  if (rcvbuf > 0) {
-    setsockopt(fd, SOL_SOCKET, SO_RCVBUF,
-               reinterpret_cast<const char *>(&rcvbuf), sizeof(rcvbuf));
-  }
-
-  // Keepalive is on by default: persistent RPC connections are exactly the
-  // workload that gets silently dropped, and idle probes never stall an
-  // active transfer. Set LUPINE_TCP_KEEPALIVE=0 to disable.
-  if (lupine_env_int("LUPINE_TCP_KEEPALIVE", 1) == 0) {
-    return 0;
-  }
-
+  setsockopt(fd, IPPROTO_TCP, TCP_NODELAY,
+             reinterpret_cast<const char *>(&enabled), sizeof(enabled));
   setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE,
              reinterpret_cast<const char *>(&enabled), sizeof(enabled));
 
-  int keepidle = lupine_env_int("LUPINE_TCP_KEEPIDLE", 60);
-  int keepintvl = lupine_env_int("LUPINE_TCP_KEEPINTVL", 15);
-  int keepcnt = lupine_env_int("LUPINE_TCP_KEEPCNT", 3);
+  int keepidle = kKeepidleSec;
+  int keepintvl = kKeepintvlSec;
+  int keepcnt = kKeepcnt;
 #ifdef _WIN32
   // SIO_KEEPALIVE_VALS sets the idle and probe intervals in one ioctl.
   tcp_keepalive ka;
@@ -295,8 +266,8 @@ inline int lupine_socket_apply_transport_options(lupine_socket_t fd) {
   WSAIoctl(fd, SIO_KEEPALIVE_VALS, &ka, sizeof(ka), nullptr, 0,
            &bytes_returned, nullptr, nullptr);
 #ifdef TCP_KEEPCNT
-  setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,
-             reinterpret_cast<const char *>(&keepcnt), sizeof(keepcnt));
+  setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, reinterpret_cast<const char *>(&keepcnt),
+             sizeof(keepcnt));
 #endif
 #else
   setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -21,6 +21,8 @@
 #include <vector>
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <mswsock.h>
+#include <mstcpip.h>
 
 using ssize_t = SSIZE_T;
 using socklen_t = int;
@@ -160,10 +162,18 @@ inline int lupine_fd_truncate(int fd, long length) {
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstdio>
+#include <cstdlib>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
+#include <thread>
 #include <unistd.h>
 
 using lupine_socket_t = int;
@@ -211,5 +221,174 @@ inline int lupine_fd_truncate(int fd, off_t length) {
 }
 
 #endif
+
+// Parses a non-negative integer environment variable, returning `fallback`
+// when unset, empty, or invalid. Used by the transport-option helpers below.
+inline int lupine_env_int(const char *name, int fallback) {
+  const char *value = getenv(name);
+  if (value == nullptr || value[0] == '\0') {
+    return fallback;
+  }
+  char *end = nullptr;
+  long parsed = strtol(value, &end, 10);
+  if (end == value || *end != '\0' || parsed < 0) {
+    return fallback;
+  }
+  return static_cast<int>(parsed);
+}
+
+// lupine_socket_apply_transport_options sets the TCP options every lupine
+// connection uses:
+//
+//   * TCP_NODELAY so small RPC frames are not delayed by Nagle.
+//   * SO_KEEPALIVE with tuned probes, so a long-lived connection survives the
+//     idle gaps in long-running workloads. Stateful middleboxes (NAT gateways,
+//     cloud load balancers, conntrack entries, firewalls) silently reap idle
+//     flows far sooner than the kernel's default 2-hour keepalive; a transient
+//     blip then surfaces as a fatal RPC error. Keepalive probes are emitted
+//     only while the connection is idle, so active transfers pay no latency.
+//   * Optional SO_SNDBUF/SO_RCVBUF for high-bandwidth, high-BDP transfers
+//     (the transport streams multi-MB GPU memcpy payloads).
+//
+// Configure or disable with the LUPINE_TCP_* environment variables documented
+// in the README. Returns 0 on success, -1 on an invalid descriptor.
+inline int lupine_socket_apply_transport_options(lupine_socket_t fd) {
+  if (fd == LUPINE_INVALID_SOCKET) {
+    return -1;
+  }
+
+  int enabled = 1;
+  setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char *>(&enabled),
+             sizeof(enabled));
+
+  int sndbuf = lupine_env_int("LUPINE_TCP_SNDBUF", 0);
+  if (sndbuf > 0) {
+    setsockopt(fd, SOL_SOCKET, SO_SNDBUF,
+               reinterpret_cast<const char *>(&sndbuf), sizeof(sndbuf));
+  }
+  int rcvbuf = lupine_env_int("LUPINE_TCP_RCVBUF", 0);
+  if (rcvbuf > 0) {
+    setsockopt(fd, SOL_SOCKET, SO_RCVBUF,
+               reinterpret_cast<const char *>(&rcvbuf), sizeof(rcvbuf));
+  }
+
+  // Keepalive is on by default: persistent RPC connections are exactly the
+  // workload that gets silently dropped, and idle probes never stall an
+  // active transfer. Set LUPINE_TCP_KEEPALIVE=0 to disable.
+  if (lupine_env_int("LUPINE_TCP_KEEPALIVE", 1) == 0) {
+    return 0;
+  }
+
+  setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE,
+             reinterpret_cast<const char *>(&enabled), sizeof(enabled));
+
+  int keepidle = lupine_env_int("LUPINE_TCP_KEEPIDLE", 60);
+  int keepintvl = lupine_env_int("LUPINE_TCP_KEEPINTVL", 15);
+  int keepcnt = lupine_env_int("LUPINE_TCP_KEEPCNT", 3);
+#ifdef _WIN32
+  // SIO_KEEPALIVE_VALS sets the idle and probe intervals in one ioctl.
+  tcp_keepalive ka;
+  ka.onoff = 1;
+  ka.keepalivetime = static_cast<ULONG>(keepidle) * 1000;
+  ka.keepaliveinterval = static_cast<ULONG>(keepintvl) * 1000;
+  DWORD bytes_returned = 0;
+  WSAIoctl(fd, SIO_KEEPALIVE_VALS, &ka, sizeof(ka), nullptr, 0,
+           &bytes_returned, nullptr, nullptr);
+#ifdef TCP_KEEPCNT
+  setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,
+             reinterpret_cast<const char *>(&keepcnt), sizeof(keepcnt));
+#endif
+#else
+  setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,
+             reinterpret_cast<const char *>(&keepidle), sizeof(keepidle));
+  setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL,
+             reinterpret_cast<const char *>(&keepintvl), sizeof(keepintvl));
+  setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,
+             reinterpret_cast<const char *>(&keepcnt), sizeof(keepcnt));
+#endif
+  return 0;
+}
+
+// lupine_socket_connect_with_timeout connects `fd` to `addr`, waiting up to
+// `timeout_ms` milliseconds. A non-positive timeout performs a plain blocking
+// connect (the historical behavior). A bounded timeout prevents a
+// packet-filtered port from blocking the connect-retry loop for minutes
+// (the kernel's SYN retransmit backoff). Returns 0 on success, -1 on error
+// or timeout.
+inline int lupine_socket_connect_with_timeout(lupine_socket_t fd,
+                                               const struct sockaddr *addr,
+                                               socklen_t addrlen,
+                                               int timeout_ms) {
+  if (timeout_ms <= 0) {
+    return connect(fd, addr, addrlen);
+  }
+#ifdef _WIN32
+  u_long nonblocking = 1;
+  if (ioctlsocket(fd, FIONBIO, &nonblocking) != 0) {
+    return connect(fd, addr, addrlen);
+  }
+  int rc = connect(fd, addr, addrlen);
+  if (rc == 0) {
+    nonblocking = 0;
+    ioctlsocket(fd, FIONBIO, &nonblocking);
+    return 0;
+  }
+  if (WSAGetLastError() != WSAEWOULDBLOCK) {
+    nonblocking = 0;
+    ioctlsocket(fd, FIONBIO, &nonblocking);
+    return -1;
+  }
+  fd_set write_fds;
+  FD_ZERO(&write_fds);
+  FD_SET(fd, &write_fds);
+  struct timeval tv;
+  tv.tv_sec = timeout_ms / 1000;
+  tv.tv_usec = (timeout_ms % 1000) * 1000;
+  rc = select(0, nullptr, &write_fds, nullptr, &tv);
+  nonblocking = 0;
+  ioctlsocket(fd, FIONBIO, &nonblocking);
+  if (rc <= 0) {
+    return -1;
+  }
+  int so_error = 0;
+  int so_len = sizeof(so_error);
+  if (getsockopt(fd, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&so_error),
+                 &so_len) != 0 ||
+      so_error != 0) {
+    return -1;
+  }
+  return 0;
+#else
+  int saved_flags = fcntl(fd, F_GETFL, 0);
+  if (saved_flags < 0 || fcntl(fd, F_SETFL, saved_flags | O_NONBLOCK) < 0) {
+    return connect(fd, addr, addrlen);
+  }
+  int rc = connect(fd, addr, addrlen);
+  if (rc == 0) {
+    fcntl(fd, F_SETFL, saved_flags);
+    return 0;
+  }
+  if (errno != EINPROGRESS) {
+    fcntl(fd, F_SETFL, saved_flags);
+    return -1;
+  }
+  struct pollfd pfd;
+  pfd.fd = fd;
+  pfd.events = POLLOUT;
+  pfd.revents = 0;
+  rc = poll(&pfd, 1, timeout_ms);
+  fcntl(fd, F_SETFL, saved_flags); // restore blocking mode regardless
+  if (rc <= 0) {
+    return -1;
+  }
+  int so_error = 0;
+  socklen_t so_len = sizeof(so_error);
+  if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &so_len) != 0 ||
+      so_error != 0) {
+    return -1;
+  }
+  return 0;
+#endif
+}
 
 #endif

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -138,8 +138,7 @@ int open_connection() {
 
     int sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
     if (sockfd >= 0) {
-      int flag = 1;
-      setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+      lupine_socket_apply_transport_options(sockfd);
       if (connect(sockfd, res->ai_addr, res->ai_addrlen) == 0) {
         if (nconns >= static_cast<int>(sizeof(conns) / sizeof(conns[0]))) {
           close(sockfd);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1,5 +1,7 @@
 #include "rpc.h"
+#include "lupine_log.h"
 #include <algorithm>
+#include <chrono>
 #include <climits>
 #include <cstdlib>
 #include <functional>
@@ -7,6 +9,69 @@
 #include <string.h>
 #include <thread>
 #include <vector>
+
+#ifndef _WIN32
+#include <netdb.h>
+#endif
+
+// lupine_tcp_connect resolves host:port and connects with optional retry and
+// per-attempt timeout (see rpc.h). It only resolves and dials; the caller
+// owns TLS setup and the HTTP/2 session. Backoff is capped at 30s and sleeps
+// in bounded chunks so the process stays responsive to signals.
+lupine_socket_t lupine_tcp_connect(const char *host, const char *port) {
+  int retries = lupine_env_int("LUPINE_CONNECT_RETRIES", 0);
+  int backoff_ms = lupine_env_int("LUPINE_CONNECT_BACKOFF_MS", 1000);
+  int timeout_ms = lupine_env_int("LUPINE_CONNECT_TIMEOUT_MS", 0);
+
+  for (int attempt = 0;; ++attempt) {
+    addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    addrinfo *res = nullptr;
+    int gai_status = getaddrinfo(host, port, &hints, &res);
+    if (gai_status != 0 || res == nullptr) {
+      LUPINE_LOG_ERROR("Resolving "
+                       << host << " port " << port << " failed: "
+                       << (gai_status != 0 ? gai_strerror(gai_status)
+                                           : strerror(errno)));
+    } else {
+      for (addrinfo *ai = res; ai != nullptr; ai = ai->ai_next) {
+        lupine_socket_t sockfd =
+            socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (sockfd == LUPINE_INVALID_SOCKET) {
+          continue;
+        }
+        lupine_socket_apply_transport_options(sockfd);
+        if (lupine_socket_connect_with_timeout(
+                sockfd, ai->ai_addr, static_cast<socklen_t>(ai->ai_addrlen),
+                timeout_ms) == 0) {
+          freeaddrinfo(res);
+          return sockfd;
+        }
+        lupine_socket_close(sockfd);
+      }
+      freeaddrinfo(res);
+    }
+
+    if (attempt >= retries) {
+      return LUPINE_INVALID_SOCKET;
+    }
+
+    int delay_ms = backoff_ms;
+    for (int i = 0; i < attempt && delay_ms < 30000; ++i) {
+      delay_ms *= 2;
+    }
+    if (delay_ms > 30000) {
+      delay_ms = 30000;
+    }
+    LUPINE_LOG_ERROR("Connecting to "
+                     << host << " port " << port << " failed, retrying in "
+                     << delay_ms << "ms (" << (retries - attempt)
+                     << " retries left)");
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+  }
+}
 
 extern void rpc_http2_destroy(conn_t *conn);
 

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -14,14 +14,20 @@
 #include <netdb.h>
 #endif
 
-// lupine_tcp_connect resolves host:port and connects with optional retry and
-// per-attempt timeout (see rpc.h). It only resolves and dials; the caller
-// owns TLS setup and the HTTP/2 session. Backoff is capped at 30s and sleeps
-// in bounded chunks so the process stays responsive to signals.
+// lupine_tcp_connect resolves host:port and connects with a bounded retry
+// policy (see rpc.h). It only resolves and dials; the caller owns TLS setup
+// and the HTTP/2 session. A transiently unreachable server (e.g. still
+// provisioning) is retried with exponential backoff, and each attempt is
+// bounded by a deadline so a packet-filtered port cannot stall the loop for
+// minutes (the kernel's SYN retransmit backoff).
 lupine_socket_t lupine_tcp_connect(const char *host, const char *port) {
-  int retries = lupine_env_int("LUPINE_CONNECT_RETRIES", 0);
-  int backoff_ms = lupine_env_int("LUPINE_CONNECT_BACKOFF_MS", 1000);
-  int timeout_ms = lupine_env_int("LUPINE_CONNECT_TIMEOUT_MS", 0);
+  // Hardcoded connect policy: a few retries with exponential backoff to ride
+  // out a server that is still starting, each capped so a black-holed port is
+  // detected quickly instead of blocking for the full SYN-retransmit window.
+  constexpr int kMaxRetries = 5;
+  constexpr int kInitialBackoffMs = 1000;
+  constexpr int kMaxBackoffMs = 30000;
+  constexpr int kConnectTimeoutMs = 10000;
 
   for (int attempt = 0;; ++attempt) {
     addrinfo hints;
@@ -45,7 +51,7 @@ lupine_socket_t lupine_tcp_connect(const char *host, const char *port) {
         lupine_socket_apply_transport_options(sockfd);
         if (lupine_socket_connect_with_timeout(
                 sockfd, ai->ai_addr, static_cast<socklen_t>(ai->ai_addrlen),
-                timeout_ms) == 0) {
+                kConnectTimeoutMs) == 0) {
           freeaddrinfo(res);
           return sockfd;
         }
@@ -54,20 +60,20 @@ lupine_socket_t lupine_tcp_connect(const char *host, const char *port) {
       freeaddrinfo(res);
     }
 
-    if (attempt >= retries) {
+    if (attempt >= kMaxRetries) {
       return LUPINE_INVALID_SOCKET;
     }
 
-    int delay_ms = backoff_ms;
-    for (int i = 0; i < attempt && delay_ms < 30000; ++i) {
+    int delay_ms = kInitialBackoffMs;
+    for (int i = 0; i < attempt && delay_ms < kMaxBackoffMs; ++i) {
       delay_ms *= 2;
     }
-    if (delay_ms > 30000) {
-      delay_ms = 30000;
+    if (delay_ms > kMaxBackoffMs) {
+      delay_ms = kMaxBackoffMs;
     }
     LUPINE_LOG_ERROR("Connecting to "
                      << host << " port " << port << " failed, retrying in "
-                     << delay_ms << "ms (" << (retries - attempt)
+                     << delay_ms << "ms (" << (kMaxRetries - attempt)
                      << " retries left)");
     std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
   }

--- a/rpc.h
+++ b/rpc.h
@@ -82,10 +82,9 @@ extern void rpc_conn_destroy(conn_t *conn);
 // lupine_tcp_connect resolves host:port and returns a connected socket with
 // the standard transport options applied (TCP_NODELAY + keepalive; see
 // lupine_socket_apply_transport_options). A server that is not reachable yet
-// (e.g. still provisioning) can be retried with exponential backoff via
-// LUPINE_CONNECT_RETRIES / LUPINE_CONNECT_BACKOFF_MS, and each attempt is
-// bounded by LUPINE_CONNECT_TIMEOUT_MS so a packet-filtered port cannot stall
-// the loop for minutes. Returns the socket, or LUPINE_INVALID_SOCKET on
+// (e.g. still provisioning) is retried a few times with exponential backoff,
+// and each attempt is bounded by a deadline so a packet-filtered port cannot
+// stall the loop for minutes. Returns the socket, or LUPINE_INVALID_SOCKET on
 // permanent failure.
 extern lupine_socket_t lupine_tcp_connect(const char *host, const char *port);
 

--- a/rpc.h
+++ b/rpc.h
@@ -79,6 +79,16 @@ extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
 extern void rpc_write_queue_free(conn_t *conn);
 extern void rpc_conn_destroy(conn_t *conn);
 
+// lupine_tcp_connect resolves host:port and returns a connected socket with
+// the standard transport options applied (TCP_NODELAY + keepalive; see
+// lupine_socket_apply_transport_options). A server that is not reachable yet
+// (e.g. still provisioning) can be retried with exponential backoff via
+// LUPINE_CONNECT_RETRIES / LUPINE_CONNECT_BACKOFF_MS, and each attempt is
+// bounded by LUPINE_CONNECT_TIMEOUT_MS so a packet-filtered port cannot stall
+// the loop for minutes. Returns the socket, or LUPINE_INVALID_SOCKET on
+// permanent failure.
+extern lupine_socket_t lupine_tcp_connect(const char *host, const char *port);
+
 extern int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,
                                          const size_t *sizes,
                                          void *const *values);

--- a/server.cpp
+++ b/server.cpp
@@ -647,8 +647,11 @@ int main() {
 #endif
 
 #ifndef _WIN32
-    int flag = 1;
-    setsockopt(connfd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+    // TCP_NODELAY keeps small RPC frames latency-low; keepalive (and optional
+    // buffer sizing) keeps this long-lived connection from being silently
+    // reaped by a NAT/load-balancer/firewall during idle gaps. See
+    // lupine_socket_apply_transport_options.
+    lupine_socket_apply_transport_options(connfd);
 #endif
 
 #ifndef _WIN32


### PR DESCRIPTION
## Summary

Closes #256.

A dropped TCP connection between client and server is fatal to the running workload. Per the discussion on #256, the fix is **not** to retry in-flight RPCs (that would break CUDA semantics), but to make the transport itself resilient so a transient blip doesn't surface as a fatal RPC error.

### Root cause
The transport is HTTP/2 over a single long-lived blocking TCP socket. Linux's default keepalive interval is **7200s (2h)**, but stateful middleboxes (AWS NLB 350s, GCP LB 600s, NAT gateways, conntrack tables, firewalls) reap idle flows far sooner. Long-running workloads sit idle between training steps, so the connection gets silently reaped and the next RPC fails fatally.

### Changes
- **TCP keepalive, always on**, on every connection (client *and* server) via a new shared `lupine_socket_apply_transport_options()`: 60s idle, 15s between probes, 3 unanswered probes before giving up. Probes fire only while idle, so active transfers pay no latency cost; a dead peer is detected in ~105s instead of hanging on the TCP retransmit timer. Cross-platform (Linux `setsockopt`; Windows `SIO_KEEPALIVE_VALS`).
- **Connect retry + deadline**: `lupine_socket_connect_with_timeout()` (non-blocking connect + `poll`/`select`) and `lupine_tcp_connect()` retry a few times with exponential backoff and a 10s per-attempt deadline, so a still-provisioning server is ridden out and a packet-filtered port is detected quickly instead of blocking for the full SYN-retransmit window.
- Consolidated the three connect paths (client, nvml client, server) onto the shared helpers, and fixed a latent double-`close` in the client TLS error path.

Socket buffer sizing is left to the OS, which auto-tunes on modern kernels. There are no configuration knobs — the policy is baked in with sensible defaults.

## Verification
- Standalone checks confirm keepalive (60/15/3) lands on a socket and that connect retry/timeout fails fast against a black-holed port.
- Full build is clean (no new warnings); all `ctest` unit tests pass (9/9; 2 skipped need a different environment).