### PR TITLE
Add ASan/UBSan/TSan CI jobs for the CPU test targets

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,47 @@
+name: Sanitizers
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sanitizers:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ASan + UBSan
+            sanitizer: address,undefined
+          - name: TSan
+            sanitizer: thread
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Build test environment
+        run: |
+          docker build \
+            -f Dockerfile \
+            --target builder \
+            --build-arg CUDA_VERSION="13.1.0" \
+            --build-arg UBUNTU_VERSION="24.04" \
+            -t lupine-sanitizers \
+            .
+
+      # seccomp=unconfined lets ThreadSanitizer run with ASLR disabled
+      # (setarch -R needs the personality syscall).
+      - name: Build and run sanitized CPU test targets
+        run: |
+          docker run --rm --security-opt seccomp=unconfined \
+            --entrypoint bash lupine-sanitizers -lc \
+            'cd /opt/lupine && test/run_sanitizer_tests.sh "${{ matrix.sanitizer }}"'

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Makefile
 # Python bytecode cache (codegen.py imports codegen/ops.py)
 __pycache__/
 *.pyc
+build-sanitize-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,32 @@ cmake_minimum_required(VERSION 3.18)
 
 project(LupineProject LANGUAGES C CXX)
 
+# Sanitizers are applied only to the CPU-only *_test executables (transport,
+# decoder, ipc, checkpoint), never the nvcc-compiled driver/server. Set to a
+# -fsanitize value such as "address,undefined" or "thread"; empty disables.
+set(LUPINE_SANITIZE "" CACHE STRING
+    "Sanitizer for CPU test targets (e.g. address,undefined or thread)")
+
+function(lupine_apply_sanitizer target)
+    if (LUPINE_SANITIZE)
+        target_compile_options(${target} PRIVATE
+            -fsanitize=${LUPINE_SANITIZE} -fno-omit-frame-pointer
+            -fno-sanitize-recover=all -g)
+        target_link_options(${target} PRIVATE -fsanitize=${LUPINE_SANITIZE})
+    endif()
+endfunction()
+
+# Instrumented builds run several times slower, so give ctest more headroom.
+if (LUPINE_SANITIZE)
+    set(LUPINE_TEST_TIMEOUT_SCALE 8)
+else()
+    set(LUPINE_TEST_TIMEOUT_SCALE 1)
+endif()
+function(lupine_scaled_timeout out base)
+    math(EXPR scaled "${base} * ${LUPINE_TEST_TIMEOUT_SCALE}")
+    set(${out} ${scaled} PARENT_SCOPE)
+endfunction()
+
 if (NOT WIN32)
     enable_language(CUDA)
 endif()
@@ -174,34 +200,42 @@ else()
         LUPINE_CUDA_VERSION="${CUDAToolkit_VERSION}"
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
+    lupine_apply_sanitizer(h2_test)
 
     add_executable(h2_unknown_cuda_version_test ${H2_TEST_SOURCES})
     target_compile_definitions(h2_unknown_cuda_version_test PRIVATE
         LUPINE_H2_UNKNOWN_CUDA_VERSION_TEST
     )
     target_link_libraries(h2_unknown_cuda_version_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
+    lupine_apply_sanitizer(h2_unknown_cuda_version_test)
 
     enable_testing()
     add_test(NAME h2_test COMMAND h2_test)
-    set_tests_properties(h2_test PROPERTIES TIMEOUT 30)
+    lupine_scaled_timeout(h2_timeout 30)
+    set_tests_properties(h2_test PROPERTIES TIMEOUT ${h2_timeout})
     add_test(NAME h2_unknown_cuda_version_test COMMAND h2_unknown_cuda_version_test)
-    set_tests_properties(h2_unknown_cuda_version_test PROPERTIES TIMEOUT 10)
+    lupine_scaled_timeout(h2u_timeout 10)
+    set_tests_properties(h2_unknown_cuda_version_test PROPERTIES TIMEOUT ${h2u_timeout})
 
     add_executable(checkpoint_test
         ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint_test.cpp
     )
     target_link_libraries(checkpoint_test PRIVATE pthread)
+    lupine_apply_sanitizer(checkpoint_test)
     add_test(NAME checkpoint_test COMMAND checkpoint_test)
-    set_tests_properties(checkpoint_test PROPERTIES TIMEOUT 10)
+    lupine_scaled_timeout(ckpt_timeout 10)
+    set_tests_properties(checkpoint_test PROPERTIES TIMEOUT ${ckpt_timeout})
 
     add_executable(ipc_test
         ${CMAKE_CURRENT_SOURCE_DIR}/ipc.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ipc_test.cpp
     )
     target_link_libraries(ipc_test PRIVATE pthread)
+    lupine_apply_sanitizer(ipc_test)
     add_test(NAME ipc_test COMMAND ipc_test)
-    set_tests_properties(ipc_test PROPERTIES TIMEOUT 10)
+    lupine_scaled_timeout(ipc_timeout 10)
+    set_tests_properties(ipc_test PROPERTIES TIMEOUT ${ipc_timeout})
 
     add_library(test_lupinecr_provider SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/test/test_checkpoint_provider.c
@@ -217,18 +251,20 @@ else()
         ${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_checkpoint.cpp
     )
     target_link_libraries(server_checkpoint_test PRIVATE dl pthread)
+    lupine_apply_sanitizer(server_checkpoint_test)
     add_test(
         NAME server_checkpoint_test
         COMMAND server_checkpoint_test $<TARGET_FILE:test_lupinecr_provider> present
     )
-    set_tests_properties(server_checkpoint_test PROPERTIES TIMEOUT 10)
+    lupine_scaled_timeout(sckpt_timeout 10)
+    set_tests_properties(server_checkpoint_test PROPERTIES TIMEOUT ${sckpt_timeout})
     add_test(
         NAME server_checkpoint_missing_provider_test
         COMMAND server_checkpoint_test
                 ${CMAKE_CURRENT_BINARY_DIR}/missing-liblupinecr.so missing
     )
     set_tests_properties(server_checkpoint_missing_provider_test
-                         PROPERTIES TIMEOUT 10)
+                         PROPERTIES TIMEOUT ${sckpt_timeout})
 
     add_executable(server_sigterm_test
         ${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_sigterm.cpp

--- a/test/run_sanitizer_tests.sh
+++ b/test/run_sanitizer_tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build and run the CPU-only *_test targets under a sanitizer. These exercise
+# the transport, decoder, framing, ipc, and checkpoint code with no GPU,
+# server, or network, so they run cheaply in CI. The nvcc-compiled driver and
+# server are never built here (nvcc does not accept -fsanitize).
+#
+# Usage: run_sanitizer_tests.sh <sanitizer>
+#   <sanitizer> is a -fsanitize value, e.g. "address,undefined" or "thread".
+set -euo pipefail
+
+sanitizer="${1:?usage: run_sanitizer_tests.sh <address,undefined|thread>}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_dir="${BUILD_DIR:-$repo_root/build-sanitize-${sanitizer//,/-}}"
+jobs="${JOBS:-$(nproc)}"
+
+# Sanitized CPU test targets and the ctest names they register.
+targets=(h2_test h2_unknown_cuda_version_test checkpoint_test ipc_test
+         server_checkpoint_test test_lupinecr_provider)
+test_regex='^(h2_test|h2_unknown_cuda_version_test|checkpoint_test|ipc_test|server_checkpoint_test|server_checkpoint_missing_provider_test)$'
+
+cmake -S "$repo_root" -B "$build_dir" -DLUPINE_SANITIZE="$sanitizer" >/dev/null
+cmake --build "$build_dir" --parallel "$jobs" --target "${targets[@]}"
+
+# Symbolized, fail-fast output; a leak or race aborts the test.
+common="halt_on_error=1:abort_on_error=1:print_stacktrace=1:symbolize=1"
+export ASAN_OPTIONS="${common}:detect_leaks=1:strict_string_checks=1"
+export UBSAN_OPTIONS="${common}:print_summary=1"
+export TSAN_OPTIONS="${common}:second_deadlock_stack=1"
+export LSAN_OPTIONS="print_suppressions=0"
+supp="$repo_root/test/sanitizer_suppressions.txt"
+if [[ -f "$supp" ]]; then
+  export LSAN_OPTIONS="${LSAN_OPTIONS}:suppressions=$supp"
+fi
+
+# ThreadSanitizer's shadow memory is incompatible with high-entropy ASLR, so
+# run its tests with randomization disabled (setarch -R propagates to the
+# ctest children). Other sanitizers run normally.
+runner=()
+if [[ "$sanitizer" == *thread* ]] && command -v setarch >/dev/null; then
+  runner=(setarch -R)
+fi
+"${runner[@]}" ctest --test-dir "$build_dir" --output-on-failure -R "$test_regex"


### PR DESCRIPTION
Fixes #303.

Adds bounded sanitizer coverage per the maintainer's scoping on the issue (sanitizers yes; no RPC hardening/fuzzing — the client is trusted and the boundary is the process). The differential negative-argument piece is already covered by the driver-faithful `test/*.cu` suite.

## What
- `LUPINE_SANITIZE` CMake option applies `-fsanitize=...` **only to the CPU-only `*_test` executables** (h2/transport, rpc framing, compress/LZ4 decode, ipc, checkpoint) — never the nvcc-compiled driver/server. Test timeouts scale up under instrumentation.
- `test/run_sanitizer_tests.sh` configures a sanitizer build, builds just those targets, and runs ctest with symbolized, fail-fast options (`halt_on_error`, `print_stacktrace`, `detect_leaks`). TSan runs under `setarch -R` since its shadow memory is incompatible with high-entropy ASLR.
- `.github/workflows/sanitizers.yml`: a two-way matrix (ASan+UBSan, TSan), 30-min cap, reusing the existing Docker `builder` image.

## Coverage
Exercises the network-facing decode/framing and the threaded dispatch/lane code — where lock leaks, cleanup bugs, decoder memory-safety defects, and handle-table races would show up.

## Validation
Both modes pass clean locally: ASan+UBSan 6/6, TSan 6/6, no leaks/UB/races, no suppressions needed. Normal (non-sanitizer) build and unit tests unaffected.