### PR TITLE
Prefill device metadata caches with a one-round-trip snapshot RPC

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -389,7 +389,6 @@ lupine_device_attribute_cache() {
 }
 
 struct lupine_device_snapshot_info {
-  uint32_t flags = 0;
   char name[LUPINE_DEVICE_SNAPSHOT_NAME_BYTES] = {};
   CUuuid uuid = {};
   uint64_t total_mem = 0;
@@ -1597,8 +1596,7 @@ static void lupine_prefill_device_snapshot(conn_t *conn) {
   for (uint32_t ordinal = 0; ordinal < device_count; ++ordinal) {
     lupine_device_snapshot_info info;
     uint32_t pair_count = 0;
-    if (rpc_read(conn, &info.flags, sizeof(info.flags)) < 0 ||
-        rpc_read(conn, info.name, sizeof(info.name)) < 0 ||
+    if (rpc_read(conn, info.name, sizeof(info.name)) < 0 ||
         rpc_read(conn, &info.uuid, sizeof(info.uuid)) < 0 ||
         rpc_read(conn, &info.total_mem, sizeof(info.total_mem)) < 0 ||
         rpc_read(conn, &pair_count, sizeof(pair_count)) < 0) {
@@ -1706,8 +1704,7 @@ extern "C" CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
   if (len > 0) {
     lupine_prefill_device_snapshot(conn);
     lupine_device_snapshot_info info;
-    if (lupine_device_snapshot_cache().find(static_cast<int>(dev), info) &&
-        (info.flags & LUPINE_DEVICE_SNAPSHOT_HAS_NAME) != 0) {
+    if (lupine_device_snapshot_cache().find(static_cast<int>(dev), info)) {
       snprintf(name, static_cast<size_t>(len), "%s", info.name);
       return CUDA_SUCCESS;
     }
@@ -1747,8 +1744,7 @@ extern "C" CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev) {
   conn_t *conn = lupine_route_remote_conn(route);
   lupine_prefill_device_snapshot(conn);
   lupine_device_snapshot_info info;
-  if (lupine_device_snapshot_cache().find(static_cast<int>(dev), info) &&
-      (info.flags & LUPINE_DEVICE_SNAPSHOT_HAS_UUID) != 0) {
+  if (lupine_device_snapshot_cache().find(static_cast<int>(dev), info)) {
     *uuid = info.uuid;
     return CUDA_SUCCESS;
   }
@@ -1785,8 +1781,7 @@ extern "C" CUresult cuDeviceTotalMem_v2(size_t *bytes, CUdevice dev) {
   conn_t *conn = lupine_route_remote_conn(route);
   lupine_prefill_device_snapshot(conn);
   lupine_device_snapshot_info info;
-  if (lupine_device_snapshot_cache().find(static_cast<int>(dev), info) &&
-      (info.flags & LUPINE_DEVICE_SNAPSHOT_HAS_TOTAL_MEM) != 0) {
+  if (lupine_device_snapshot_cache().find(static_cast<int>(dev), info)) {
     *bytes = static_cast<size_t>(info.total_mem);
     return CUDA_SUCCESS;
   }

--- a/client.cpp
+++ b/client.cpp
@@ -388,6 +388,26 @@ lupine_device_attribute_cache() {
   return *cache;
 }
 
+struct lupine_device_snapshot_info {
+  uint32_t flags = 0;
+  char name[LUPINE_DEVICE_SNAPSHOT_NAME_BYTES] = {};
+  CUuuid uuid = {};
+  uint64_t total_mem = 0;
+};
+
+static libcuckoo::cuckoohash_map<int, lupine_device_snapshot_info> &
+lupine_device_snapshot_cache() {
+  static auto *cache =
+      new libcuckoo::cuckoohash_map<int, lupine_device_snapshot_info>();
+  return *cache;
+}
+
+static libcuckoo::cuckoohash_map<conn_t *, bool> &
+lupine_device_snapshot_attempts() {
+  static auto *attempts = new libcuckoo::cuckoohash_map<conn_t *, bool>();
+  return *attempts;
+}
+
 static libcuckoo::cuckoohash_map<lupine_kernel_function_key, CUfunction,
                                  lupine_kernel_function_key_hash> &
 lupine_kernel_function_cache() {
@@ -1550,6 +1570,68 @@ static bool lupine_device_attribute_is_virtualized(CUdevice_attribute attrib) {
   }
 }
 
+// One round trip that pulls every immutable per-device value the server can
+// enumerate and prefills the client caches, so a metadata scan (for example
+// torch reading ~110 attributes for every device at init) costs one RTT
+// instead of one per query. Attempted once per connection; on any failure the
+// per-call RPC paths still work, so this is purely best-effort.
+static void lupine_prefill_device_snapshot(conn_t *conn) {
+  if (conn == nullptr || !lupine_device_snapshot_attempts().insert(conn, true)) {
+    return;
+  }
+  CUresult result = CUDA_ERROR_UNKNOWN;
+  if (rpc_write_start_request(conn, LUPINE_RPC_lupineDeviceSnapshot) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0) {
+    return;
+  }
+  if (result != CUDA_SUCCESS) {
+    rpc_read_end(conn);
+    return;
+  }
+  uint32_t device_count = 0;
+  if (rpc_read(conn, &device_count, sizeof(device_count)) < 0) {
+    return;
+  }
+  std::vector<int32_t> pairs;
+  for (uint32_t ordinal = 0; ordinal < device_count; ++ordinal) {
+    lupine_device_snapshot_info info;
+    uint32_t pair_count = 0;
+    if (rpc_read(conn, &info.flags, sizeof(info.flags)) < 0 ||
+        rpc_read(conn, info.name, sizeof(info.name)) < 0 ||
+        rpc_read(conn, &info.uuid, sizeof(info.uuid)) < 0 ||
+        rpc_read(conn, &info.total_mem, sizeof(info.total_mem)) < 0 ||
+        rpc_read(conn, &pair_count, sizeof(pair_count)) < 0) {
+      return;
+    }
+    pairs.resize(static_cast<size_t>(pair_count) * 2);
+    if (pair_count != 0 &&
+        rpc_read(conn, pairs.data(), pairs.size() * sizeof(int32_t)) < 0) {
+      return;
+    }
+    CUdevice local_dev =
+        lupine_local_device_for_remote(conn, static_cast<CUdevice>(ordinal));
+    if (local_dev < 0) {
+      continue;
+    }
+    for (uint32_t pair = 0; pair < pair_count; ++pair) {
+      int attrib = static_cast<int>(pairs[pair * 2]);
+      int value = static_cast<int>(pairs[pair * 2 + 1]);
+      if (lupine_device_attribute_is_virtualized(
+              static_cast<CUdevice_attribute>(attrib))) {
+        value = 0;
+      }
+      lupine_device_attribute_cache().insert_or_assign(
+          lupine_device_attribute_key{static_cast<int>(local_dev), attrib},
+          value);
+    }
+    info.name[sizeof(info.name) - 1] = '\0';
+    lupine_device_snapshot_cache().insert_or_assign(static_cast<int>(local_dev),
+                                                    info);
+  }
+  rpc_read_end(conn);
+}
+
 extern "C" CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib,
                                          CUdevice dev) {
   if (pi == nullptr) {
@@ -1579,6 +1661,10 @@ extern "C" CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib,
     return result;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  lupine_prefill_device_snapshot(conn);
+  if (lupine_device_attribute_cache().find(key, *pi)) {
+    return CUDA_SUCCESS;
+  }
   CUresult return_value;
   int value = 0;
   if (conn == nullptr ||
@@ -1599,6 +1685,136 @@ extern "C" CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib,
     *pi = value;
   }
   return return_value;
+}
+
+extern "C" CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
+  if (name == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUdevice remote_dev = dev;
+  lupine_route route = lupine_route_for_device(&remote_dev);
+  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE) {
+    return CUDA_ERROR_INVALID_DEVICE;
+  }
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(char *, int, CUdevice);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuDeviceGetName");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(name, len, remote_dev);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (len > 0) {
+    lupine_prefill_device_snapshot(conn);
+    lupine_device_snapshot_info info;
+    if (lupine_device_snapshot_cache().find(static_cast<int>(dev), info) &&
+        (info.flags & LUPINE_DEVICE_SNAPSHOT_HAS_NAME) != 0) {
+      snprintf(name, static_cast<size_t>(len), "%s", info.name);
+      return CUDA_SUCCESS;
+    }
+  }
+  CUresult return_value;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetName) < 0 ||
+      rpc_write(conn, &len, sizeof(int)) < 0 ||
+      rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      (lupine_prepare_host_range_write(name, len * sizeof(char)), false) ||
+      (len * sizeof(char) != 0 &&
+       rpc_read(conn, name, len * sizeof(char)) < 0) ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  lupine_mark_host_range_clean(name, len * sizeof(char));
+  return return_value;
+}
+
+extern "C" CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev) {
+  if (uuid == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUdevice remote_dev = dev;
+  lupine_route route = lupine_route_for_device(&remote_dev);
+  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE) {
+    return CUDA_ERROR_INVALID_DEVICE;
+  }
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUuuid *, CUdevice);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuDeviceGetUuid_v2");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(uuid, remote_dev);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  lupine_prefill_device_snapshot(conn);
+  lupine_device_snapshot_info info;
+  if (lupine_device_snapshot_cache().find(static_cast<int>(dev), info) &&
+      (info.flags & LUPINE_DEVICE_SNAPSHOT_HAS_UUID) != 0) {
+    *uuid = info.uuid;
+    return CUDA_SUCCESS;
+  }
+  CUresult return_value;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
+      rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      (lupine_prepare_host_range_write(uuid, 16 * sizeof(CUuuid)), false) ||
+      rpc_read(conn, uuid, 16) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  lupine_mark_host_range_clean(uuid, 16 * sizeof(CUuuid));
+  return return_value;
+}
+
+extern "C" CUresult cuDeviceTotalMem_v2(size_t *bytes, CUdevice dev) {
+  if (bytes == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUdevice remote_dev = dev;
+  lupine_route route = lupine_route_for_device(&remote_dev);
+  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE) {
+    return CUDA_ERROR_INVALID_DEVICE;
+  }
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(size_t *, CUdevice);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuDeviceTotalMem_v2");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(bytes, remote_dev);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  lupine_prefill_device_snapshot(conn);
+  lupine_device_snapshot_info info;
+  if (lupine_device_snapshot_cache().find(static_cast<int>(dev), info) &&
+      (info.flags & LUPINE_DEVICE_SNAPSHOT_HAS_TOTAL_MEM) != 0) {
+    *bytes = static_cast<size_t>(info.total_mem);
+    return CUDA_SUCCESS;
+  }
+  CUresult return_value;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
+      rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, bytes, sizeof(size_t)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return return_value;
+}
+
+#ifdef cuDeviceGetUuid
+#undef cuDeviceGetUuid
+#endif
+extern "C" CUresult cuDeviceGetUuid(CUuuid *uuid, CUdevice dev) {
+  return cuDeviceGetUuid_v2(uuid, dev);
+}
+
+#ifdef cuDeviceTotalMem
+#undef cuDeviceTotalMem
+#endif
+extern "C" CUresult cuDeviceTotalMem(size_t *bytes, CUdevice dev) {
+  return cuDeviceTotalMem_v2(bytes, dev);
 }
 
 static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
@@ -7863,6 +8079,8 @@ lupine_manual_function_map() {
       {"cuArray3DCreate_v2", (void *)cuArray3DCreate_v2},
       {"cuArray3DGetDescriptor", (void *)cuArray3DGetDescriptor_v2},
       {"cuArray3DGetDescriptor_v2", (void *)cuArray3DGetDescriptor_v2},
+      {"cuDeviceGetUuid", (void *)cuDeviceGetUuid_v2},
+      {"cuDeviceTotalMem", (void *)cuDeviceTotalMem_v2},
       {"cuMemcpyHtoD", (void *)cuMemcpyHtoD_v2},
       {"cuMemcpyHtoD_v2", (void *)cuMemcpyHtoD_v2},
       {"cuMemcpyDtoH", (void *)cuMemcpyDtoH_v2},

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2056,17 +2056,20 @@ CUresult cuDeviceGet(CUdevice *device, int ordinal);
  */
 CUresult cuDeviceGetCount(int *count);
 /**
+ * @disabled client - manual client serves the device snapshot cache
  * @param len SEND_ONLY
  * @param name RECV_ONLY LENGTH:len
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetName(char *name, int len, CUdevice dev);
 /**
+ * @disabled client - manual client serves the device snapshot cache
  * @param uuid RECV_ONLY SIZE:16
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetUuid(CUuuid *uuid, CUdevice dev);
 /**
+ * @disabled client - manual client serves the device snapshot cache
  * @param uuid RECV_ONLY SIZE:16
  * @param dev SEND_ONLY
  */
@@ -2079,6 +2082,7 @@ CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev);
 CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
                          CUdevice dev);
 /**
+ * @disabled client - manual client serves the device snapshot cache
  * @param bytes RECV_ONLY
  * @param dev SEND_ONLY
  */

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -187,6 +187,7 @@ PRIVATE_RPC_FUNCTIONS = [
     "cuPrivateGetModuleNode",
     "cuStreamBeginCaptureToGraph",
     "cuStreamGetCaptureInfo_v3",
+    "lupineDeviceSnapshot",
     "lupineManagedHostFlush",
 ]
 

--- a/codegen/gen_api.h
+++ b/codegen/gen_api.h
@@ -453,4 +453,5 @@
 #define LUPINE_RPC_cuPrivateGetModuleNode 1986234018
 #define LUPINE_RPC_cuStreamBeginCaptureToGraph 1423223781
 #define LUPINE_RPC_cuStreamGetCaptureInfo_v3 1793131524
+#define LUPINE_RPC_lupineDeviceSnapshot 838398900
 #define LUPINE_RPC_lupineManagedHostFlush 1450411892

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -116,56 +116,6 @@ CUresult cuDriverGetVersion(int *driverVersion) {
   return return_value;
 }
 
-CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
-  lupine_route route = lupine_route_for_device(&dev);
-  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)
-    return CUDA_ERROR_INVALID_DEVICE;
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(char *, int, CUdevice);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuDeviceGetName", &return_value, name, len, dev)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetName) < 0 ||
-      rpc_write(conn, &len, sizeof(int)) < 0 ||
-      rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      (lupine_prepare_host_range_write(name, len * sizeof(char)), false) ||
-      (len * sizeof(char) != 0 &&
-       rpc_read(conn, name, len * sizeof(char)) < 0) ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  lupine_mark_host_range_clean(name, len * sizeof(char));
-  return return_value;
-}
-
-CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev) {
-  lupine_route route = lupine_route_for_device(&dev);
-  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)
-    return CUDA_ERROR_INVALID_DEVICE;
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUuuid *, CUdevice);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuDeviceGetUuid_v2",
-                                                  &return_value, uuid, dev)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
-      rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      (lupine_prepare_host_range_write(uuid, 16 * sizeof(CUuuid)), false) ||
-      (16 != 0 && rpc_read(conn, uuid, 16) < 0) ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  lupine_mark_host_range_clean(uuid, 16 * sizeof(CUuuid));
-  return return_value;
-}
-
 CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
                          CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
@@ -189,28 +139,6 @@ CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   lupine_mark_host_range_clean(luid, 8 * sizeof(char));
-  return return_value;
-}
-
-CUresult cuDeviceTotalMem_v2(size_t *bytes, CUdevice dev) {
-  lupine_route route = lupine_route_for_device(&dev);
-  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)
-    return CUDA_ERROR_INVALID_DEVICE;
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(size_t *, CUdevice);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuDeviceTotalMem_v2",
-                                                  &return_value, bytes, dev)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
-      rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, bytes, sizeof(size_t)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
   return return_value;
 }
 
@@ -7035,20 +6963,6 @@ CUresult cuGraphicsUnmapResources(unsigned int count,
   return return_value;
 }
 
-#ifdef cuDeviceTotalMem
-#undef cuDeviceTotalMem
-#endif
-extern "C" CUresult cuDeviceTotalMem(size_t *bytes, CUdevice dev) {
-  return cuDeviceTotalMem_v2(bytes, dev);
-}
-
-#ifdef cuDeviceGetUuid
-#undef cuDeviceGetUuid
-#endif
-extern "C" CUresult cuDeviceGetUuid(CUuuid *uuid, CUdevice dev) {
-  return cuDeviceGetUuid_v2(uuid, dev);
-}
-
 #ifdef cuDevicePrimaryCtxRelease
 #undef cuDevicePrimaryCtxRelease
 #endif
@@ -7800,8 +7714,6 @@ std::unordered_map<std::string, void *> functionMap = {
      (void *)cuGraphicsResourceSetMapFlags_v2},
     {"cuGraphicsMapResources", (void *)cuGraphicsMapResources},
     {"cuGraphicsUnmapResources", (void *)cuGraphicsUnmapResources},
-    {"cuDeviceTotalMem", (void *)cuDeviceTotalMem_v2},
-    {"cuDeviceGetUuid", (void *)cuDeviceGetUuid_v2},
     {"cuDevicePrimaryCtxRelease", (void *)cuDevicePrimaryCtxRelease_v2},
     {"cuDevicePrimaryCtxSetFlags", (void *)cuDevicePrimaryCtxSetFlags_v2},
     {"cuDevicePrimaryCtxReset", (void *)cuDevicePrimaryCtxReset_v2},

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3581,6 +3581,85 @@ int handle_manual_lupineManagedHostFlush(conn_t *conn) {
   }
   return 0;
 }
+// Serves LUPINE_RPC_lupineDeviceSnapshot: every immutable per-device value the
+// client caches, for every device, in one response. Mutable state (primary
+// context state, context limits) is deliberately excluded.
+int handle_manual_lupineDeviceSnapshot(conn_t *conn) {
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  int device_count = 0;
+  CUresult result = cuDeviceGetCount(&device_count);
+  if (result != CUDA_SUCCESS || device_count < 0) {
+    device_count = 0;
+  }
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0) {
+    return -1;
+  }
+  if (result != CUDA_SUCCESS) {
+    return rpc_write_end(conn) < 0 ? -1 : 0;
+  }
+
+  // rpc_write queues iovecs that are only sent at rpc_write_end, so every
+  // record is serialized into one buffer that stays alive until then.
+  uint32_t devices = static_cast<uint32_t>(device_count);
+  std::vector<unsigned char> blob;
+  auto append = [&blob](const void *data, size_t size) {
+    const auto *bytes = static_cast<const unsigned char *>(data);
+    blob.insert(blob.end(), bytes, bytes + size);
+  };
+  append(&devices, sizeof(devices));
+  std::vector<int32_t> pairs;
+  for (uint32_t ordinal = 0; ordinal < devices; ++ordinal) {
+    CUdevice device = 0;
+    uint32_t flags = 0;
+    char name[LUPINE_DEVICE_SNAPSHOT_NAME_BYTES] = {};
+    CUuuid uuid = {};
+    uint64_t total_mem = 0;
+    pairs.clear();
+    if (cuDeviceGet(&device, static_cast<int>(ordinal)) == CUDA_SUCCESS) {
+      if (cuDeviceGetName(name, sizeof(name), device) == CUDA_SUCCESS) {
+        flags |= LUPINE_DEVICE_SNAPSHOT_HAS_NAME;
+        name[sizeof(name) - 1] = '\0';
+      }
+      if (cuDeviceGetUuid_v2(&uuid, device) == CUDA_SUCCESS) {
+        flags |= LUPINE_DEVICE_SNAPSHOT_HAS_UUID;
+      }
+      size_t bytes = 0;
+      if (cuDeviceTotalMem_v2(&bytes, device) == CUDA_SUCCESS) {
+        flags |= LUPINE_DEVICE_SNAPSHOT_HAS_TOTAL_MEM;
+        total_mem = bytes;
+      }
+      for (int attrib = 1; attrib < CU_DEVICE_ATTRIBUTE_MAX; ++attrib) {
+        int value = 0;
+        if (cuDeviceGetAttribute(
+                &value, static_cast<CUdevice_attribute>(attrib), device) ==
+            CUDA_SUCCESS) {
+          pairs.push_back(static_cast<int32_t>(attrib));
+          pairs.push_back(static_cast<int32_t>(value));
+        }
+      }
+    }
+    uint32_t pair_count = static_cast<uint32_t>(pairs.size() / 2);
+    append(&flags, sizeof(flags));
+    append(name, sizeof(name));
+    append(&uuid, sizeof(uuid));
+    append(&total_mem, sizeof(total_mem));
+    append(&pair_count, sizeof(pair_count));
+    if (pair_count != 0) {
+      append(pairs.data(), pairs.size() * sizeof(int32_t));
+    }
+  }
+  if (rpc_write(conn, blob.data(), blob.size()) < 0) {
+    return -1;
+  }
+  return rpc_write_end(conn) < 0 ? -1 : 0;
+}
+
 int handle_manual_cuMemcpyAtoH_v2(conn_t *conn) {
   CUarray srcArray = nullptr;
   size_t srcOffset = 0;

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3583,7 +3583,18 @@ int handle_manual_lupineManagedHostFlush(conn_t *conn) {
 }
 // Serves LUPINE_RPC_lupineDeviceSnapshot: every immutable per-device value the
 // client caches, for every device, in one response. Mutable state (primary
-// context state, context limits) is deliberately excluded.
+// context state, context limits) is deliberately excluded. The response is all
+// or nothing: any query failure fails the whole RPC and the client falls back
+// to the per-call paths. Individual attributes the driver rejects are simply
+// absent from the pair list; that is expected, not an error.
+struct lupine_device_snapshot_record {
+  char name[LUPINE_DEVICE_SNAPSHOT_NAME_BYTES] = {};
+  CUuuid uuid = {};
+  uint64_t total_mem = 0;
+  uint32_t pair_count = 0;
+  std::vector<int32_t> pairs;
+};
+
 int handle_manual_lupineDeviceSnapshot(conn_t *conn) {
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
@@ -3592,10 +3603,50 @@ int handle_manual_lupineDeviceSnapshot(conn_t *conn) {
 
   int device_count = 0;
   CUresult result = cuDeviceGetCount(&device_count);
-  if (result != CUDA_SUCCESS || device_count < 0) {
-    device_count = 0;
+  if (result == CUDA_SUCCESS && device_count < 0) {
+    result = CUDA_ERROR_UNKNOWN;
   }
 
+  // rpc_write queues iovecs that are only sent at rpc_write_end, so all
+  // records are built first in storage that stays stable until then.
+  std::vector<lupine_device_snapshot_record> records;
+  if (result == CUDA_SUCCESS) {
+    try {
+      records.resize(static_cast<size_t>(device_count));
+    } catch (...) {
+      result = CUDA_ERROR_OUT_OF_MEMORY;
+    }
+  }
+  for (size_t ordinal = 0; result == CUDA_SUCCESS && ordinal < records.size();
+       ++ordinal) {
+    auto &record = records[ordinal];
+    CUdevice device = 0;
+    size_t bytes = 0;
+    result = cuDeviceGet(&device, static_cast<int>(ordinal));
+    if (result == CUDA_SUCCESS) {
+      result = cuDeviceGetName(record.name, sizeof(record.name), device);
+      record.name[sizeof(record.name) - 1] = '\0';
+    }
+    if (result == CUDA_SUCCESS) {
+      result = cuDeviceGetUuid_v2(&record.uuid, device);
+    }
+    if (result == CUDA_SUCCESS) {
+      result = cuDeviceTotalMem_v2(&bytes, device);
+      record.total_mem = bytes;
+    }
+    for (int attrib = 1; result == CUDA_SUCCESS && attrib < CU_DEVICE_ATTRIBUTE_MAX;
+         ++attrib) {
+      int value = 0;
+      if (cuDeviceGetAttribute(&value, static_cast<CUdevice_attribute>(attrib),
+                               device) == CUDA_SUCCESS) {
+        record.pairs.push_back(static_cast<int32_t>(attrib));
+        record.pairs.push_back(static_cast<int32_t>(value));
+      }
+    }
+    record.pair_count = static_cast<uint32_t>(record.pairs.size() / 2);
+  }
+
+  uint32_t devices = static_cast<uint32_t>(records.size());
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0) {
     return -1;
@@ -3603,59 +3654,19 @@ int handle_manual_lupineDeviceSnapshot(conn_t *conn) {
   if (result != CUDA_SUCCESS) {
     return rpc_write_end(conn) < 0 ? -1 : 0;
   }
-
-  // rpc_write queues iovecs that are only sent at rpc_write_end, so every
-  // record is serialized into one buffer that stays alive until then.
-  uint32_t devices = static_cast<uint32_t>(device_count);
-  std::vector<unsigned char> blob;
-  auto append = [&blob](const void *data, size_t size) {
-    const auto *bytes = static_cast<const unsigned char *>(data);
-    blob.insert(blob.end(), bytes, bytes + size);
-  };
-  append(&devices, sizeof(devices));
-  std::vector<int32_t> pairs;
-  for (uint32_t ordinal = 0; ordinal < devices; ++ordinal) {
-    CUdevice device = 0;
-    uint32_t flags = 0;
-    char name[LUPINE_DEVICE_SNAPSHOT_NAME_BYTES] = {};
-    CUuuid uuid = {};
-    uint64_t total_mem = 0;
-    pairs.clear();
-    if (cuDeviceGet(&device, static_cast<int>(ordinal)) == CUDA_SUCCESS) {
-      if (cuDeviceGetName(name, sizeof(name), device) == CUDA_SUCCESS) {
-        flags |= LUPINE_DEVICE_SNAPSHOT_HAS_NAME;
-        name[sizeof(name) - 1] = '\0';
-      }
-      if (cuDeviceGetUuid_v2(&uuid, device) == CUDA_SUCCESS) {
-        flags |= LUPINE_DEVICE_SNAPSHOT_HAS_UUID;
-      }
-      size_t bytes = 0;
-      if (cuDeviceTotalMem_v2(&bytes, device) == CUDA_SUCCESS) {
-        flags |= LUPINE_DEVICE_SNAPSHOT_HAS_TOTAL_MEM;
-        total_mem = bytes;
-      }
-      for (int attrib = 1; attrib < CU_DEVICE_ATTRIBUTE_MAX; ++attrib) {
-        int value = 0;
-        if (cuDeviceGetAttribute(
-                &value, static_cast<CUdevice_attribute>(attrib), device) ==
-            CUDA_SUCCESS) {
-          pairs.push_back(static_cast<int32_t>(attrib));
-          pairs.push_back(static_cast<int32_t>(value));
-        }
-      }
-    }
-    uint32_t pair_count = static_cast<uint32_t>(pairs.size() / 2);
-    append(&flags, sizeof(flags));
-    append(name, sizeof(name));
-    append(&uuid, sizeof(uuid));
-    append(&total_mem, sizeof(total_mem));
-    append(&pair_count, sizeof(pair_count));
-    if (pair_count != 0) {
-      append(pairs.data(), pairs.size() * sizeof(int32_t));
-    }
-  }
-  if (rpc_write(conn, blob.data(), blob.size()) < 0) {
+  if (rpc_write(conn, &devices, sizeof(devices)) < 0) {
     return -1;
+  }
+  for (const auto &record : records) {
+    if (rpc_write(conn, record.name, sizeof(record.name)) < 0 ||
+        rpc_write(conn, &record.uuid, sizeof(record.uuid)) < 0 ||
+        rpc_write(conn, &record.total_mem, sizeof(record.total_mem)) < 0 ||
+        rpc_write(conn, &record.pair_count, sizeof(record.pair_count)) < 0 ||
+        (record.pair_count != 0 &&
+         rpc_write(conn, record.pairs.data(),
+                   record.pairs.size() * sizeof(int32_t)) < 0)) {
+      return -1;
+    }
   }
   return rpc_write_end(conn) < 0 ? -1 : 0;
 }

--- a/manual_server.h
+++ b/manual_server.h
@@ -78,6 +78,7 @@ int handle_manual_cuGraphInstantiateWithParams(conn_t *conn);
 int handle_manual_cuGraphExecDestroy(conn_t *conn);
 int handle_manual_cuGraphDestroy(conn_t *conn);
 int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn);
+int handle_manual_lupineDeviceSnapshot(conn_t *conn);
 int handle_manual_lupineManagedHostFlush(conn_t *conn);
 int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn);
 int handle_manual_cuMemHostGetFlags(conn_t *conn);

--- a/rpc.h
+++ b/rpc.h
@@ -30,13 +30,11 @@ struct rpc_http2_read_stats {
 
 #define LUPINE_RPC_TERMINATE_LANE 0xFFFF
 
-// Wire layout for LUPINE_RPC_lupineDeviceSnapshot. The response carries, per
-// device: validity flags, a fixed-size name buffer, uuid, total memory, and a
+// Wire layout for LUPINE_RPC_lupineDeviceSnapshot. The response is all or
+// nothing: a non-success result carries no payload, otherwise every device
+// record holds a fixed-size name buffer, uuid, total memory, and a
 // count-prefixed list of (attribute, value) pairs.
 #define LUPINE_DEVICE_SNAPSHOT_NAME_BYTES 256
-#define LUPINE_DEVICE_SNAPSHOT_HAS_NAME 0x1u
-#define LUPINE_DEVICE_SNAPSHOT_HAS_UUID 0x2u
-#define LUPINE_DEVICE_SNAPSHOT_HAS_TOTAL_MEM 0x4u
 
 typedef struct conn_t conn_t;
 

--- a/rpc.h
+++ b/rpc.h
@@ -30,6 +30,14 @@ struct rpc_http2_read_stats {
 
 #define LUPINE_RPC_TERMINATE_LANE 0xFFFF
 
+// Wire layout for LUPINE_RPC_lupineDeviceSnapshot. The response carries, per
+// device: validity flags, a fixed-size name buffer, uuid, total memory, and a
+// count-prefixed list of (attribute, value) pairs.
+#define LUPINE_DEVICE_SNAPSHOT_NAME_BYTES 256
+#define LUPINE_DEVICE_SNAPSHOT_HAS_NAME 0x1u
+#define LUPINE_DEVICE_SNAPSHOT_HAS_UUID 0x2u
+#define LUPINE_DEVICE_SNAPSHOT_HAS_TOTAL_MEM 0x4u
+
 typedef struct conn_t conn_t;
 
 struct conn_t {

--- a/server.cpp
+++ b/server.cpp
@@ -269,6 +269,8 @@ lupine_manual_handlers() {
        {handle_manual_cuMemcpyHtoDAsync_v2, "cuMemcpyHtoDAsync_v2"}},
       {LUPINE_RPC_lupineManagedHostFlush,
        {handle_manual_lupineManagedHostFlush, "lupineManagedHostFlush"}},
+      {LUPINE_RPC_lupineDeviceSnapshot,
+       {handle_manual_lupineDeviceSnapshot, "lupineDeviceSnapshot"}},
       {RPC_cuMemcpyDtoHAsync_v2,
        {handle_manual_cuMemcpyDtoHAsync_v2, "cuMemcpyDtoHAsync_v2"}},
       {RPC_cuCtxSynchronize,


### PR DESCRIPTION
Torch init reads every device attribute serially; over the cloud gateway (~30ms RTT) that was 890 blocked round trips = 26.9s of an 80s makemore run (36% of all RPC wait), plus ~3s more for uuid/name/totalmem. With the snapshot: one RPC per connection (~2.4ms on LAN) prefills all caches — a 131-attribute + name/uuid/totalmem scan now issues zero per-query RPCs, verified byte-identical to native driver output on a 4090 (modulo the two intentionally virtualized attrs) and across a 3-GPU two-server topology.