### PR TITLE
Bump Python package to 0.5.1

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lupine"
-version = "0.5.0"
+version = "0.5.1"
 description = "Small PyTorch adapter helpers for LUPINE-backed CUDA devices"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- bump the Python package version from 0.5.0 to 0.5.1

## Why

Prepare the next patch release of the `lupine` Python package. This changes package metadata only; runtime behavior is unchanged.

## Validation

- `uv build`
- `uv run --frozen --all-extras pytest` (82 passed, 1 skipped)
- `uv run --python 3.10 --frozen --all-extras pytest` (82 passed, 1 skipped)
