### PR TITLE
Serialize cuLinkDestroy against in-flight cuLinkComplete responses

### DIFF
--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -76,10 +76,14 @@ static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBINC_V2 = 3;
 static constexpr uint32_t LUPINE_PRIVATE_EXPORT_MAX_SLOTS = 256;
 
 // The CUDA linker requires output option buffers to remain valid for the
-// lifetime of CUlinkState.
+// lifetime of CUlinkState. The mutex serializes cuLinkDestroy against a
+// concurrent cuLinkComplete on another RPC lane: the cubin buffer returned by
+// cuLinkComplete is driver-owned and freed by cuLinkDestroy, so it must stay
+// locked out until the response holding that buffer has been flushed.
 struct lupine_link_state {
   CUlinkState cuda_state = nullptr;
   rpc_jit_server_state jit;
+  std::mutex mutex;
 };
 
 static lupine_link_state *lupine_link_state_from_handle(CUlinkState state) {
@@ -1563,7 +1567,12 @@ int handle_manual_cuLinkComplete(conn_t *conn) {
   auto *link_state = lupine_link_state_from_handle(state);
   rpc_jit_server_state empty_jit_state;
   rpc_jit_server_state *jit_state = &empty_jit_state;
+  // Held until the response is flushed: the cubin buffer belongs to the
+  // driver's link state, and a concurrent cuLinkDestroy would free it while
+  // the queued iovec still points at it.
+  std::unique_lock<std::mutex> lock;
   if (link_state != nullptr) {
+    lock = std::unique_lock<std::mutex>(link_state->mutex);
     result = cuLinkComplete(link_state->cuda_state, &cubin, &size);
     jit_state = &link_state->jit;
   }
@@ -1590,10 +1599,13 @@ int handle_manual_cuLinkDestroy(conn_t *conn) {
   }
   auto *link_state = lupine_link_state_from_handle(state);
   if (link_state != nullptr) {
+    // Wait for any cuLinkComplete on another lane to finish flushing the
+    // driver-owned cubin buffer before cuLinkDestroy frees it.
+    std::lock_guard<std::mutex> lock(link_state->mutex);
     result = cuLinkDestroy(link_state->cuda_state);
   }
-  // A concurrent cuLinkComplete may still be serializing the output buffers.
-  // Retain the opaque handle wrapper until process exit.
+  // Retain the opaque handle wrapper until process exit so stale client
+  // handles never dereference freed memory.
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;


### PR DESCRIPTION
rpc_write queues zero-copy iovecs that are only transmitted at rpc_write_end, and the cubin pointer returned by cuLinkComplete is driver-owned memory that cuLinkDestroy frees. RPC lanes run handlers concurrently on one connection, so a client thread calling cuLinkDestroy while another thread's cuLinkComplete response is still being serialized could free the cubin out from under the queued iovec — the server would then stream freed memory (or crash) mid-response. The existing mitigation only retained the handle wrapper, not the driver buffer. A per-link-state mutex now holds cuLinkDestroy out until the cuLinkComplete response has flushed.