### PR TITLE
Piggyback the library kernel table on cuLibraryLoadData responses

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -444,6 +444,33 @@ lupine_param_info_cache() {
   return *cache;
 }
 
+// Filled from the kernel table piggybacked on the cuLibraryLoadData response;
+// serves cuLibraryGetKernel without a round trip.
+struct lupine_library_kernel_name_key {
+  CUlibrary library = nullptr;
+  std::string name;
+
+  bool operator==(const lupine_library_kernel_name_key &other) const {
+    return library == other.library && name == other.name;
+  }
+};
+
+struct lupine_library_kernel_name_key_hash {
+  size_t operator()(const lupine_library_kernel_name_key &key) const {
+    return reinterpret_cast<uintptr_t>(key.library) ^
+           std::hash<std::string>()(key.name);
+  }
+};
+
+static libcuckoo::cuckoohash_map<lupine_library_kernel_name_key, CUkernel,
+                                 lupine_library_kernel_name_key_hash> &
+lupine_library_kernel_names() {
+  static auto *cache =
+      new libcuckoo::cuckoohash_map<lupine_library_kernel_name_key, CUkernel,
+                                    lupine_library_kernel_name_key_hash>();
+  return *cache;
+}
+
 static std::mutex &lupine_host_function_mutex() {
   static auto *mutex = new std::mutex();
   return *mutex;
@@ -872,6 +899,55 @@ extern "C" void lupine_record_module_image(CUmodule module, lupine_route route,
   record.image_ptr = image_ptr;
   record.image.assign(image, image + image_size);
   record.modules_by_route[route_id] = module;
+}
+
+extern "C" CUresult lupine_record_library_kernel(CUkernel kernel,
+                                                 CUlibrary library,
+                                                 const char *name,
+                                                 lupine_route route);
+
+extern "C" CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
+                                       const char *name) {
+  if (pKernel == nullptr || name == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  lupine_route route = lupine_route_for_library(library);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUkernel *, CUlibrary, const char *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLibraryGetKernel", &return_value, pKernel, library, name)) {
+    if (return_value == CUDA_SUCCESS && pKernel != nullptr) {
+      return_value =
+          lupine_record_library_kernel(*pKernel, library, name, route);
+    }
+    return return_value;
+  }
+  // Served from the kernel table piggybacked on the cuLibraryLoadData
+  // response; ownership recording and param-info warming already happened at
+  // prefill time.
+  CUkernel cached = nullptr;
+  if (lupine_library_kernel_names().find(
+          lupine_library_kernel_name_key{library, std::string(name)},
+          cached)) {
+    *pKernel = cached;
+    return CUDA_SUCCESS;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  std::size_t name_len = std::strlen(name) + 1;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
+      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
+      rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
+      rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, pKernel, sizeof(CUkernel)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS && pKernel != nullptr) {
+    return_value = lupine_record_library_kernel(*pKernel, library, name, route);
+  }
+  return return_value;
 }
 
 extern "C" CUresult lupine_record_library_kernel(CUkernel kernel,
@@ -3929,8 +4005,49 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
                                 libraryOptionValues, &library_raw_values) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, library, sizeof(CUlibrary)) < 0 ||
-      rpc_read_jit_outputs(conn, bindings) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_jit_outputs(conn, bindings) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+
+  // The server piggybacks the library's kernel table onto this response:
+  // names, handles, and full parameter layouts. Prefilling the param-info and
+  // name caches here means cuLibraryGetKernel and the per-kernel param walk
+  // never issue their own round trips.
+  struct lupine_wire_kernel_record {
+    std::string name;
+    CUkernel kernel = nullptr;
+    uint32_t param_count = 0;
+    std::vector<uint64_t> params;
+  };
+  uint32_t table_count = 0;
+  std::vector<lupine_wire_kernel_record> table;
+  if (rpc_read(conn, &table_count, sizeof(table_count)) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  for (uint32_t i = 0; i < table_count; ++i) {
+    lupine_wire_kernel_record record;
+    uint32_t name_len = 0;
+    if (rpc_read(conn, &name_len, sizeof(name_len)) < 0 || name_len == 0 ||
+        name_len > 64 * 1024) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    record.name.resize(name_len);
+    if (rpc_read(conn, record.name.data(), name_len) < 0 ||
+        rpc_read(conn, &record.kernel, sizeof(record.kernel)) < 0 ||
+        rpc_read(conn, &record.param_count, sizeof(record.param_count)) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    record.name.resize(name_len - 1);
+    record.params.resize(static_cast<size_t>(record.param_count) * 2);
+    if (record.param_count != 0 &&
+        rpc_read(conn, record.params.data(),
+                 record.params.size() * sizeof(uint64_t)) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    table.push_back(std::move(record));
+  }
+
+  if (rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
@@ -3939,6 +4056,33 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
     lupine_record_library_image(*library, lupine_remote_route_for_conn(conn),
                                 kind, image_bytes.data(), image_bytes.size(),
                                 code);
+    lupine_route route = lupine_remote_route_for_conn(conn);
+    for (const auto &record : table) {
+      if (record.kernel == nullptr) {
+        continue;
+      }
+      for (uint32_t index = 0; index < record.param_count; ++index) {
+        lupine_param_info_cache().insert_or_assign(
+            lupine_param_info_key{reinterpret_cast<uintptr_t>(record.kernel),
+                                  index, true},
+            lupine_param_info_value{CUDA_SUCCESS,
+                                    static_cast<size_t>(
+                                        record.params[index * 2]),
+                                    static_cast<size_t>(
+                                        record.params[index * 2 + 1])});
+      }
+      lupine_param_info_cache().insert_or_assign(
+          lupine_param_info_key{reinterpret_cast<uintptr_t>(record.kernel),
+                                record.param_count, true},
+          lupine_param_info_value{CUDA_ERROR_INVALID_VALUE, 0, 0});
+      if (lupine_record_library_kernel(record.kernel, *library,
+                                       record.name.c_str(), route) ==
+          CUDA_SUCCESS) {
+        lupine_library_kernel_names().insert_or_assign(
+            lupine_library_kernel_name_key{*library, record.name},
+            record.kernel);
+      }
+    }
   }
   return return_value;
 }

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2458,6 +2458,7 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
  */
 CUresult cuLibraryUnload(CUlibrary library);
 /**
+ * @disabled client - manual client serves the library kernel table
  * @routingkey LIBRARY library
  * @param pKernel RECV_ONLY
  * @param library SEND_ONLY

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -1022,34 +1022,6 @@ CUresult cuLibraryUnload(CUlibrary library) {
   return return_value;
 }
 
-CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
-                            const char *name) {
-  lupine_route route = lupine_route_for_library(library);
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUkernel *, CUlibrary, const char *);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuLibraryGetKernel", &return_value, pKernel, library, name)) {
-    if (return_value == CUDA_SUCCESS && pKernel != nullptr)
-      return_value =
-          lupine_record_library_kernel(*pKernel, library, name, route);
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  std::size_t name_len = std::strlen(name) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
-      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
-      rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
-      rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, pKernel, sizeof(CUkernel)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS && pKernel != nullptr)
-    return_value = lupine_record_library_kernel(*pKernel, library, name, route);
-  return return_value;
-}
-
 CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
   lupine_route route = lupine_route_for_library(library);
   CUresult return_value;

--- a/cuda_compat.h
+++ b/cuda_compat.h
@@ -48,6 +48,7 @@ CUresult cuKernelGetParamInfo(CUkernel, size_t, size_t *, size_t *);
 CUresult cuFuncGetParamInfo(CUfunction, size_t, size_t *, size_t *);
 CUresult cuKernelGetAttribute(int *, CUfunction_attribute, CUkernel, CUdevice);
 CUresult cuKernelGetFunction(CUfunction *, CUkernel);
+CUresult cuLibraryGetKernel(CUkernel *, CUlibrary, const char *);
 #ifdef __cplusplus
 }
 #endif

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -999,10 +999,77 @@ int handle_manual_cuLibraryLoadData(conn_t *conn) {
     lupine_note_device_stdout_image(image.data(), image.size());
   }
 
+  // The response carries every kernel in the library with its name and full
+  // parameter layout, so the client can serve cuLibraryGetKernel and the
+  // per-kernel param-info walk from cache instead of one round trip per
+  // query. Enumeration failures degrade to an empty table; the client then
+  // falls back to the per-call RPCs. Records are built before any rpc_write
+  // because queued iovecs are only transmitted at rpc_write_end.
+  struct kernel_record {
+    std::string name;
+    CUkernel kernel = nullptr;
+    uint32_t name_len = 0;
+    uint32_t param_count = 0;
+    std::vector<uint64_t> params;
+  };
+  std::vector<kernel_record> records;
+#if CUDA_VERSION >= 12040
+  if (result == CUDA_SUCCESS) {
+    unsigned int kernel_count = 0;
+    std::vector<CUkernel> kernels;
+    if (cuLibraryGetKernelCount(&kernel_count, library) == CUDA_SUCCESS &&
+        kernel_count != 0) {
+      kernels.resize(kernel_count);
+      if (cuLibraryEnumerateKernels(kernels.data(), kernel_count, library) !=
+          CUDA_SUCCESS) {
+        kernels.clear();
+      }
+    }
+    for (CUkernel kernel : kernels) {
+      const char *name = nullptr;
+      if (kernel == nullptr || cuKernelGetName(&name, kernel) != CUDA_SUCCESS ||
+          name == nullptr) {
+        continue;
+      }
+      kernel_record record;
+      record.name = name;
+      record.name_len = static_cast<uint32_t>(record.name.size() + 1);
+      record.kernel = kernel;
+      for (size_t index = 0;; ++index) {
+        size_t offset = 0;
+        size_t size = 0;
+        if (cuKernelGetParamInfo(kernel, index, &offset, &size) !=
+            CUDA_SUCCESS) {
+          break;
+        }
+        record.params.push_back(static_cast<uint64_t>(offset));
+        record.params.push_back(static_cast<uint64_t>(size));
+      }
+      record.param_count = static_cast<uint32_t>(record.params.size() / 2);
+      records.push_back(std::move(record));
+    }
+  }
+#endif
+
+  uint32_t table_count = static_cast<uint32_t>(records.size());
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &library, sizeof(library)) < 0 ||
       rpc_write_jit_outputs(conn, &jit_state) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+      rpc_write(conn, &table_count, sizeof(table_count)) < 0) {
+    return -1;
+  }
+  for (const auto &record : records) {
+    if (rpc_write(conn, &record.name_len, sizeof(record.name_len)) < 0 ||
+        rpc_write(conn, record.name.c_str(), record.name_len) < 0 ||
+        rpc_write(conn, &record.kernel, sizeof(record.kernel)) < 0 ||
+        rpc_write(conn, &record.param_count, sizeof(record.param_count)) < 0 ||
+        (record.param_count != 0 &&
+         rpc_write(conn, record.params.data(),
+                   record.params.size() * sizeof(uint64_t)) < 0)) {
+      return -1;
+    }
+  }
+  if (rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
   return 0;


### PR DESCRIPTION
After loading a library the client walks every kernel's parameter layout one cuKernelGetParamInfo RPC at a time (and resolves each kernel with its own cuLibraryGetKernel RPC) — 228 + 36 blocked round trips = 7.9s of the makemore init profile at the cloud gateway's ~30ms RTT. The server now enumerates the library's kernels after cuLibraryLoadData and appends {name, handle, param table} per kernel to the response it already sends; the client prefills the param-info and name caches from it. Measured over LAN against an RTX 4090: cuKernelGetParamInfo 193 to 0 RPCs, cuLibraryGetKernel 35 to 0, cuFuncGetParamInfo/cuKernelGetFunction also 0, training loss curves identical. Cost: cuLibraryLoadData averages 14.9 to 19.6ms from server-side enumeration (+113ms total for 24 libraries, vs ~7.9s of round trips removed at WAN latency). Enumeration failures or pre-12.4 CUDA degrade to an empty table and the per-call RPC paths.