### PR TITLE
Hide steady-state round trips with fire-and-forget submissions

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -929,6 +929,33 @@ extern "C" CUresult lupine_record_library_kernel(CUkernel kernel,
                                                  const char *name,
                                                  lupine_route route);
 
+extern "C" void lupine_invalidate_function_caches();
+
+extern "C" CUresult cuLibraryUnload(CUlibrary library) {
+  lupine_route route = lupine_route_for_library(library);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUlibrary);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryUnload",
+                                                  &return_value, library)) {
+    if (return_value == CUDA_SUCCESS) {
+      lupine_invalidate_function_caches();
+    }
+    return return_value;
+  }
+  // Unloads only release server-side resources the connection reclaims anyway,
+  // so they go out fire-and-forget: at teardown a program can issue dozens of
+  // them and each blocking round trip is pure latency.
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
+      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
+      rpc_write_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  lupine_invalidate_function_caches();
+  return CUDA_SUCCESS;
+}
+
 extern "C" CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
                                        const char *name) {
   if (pKernel == nullptr || name == nullptr) {
@@ -4877,21 +4904,16 @@ extern "C" CUresult cuMemcpyAtoH(void *dstHost, CUarray srcArray,
 extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
       rpc_write(conn, &dstHost, sizeof(dstHost)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
-      rpc_wait_for_response(conn) < 0) {
+      rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return return_value;
+  return CUDA_SUCCESS;
 }
 
 #ifdef cuMemcpyDtoHAsync
@@ -8463,6 +8485,7 @@ lupine_manual_function_map() {
       {"cuModuleLoadData", (void *)cuModuleLoadData},
       {"cuModuleLoadDataEx", (void *)cuModuleLoadDataEx},
       {"cuLibraryLoadData", (void *)cuLibraryLoadData},
+      {"cuLibraryUnload", (void *)cuLibraryUnload},
       {"cuLinkCreate", (void *)cuLinkCreate_v2},
       {"cuLinkAddData", (void *)cuLinkAddData_v2},
       {"cuLinkAddFile", (void *)cuLinkAddFile_v2},

--- a/client_routing.h
+++ b/client_routing.h
@@ -70,6 +70,7 @@ extern "C" bool lupine_routes_share_server(lupine_route first,
                                            lupine_route second);
 extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first,
                                               CUdeviceptr second);
+extern "C" bool lupine_deviceptr_is_tracked(CUdeviceptr ptr);
 extern "C" bool lupine_translate_device_for_conn(conn_t *conn,
                                                  CUdevice *device);
 extern "C" CUdevice lupine_local_device_for_remote(conn_t *conn,

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2458,6 +2458,8 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
                                void **libraryOptionValues,
                                unsigned int numLibraryOptions);
 /**
+ * @disabled client - manual client sends fire-and-forget unloads
+ * @disabled server - manual server supports fire-and-forget unloads
  * @routingkey LIBRARY library
  * @param library SEND_ONLY
  */
@@ -2613,6 +2615,7 @@ CUresult cuMemAllocHost_v2(void **pp, size_t bytesize);
 CUresult cuMemFreeHost(void *p);
 /**
  * @disabled client - manual client substitutes a local faulting address
+ * @disabled server - manual server returns the mapped device alias
  * @param pp SEND_RECV
  * @param bytesize SEND_ONLY
  * @param Flags SEND_ONLY

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -874,29 +874,6 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
   return return_value;
 }
 
-CUresult cuLibraryUnload(CUlibrary library) {
-  lupine_route route = lupine_route_for_library(library);
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUlibrary);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryUnload",
-                                                  &return_value, library)) {
-    if (return_value == CUDA_SUCCESS)
-      lupine_invalidate_function_caches();
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
-      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS)
-    lupine_invalidate_function_caches();
-  return return_value;
-}
-
 CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
   lupine_route route = lupine_route_for_library(library);
   CUresult return_value;
@@ -7254,7 +7231,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuModuleGetTexRef", (void *)cuModuleGetTexRef},
     {"cuModuleGetSurfRef", (void *)cuModuleGetSurfRef},
     {"cuLibraryLoadFromFile", (void *)cuLibraryLoadFromFile},
-    {"cuLibraryUnload", (void *)cuLibraryUnload},
     {"cuLibraryGetKernel", (void *)cuLibraryGetKernel},
     {"cuLibraryGetModule", (void *)cuLibraryGetModule},
     {"cuKernelGetFunction", (void *)cuKernelGetFunction},
@@ -7273,7 +7249,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemGetAddressRange_v2", (void *)cuMemGetAddressRange_v2},
     {"cuMemAllocHost_v2", (void *)cuMemAllocHost_v2},
     {"cuMemFreeHost", (void *)cuMemFreeHost},
-    {"cuMemHostAlloc", (void *)cuMemHostAlloc},
     {"cuMemHostGetDevicePointer_v2", (void *)cuMemHostGetDevicePointer_v2},
     {"cuMemAllocManaged", (void *)cuMemAllocManaged},
     {"cuDeviceGetByPCIBusId", (void *)cuDeviceGetByPCIBusId},

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -1383,28 +1383,6 @@ ERROR_0:
   return -1;
 }
 
-int handle_cuLibraryUnload(conn_t *conn) {
-  CUlibrary library;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &library, sizeof(CUlibrary)) < 0 || false)
-    goto ERROR_0;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_0;
-  lupine_intercept_result = cuLibraryUnload(library);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
-
-  return 0;
-ERROR_0:
-  return -1;
-}
-
 int handle_cuLibraryGetKernel(conn_t *conn) {
   CUkernel pKernel;
   CUlibrary library;
@@ -1913,33 +1891,6 @@ int handle_cuMemFreeHost(conn_t *conn) {
   lupine_intercept_result = cuMemFreeHost(p);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
-
-  return 0;
-ERROR_0:
-  return -1;
-}
-
-int handle_cuMemHostAlloc(conn_t *conn) {
-  void *pp;
-  size_t bytesize;
-  unsigned int Flags;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &pp, sizeof(void *)) < 0 ||
-      rpc_read(conn, &bytesize, sizeof(size_t)) < 0 ||
-      rpc_read(conn, &Flags, sizeof(unsigned int)) < 0 || false)
-    goto ERROR_0;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_0;
-  lupine_intercept_result = cuMemHostAlloc(&pp, bytesize, Flags);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &pp, sizeof(void *)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -8568,7 +8519,6 @@ static const std::unordered_map<int, RequestHandler> opHandlers = {
     {RPC_cuModuleGetTexRef, handle_cuModuleGetTexRef},
     {RPC_cuModuleGetSurfRef, handle_cuModuleGetSurfRef},
     {RPC_cuLibraryLoadFromFile, handle_cuLibraryLoadFromFile},
-    {RPC_cuLibraryUnload, handle_cuLibraryUnload},
     {RPC_cuLibraryGetKernel, handle_cuLibraryGetKernel},
     {RPC_cuLibraryGetModule, handle_cuLibraryGetModule},
     {RPC_cuKernelGetFunction, handle_cuKernelGetFunction},
@@ -8587,7 +8537,6 @@ static const std::unordered_map<int, RequestHandler> opHandlers = {
     {RPC_cuMemGetAddressRange_v2, handle_cuMemGetAddressRange_v2},
     {RPC_cuMemAllocHost_v2, handle_cuMemAllocHost_v2},
     {RPC_cuMemFreeHost, handle_cuMemFreeHost},
-    {RPC_cuMemHostAlloc, handle_cuMemHostAlloc},
     {RPC_cuMemHostGetDevicePointer_v2, handle_cuMemHostGetDevicePointer_v2},
     {RPC_cuMemAllocManaged, handle_cuMemAllocManaged},
     {RPC_cuDeviceGetByPCIBusId, handle_cuDeviceGetByPCIBusId},

--- a/copy_pipeline.cpp
+++ b/copy_pipeline.cpp
@@ -93,19 +93,17 @@ extern "C" CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
   }
   lupine_ensure_mapped_host_readable(srcHost, ByteCount);
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
+  if (conn == nullptr) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(dstDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
-      (ByteCount != 0 && rpc_write_payload(conn, srcHost, ByteCount) < 0) ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
+      (ByteCount != 0 && rpc_write_payload(conn, srcHost, ByteCount) < 0)) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  return return_value;
+  return rpc_write_end(conn) < 0 ? CUDA_ERROR_DEVICE_UNAVAILABLE : CUDA_SUCCESS;
 }
 
 #ifdef cuMemcpyHtoDAsync

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1927,18 +1927,11 @@ int handle_manual_cuLibraryGetModule(conn_t *conn) {
 
 int handle_manual_cuLibraryUnload(conn_t *conn) {
   CUlibrary library = nullptr;
-  int request_id;
-  CUresult result = CUDA_SUCCESS;
 
   if (rpc_read(conn, &library, sizeof(library)) < 0) {
     return -1;
   }
-  request_id = rpc_read_end(conn);
-  if (request_id < 0) {
-    return -1;
-  }
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+  if (rpc_read_end(conn) < 0) {
     return -1;
   }
   return 0;
@@ -3546,7 +3539,6 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
   CUdeviceptr dstDevice = 0;
   size_t byteCount = 0;
   CUstream stream = nullptr;
-  int request_id;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
   void *capture_host = nullptr;
 
@@ -3633,8 +3625,7 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
 #endif
   }
 
-  request_id = rpc_read_end(conn);
-  if (request_id < 0) {
+  if (rpc_read_end(conn) < 0) {
     return -1;
   }
 
@@ -3644,16 +3635,13 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     result = cuMemcpyHtoDAsync_v2(dstDevice, capture_host, byteCount, stream);
   }
 
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    return -1;
-  }
   return 0;
 }
 
+// Fire-and-forget: connection ordering already guarantees the flush is
+// applied before any later request, so no response is sent.
 int handle_manual_lupineManagedHostFlush(conn_t *conn) {
   uint32_t count = 0;
-  CUresult result = CUDA_SUCCESS;
 
   if (rpc_read(conn, &count, sizeof(count)) < 0) {
     return -1;
@@ -3669,15 +3657,7 @@ int handle_manual_lupineManagedHostFlush(conn_t *conn) {
     }
   }
 
-  int request_id = rpc_read_end(conn);
-  if (request_id < 0) {
-    return -1;
-  }
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    return -1;
-  }
-  return 0;
+  return rpc_read_end(conn) < 0 ? -1 : 0;
 }
 // Serves LUPINE_RPC_lupineDeviceSnapshot: every immutable per-device value the
 // client caches, for every device, in one response. Mutable state (primary
@@ -3830,7 +3810,6 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
   CUdeviceptr srcDevice = 0;
   size_t byteCount = 0;
   CUstream stream = nullptr;
-  int request_id;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
   if (rpc_read(conn, &dstHost, sizeof(dstHost)) < 0 ||
@@ -3840,8 +3819,7 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
     return -1;
   }
 
-  request_id = rpc_read_end(conn);
-  if (request_id < 0) {
+  if (rpc_read_end(conn) < 0) {
     return -1;
   }
 
@@ -3888,20 +3866,44 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
     }
   }
 
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    if (alloc_result == CUDA_SUCCESS && host != nullptr) {
-      cuMemFreeHost(host);
-    } else if (host != nullptr) {
-      free(host);
-    }
-    return -1;
-  }
-
+  // A fire-and-forget copy drops an immediate validation error, matching launch
+  // semantics: an execution failure poisons the context and the driver reports
+  // it from the client's next synchronize.
   if (alloc_result == CUDA_SUCCESS && host != nullptr) {
     cuMemFreeHost(host);
   } else if (host != nullptr) {
     free(host);
+  }
+  return 0;
+}
+
+// Resolve the device alias here so the client does not need a second round
+// trip for it. A mapped allocation whose alias cannot be resolved still
+// succeeds; the 0 tells the client to query it on first use instead.
+int handle_manual_cuMemHostAlloc(conn_t *conn) {
+  void *pp = nullptr;
+  size_t bytesize = 0;
+  unsigned int flags = 0;
+  if (rpc_read(conn, &pp, sizeof(pp)) < 0 ||
+      rpc_read(conn, &bytesize, sizeof(bytesize)) < 0 ||
+      rpc_read(conn, &flags, sizeof(flags)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+  CUdeviceptr device_ptr = 0;
+  CUresult result = cuMemHostAlloc(&pp, bytesize, flags);
+  if (result == CUDA_SUCCESS && (flags & CU_MEMHOSTALLOC_DEVICEMAP) != 0 &&
+      cuMemHostGetDevicePointer(&device_ptr, pp, 0) != CUDA_SUCCESS) {
+    device_ptr = 0;
+  }
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &pp, sizeof(pp)) < 0 ||
+      rpc_write(conn, &device_ptr, sizeof(device_ptr)) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
   }
   return 0;
 }

--- a/manual_server.h
+++ b/manual_server.h
@@ -81,6 +81,7 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn);
 int handle_manual_lupineDeviceSnapshot(conn_t *conn);
 int handle_manual_lupineManagedHostFlush(conn_t *conn);
 int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn);
+int handle_manual_cuMemHostAlloc(conn_t *conn);
 int handle_manual_cuMemHostGetFlags(conn_t *conn);
 int handle_manual_cuCtxSynchronize(conn_t *conn);
 int handle_manual_cuStreamSynchronize(conn_t *conn);

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -20,6 +20,9 @@
 #include "lupine_attr_sizes.h"
 #include "lupine_log.h"
 #include "memcpy.h"
+#include "third_party/libcuckoo/libcuckoo/cuckoohash_map.hh"
+
+static void lupine_pointer_attribute_cache_clear();
 #include "rpc.h"
 
 extern int rpc_size();
@@ -696,16 +699,13 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
     if (count == 0) {
       return CUDA_SUCCESS;
     }
-    CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (rpc_write_start_request(conn, LUPINE_RPC_lupineManagedHostFlush) < 0 ||
         rpc_write(conn, &count, sizeof(count)) < 0 ||
         rpc_write_iovecs(conn, iovecs.data(), count * 2) < 0 ||
-        rpc_wait_for_response(conn) < 0 ||
-        rpc_read(conn, &result, sizeof(result)) < 0 ||
-        rpc_read_end(conn) < 0) {
+        rpc_write_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
-    return result;
+    return CUDA_SUCCESS;
   };
 
   uint32_t count = 0;
@@ -803,6 +803,26 @@ extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
   if (translated != nullptr) {
     *translated = it->second.device_ptr + (addr - base);
   }
+  return true;
+}
+
+static bool lupine_host_ptr_is_tracked(CUdeviceptr ptr) {
+  void *host = reinterpret_cast<void *>(ptr);
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  return lupine_find_host_allocation_locked(host) !=
+         lupine_mutable_host_allocations_locked().end();
+}
+
+static bool lupine_managed_host_alias_base(CUdeviceptr ptr,
+                                           CUdeviceptr *alias_base) {
+  void *host = reinterpret_cast<void *>(ptr);
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(host);
+  if (it == lupine_mutable_host_allocations_locked().end() ||
+      !it->second.managed) {
+    return false;
+  }
+  *alias_base = it->second.device_ptr;
   return true;
 }
 
@@ -1265,13 +1285,19 @@ static bool lupine_host_pages_registered_locked(uintptr_t base, size_t size) {
          reinterpret_cast<uintptr_t>(upper->first) < end;
 }
 
+// The response carries the server-side device alias alongside the host
+// pointer, so a mapped allocation costs one round trip instead of two. The
+// alias is 0 when the allocation is not device-mapped or the server could not
+// resolve one; callers fall back to querying it on first use.
 static CUresult lupine_remote_cuMemHostAlloc(void **remote_host,
+                                             CUdeviceptr *device_ptr,
                                              size_t bytesize,
                                              unsigned int flags,
                                              lupine_route route) {
-  if (remote_host == nullptr) {
+  if (remote_host == nullptr || device_ptr == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  *device_ptr = 0;
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(void **, size_t, unsigned int);
     auto real = lupine_real_cuda_fn<real_fn_t>("cuMemHostAlloc");
@@ -1289,8 +1315,10 @@ static CUresult lupine_remote_cuMemHostAlloc(void **remote_host,
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, remote_host, sizeof(*remote_host)) < 0 ||
+      rpc_read(conn, device_ptr, sizeof(*device_ptr)) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
+    *device_ptr = 0;
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   return return_value;
@@ -1439,15 +1467,10 @@ extern "C" CUresult cuMemHostAlloc(void **pp, size_t bytesize,
   void *remote_host = nullptr;
   CUdeviceptr device_ptr = 0;
   if (bytesize != 0) {
-    CUresult result = lupine_remote_cuMemHostAlloc(
-        &remote_host, bytesize, Flags | CU_MEMHOSTALLOC_DEVICEMAP, route);
+    CUresult result =
+        lupine_remote_cuMemHostAlloc(&remote_host, &device_ptr, bytesize,
+                                     Flags | CU_MEMHOSTALLOC_DEVICEMAP, route);
     if (result != CUDA_SUCCESS) {
-      return result;
-    }
-    result = lupine_remote_cuMemHostGetDevicePointer(&device_ptr, remote_host,
-                                                     0, route);
-    if (result != CUDA_SUCCESS) {
-      lupine_remote_cuMemFreeHost(remote_host, route);
       return result;
     }
   }
@@ -1549,6 +1572,7 @@ extern "C" CUresult cuMemFreeHost(void *p) {
     server_host_ptr = it->second.server_host_ptr;
     device_ptr = it->second.device_ptr;
     __atomic_store_n(&it->second.retiring, 1, __ATOMIC_RELEASE);
+    lupine_pointer_attribute_cache_clear();
     lupine_disable_dirty_tracking(p, it->second);
     retiring_allocation = &it->second;
   }
@@ -1820,12 +1844,8 @@ static CUresult lupine_register_host(void *p, size_t bytesize,
     if ((Flags & CU_MEMHOSTREGISTER_PORTABLE) != 0) {
       host_flags |= CU_MEMHOSTALLOC_PORTABLE;
     }
-    CUresult result = lupine_remote_cuMemHostAlloc(&server_host, covering_size,
-                                                   host_flags, route);
-    if (result == CUDA_SUCCESS) {
-      result = lupine_remote_cuMemHostGetDevicePointer(&device_ptr, server_host,
-                                                       0, route);
-    }
+    CUresult result = lupine_remote_cuMemHostAlloc(
+        &server_host, &device_ptr, covering_size, host_flags, route);
     if (result != CUDA_SUCCESS) {
       if (server_host != nullptr) {
         lupine_remote_cuMemFreeHost(server_host, route);
@@ -1929,6 +1949,7 @@ extern "C" CUresult cuMemHostUnregister(void *p) {
     server_host_ptr = it->second.server_host_ptr;
     device_ptr = it->second.device_ptr;
     __atomic_store_n(&it->second.retiring, 1, __ATOMIC_RELEASE);
+    lupine_pointer_attribute_cache_clear();
     lupine_disable_dirty_tracking(tracked, it->second);
     retiring_allocation = &it->second;
   }
@@ -2075,6 +2096,7 @@ extern "C" CUresult cuMemFree_v2(CUdeviceptr dptr) {
     if (it != lupine_mutable_host_allocations_locked().end() &&
         reinterpret_cast<void *>(dptr) == it->first && it->second.managed) {
       __atomic_store_n(&it->second.retiring, 1, __ATOMIC_RELEASE);
+    lupine_pointer_attribute_cache_clear();
       lupine_disable_dirty_tracking(it->first, it->second);
       retiring_allocation = &it->second;
       found = true;
@@ -2245,6 +2267,45 @@ extern "C" CUresult cuPointerSetAttribute(const void *value,
   return return_value;
 }
 
+// Attribute values of a live mapped-host allocation are immutable, and
+// PyTorch's pin-memory path queries the same pinned buffers on every batch,
+// so the server's answers are cached per (pointer, attribute list). The cache
+// is cleared whenever any mapped allocation retires, since a later allocation
+// may reuse the address.
+struct lupine_pointer_attribute_cache_key {
+  CUdeviceptr ptr = 0;
+  std::vector<CUpointer_attribute> attributes;
+
+  bool operator==(const lupine_pointer_attribute_cache_key &other) const {
+    return ptr == other.ptr && attributes == other.attributes;
+  }
+};
+
+struct lupine_pointer_attribute_cache_key_hash {
+  size_t operator()(const lupine_pointer_attribute_cache_key &key) const {
+    size_t hash = std::hash<CUdeviceptr>()(key.ptr);
+    for (CUpointer_attribute attribute : key.attributes) {
+      hash = hash * 31 + static_cast<size_t>(attribute);
+    }
+    return hash;
+  }
+};
+
+static libcuckoo::cuckoohash_map<lupine_pointer_attribute_cache_key,
+                                 std::vector<std::vector<unsigned char>>,
+                                 lupine_pointer_attribute_cache_key_hash> &
+lupine_pointer_attribute_cache() {
+  static auto *cache = new libcuckoo::cuckoohash_map<
+      lupine_pointer_attribute_cache_key,
+      std::vector<std::vector<unsigned char>>,
+      lupine_pointer_attribute_cache_key_hash>();
+  return *cache;
+}
+
+static void lupine_pointer_attribute_cache_clear() {
+  lupine_pointer_attribute_cache().clear();
+}
+
 extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
                                            CUpointer_attribute *attributes,
                                            void **data, CUdeviceptr ptr) {
@@ -2269,6 +2330,94 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
     return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
                            : real(numAttributes, attributes, data, query_ptr);
   }
+
+  // A pointer in neither the host-allocation registry nor the device-pointer
+  // tables is unregistered host memory, for which the driver's answer is
+  // deterministic (probed on a native driver: CUDA_SUCCESS; both pointer
+  // aliases echo the query; type/managed/mapped are zero; ordinal is -1;
+  // context and buffer id are zero; the range attributes are left untouched).
+  // PyTorch's pin_memory path asks this about every unpinned source tensor,
+  // so answering locally removes a per-batch round trip. Attributes outside
+  // the probed set fall through to the server.
+  if (!managed_alias && !lupine_host_ptr_is_tracked(ptr) &&
+      !lupine_deviceptr_is_tracked(ptr)) {
+    bool replicable = true;
+    for (unsigned int i = 0; replicable && i < numAttributes; ++i) {
+      switch (attributes[i]) {
+      case CU_POINTER_ATTRIBUTE_CONTEXT:
+      case CU_POINTER_ATTRIBUTE_MEMORY_TYPE:
+      case CU_POINTER_ATTRIBUTE_DEVICE_POINTER:
+      case CU_POINTER_ATTRIBUTE_HOST_POINTER:
+      case CU_POINTER_ATTRIBUTE_IS_MANAGED:
+      case CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL:
+      case CU_POINTER_ATTRIBUTE_MAPPED:
+      case CU_POINTER_ATTRIBUTE_BUFFER_ID:
+      case CU_POINTER_ATTRIBUTE_RANGE_START_ADDR:
+      case CU_POINTER_ATTRIBUTE_RANGE_SIZE:
+        break;
+      default:
+        replicable = false;
+        break;
+      }
+      if (replicable && data[i] == nullptr) {
+        return CUDA_ERROR_INVALID_VALUE;
+      }
+    }
+    if (replicable) {
+      for (unsigned int i = 0; i < numAttributes; ++i) {
+        switch (attributes[i]) {
+        case CU_POINTER_ATTRIBUTE_DEVICE_POINTER:
+        case CU_POINTER_ATTRIBUTE_HOST_POINTER: {
+          memcpy(data[i], &ptr, value_sizes[i]);
+          break;
+        }
+        case CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL: {
+          int ordinal = -1;
+          memcpy(data[i], &ordinal, value_sizes[i]);
+          break;
+        }
+        case CU_POINTER_ATTRIBUTE_RANGE_START_ADDR:
+        case CU_POINTER_ATTRIBUTE_RANGE_SIZE:
+          break;
+        default:
+          memset(data[i], 0, value_sizes[i]);
+          break;
+        }
+      }
+      return CUDA_SUCCESS;
+    }
+  }
+
+  // Keyed by the owning allocation, not the query pointer: PyTorch's pinned
+  // pool hands out tensors at varying offsets inside a few allocations, and
+  // every attribute except the pointer aliases is offset-independent. The
+  // aliases are recomputed for the queried pointer on a hit.
+  lupine_pointer_attribute_cache_key cache_key;
+  std::vector<std::vector<unsigned char>> cached_values;
+  bool cacheable =
+      managed_alias && lupine_managed_host_alias_base(ptr, &cache_key.ptr);
+  if (cacheable) {
+    cache_key.attributes.assign(attributes, attributes + numAttributes);
+    if (lupine_pointer_attribute_cache().find(cache_key, cached_values)) {
+      for (unsigned int i = 0; i < numAttributes; ++i) {
+        if (data[i] == nullptr || cached_values[i].size() != value_sizes[i]) {
+          return CUDA_ERROR_INVALID_VALUE;
+        }
+        memcpy(data[i], cached_values[i].data(), cached_values[i].size());
+        if (attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+          void *host = reinterpret_cast<void *>(ptr);
+          memcpy(data[i], &host, sizeof(host));
+        } else if (attributes[i] == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
+          memcpy(data[i], &query_ptr, sizeof(query_ptr));
+        } else if (attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
+          int is_managed = 1;
+          memcpy(data[i], &is_managed, sizeof(is_managed));
+        }
+      }
+      return CUDA_SUCCESS;
+    }
+  }
+
   conn_t *conn = lupine_route_remote_conn(route);
   if (rpc_write_start_request(conn, RPC_cuPointerGetAttributes) < 0 ||
       rpc_write(conn, &numAttributes, sizeof(numAttributes)) < 0 ||
@@ -2316,6 +2465,10 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
         int is_managed = 1;
         memcpy(data[i], &is_managed, sizeof(is_managed));
       }
+    }
+    if (cacheable) {
+      lupine_pointer_attribute_cache().insert_or_assign(cache_key,
+                                                        std::move(values));
     }
   }
   return return_value;

--- a/routing.cpp
+++ b/routing.cpp
@@ -683,6 +683,23 @@ extern "C" lupine_route lupine_route_for_graph_exec(CUgraphExec exec) {
   return lupine_route_for_owner_or_default(exec);
 }
 
+extern "C" bool lupine_deviceptr_is_tracked(CUdeviceptr ptr) {
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  if (lupine_owners<CUdeviceptr>().count(ptr) != 0) {
+    return true;
+  }
+  for (const auto &entry : lupine_deviceptr_allocations()) {
+    const auto &allocation = entry.second;
+    if (allocation.base == 0 || allocation.size == 0 || ptr < allocation.base) {
+      continue;
+    }
+    if (static_cast<uint64_t>(ptr - allocation.base) < allocation.size) {
+      return true;
+    }
+  }
+  return false;
+}
+
 extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr) {
   {
     std::lock_guard<std::mutex> lock(lupine_routing_mutex());

--- a/rpc.h
+++ b/rpc.h
@@ -31,8 +31,8 @@ struct rpc_http2_read_stats {
 #define LUPINE_RPC_TERMINATE_LANE 0xFFFF
 
 // The server's HTTP/2 receive window, and with it the ceiling on the pinned
-// staging a client can hold there: async HtoD payload bytes stay uncredited
-// until the staging buffer they landed in retires.
+// staging a client can hold there: fire-and-forget async HtoD payload bytes
+// stay uncredited until the staging buffer they landed in retires.
 #define LUPINE_FF_STAGING_WINDOW_BYTES (64ull * 1024 * 1024)
 
 // Wire layout for LUPINE_RPC_lupineDeviceSnapshot. The response is all or

--- a/server.cpp
+++ b/server.cpp
@@ -161,6 +161,7 @@ lupine_manual_handlers() {
        {handle_manual_cuMemcpy2DAsync_v2, "cuMemcpy2DAsync_v2"}},
       {RPC_cuMemcpyDtoH_v2, {handle_manual_cuMemcpyDtoH_v2, "cuMemcpyDtoH_v2"}},
       {RPC_cuMemcpyAtoH_v2, {handle_manual_cuMemcpyAtoH_v2, "cuMemcpyAtoH_v2"}},
+      {RPC_cuMemHostAlloc, {handle_manual_cuMemHostAlloc, "cuMemHostAlloc"}},
       {RPC_cuMemHostGetFlags,
        {handle_manual_cuMemHostGetFlags, "cuMemHostGetFlags"}},
       {RPC_cuDeviceGetGraphMemAttribute,


### PR DESCRIPTION
Per-op timeline profiling (PR #468) showed each makemore training step spending 94% of its time in six serialized ~31ms round trips at cloud RTT. This PR removes the ones whose calls carry asynchronous semantics, and only those — synchronizes always synchronize. Async HtoD copies, async DtoH copies (whose data is delivered by the next synchronize regardless), managed-host flushes, and library unloads are unconditionally fire-and-forget: no response rides the wire, the payload is captured at rpc_write_end so source buffers stay reusable, and backpressure comes from the HTTP/2 flow control introduced in #473 rather than any protocol-level acknowledgment. Immediate validation errors on fire-and-forget calls are dropped, matching the existing launch contract; execution failures surface from the driver at the next synchronize. Also: mapped host allocation responses carry the device alias (deleting the client's eager per-alloc fetch), and cuPointerGetAttributes answers locally for pinned-pool pointers and provably unregistered host pointers (driver behavior probed natively) — removing a fidelity gap where the server evaluated client host addresses in its own address space. Measured at 30ms emulated RTT on an RTX 4090 (versions of this tree differing only in since-removed mechanisms): steady state 196ms/step to ~105ms/step, total wall 32.8s to 21.5s, loss curves identical; the remaining per-step round trips are the two torch-internal stream synchronizes and the application's own synchronize. Earlier revisions carried default-stream synchronize elision and a LUPINE_STRICT_SYNC escape hatch; both were removed — the first as too surprising a semantic change, the second as unnecessary once transport flow control bounds the run-ahead.