### PR TITLE
Drop remaining teardown, DtoH, and mapped-alloc round trips

### DIFF
--- a/async.cpp
+++ b/async.cpp
@@ -5,30 +5,6 @@
 
 #include "third_party/libcuckoo/libcuckoo/cuckoohash_map.hh"
 
-void lupine_async_note_pending_dtoh(lupine_conn_async_state *state) {
-  if (state != nullptr) {
-    state->pending_dtoh.fetch_add(1, std::memory_order_acq_rel);
-  }
-}
-
-void lupine_async_note_dtoh_delivered(lupine_conn_async_state *state,
-                                      long count) {
-  if (state == nullptr || count <= 0) {
-    return;
-  }
-  long previous =
-      state->pending_dtoh.fetch_sub(count, std::memory_order_acq_rel);
-  if (previous < count) {
-    state->pending_dtoh.store(0, std::memory_order_release);
-  }
-}
-
-void lupine_async_disable_elision(lupine_conn_async_state *state) {
-  if (state != nullptr) {
-    state->elision_disabled.store(true, std::memory_order_release);
-  }
-}
-
 // Returns true when a fire-and-forget copy of `bytes` should instead request
 // a response: large copies, or the unacknowledged window filling up, so the
 // server's staging cannot grow unboundedly.
@@ -46,23 +22,6 @@ void lupine_async_ff_acknowledged(lupine_conn_async_state *state) {
   if (state != nullptr) {
     state->ff_outstanding_bytes.store(0, std::memory_order_release);
   }
-}
-
-// Only the default-stream sentinels are elidable: a synchronous fetch of
-// mapped memory is ordered after legacy-stream work, so elision stays
-// coherent there; named streams keep the full round trip.
-bool lupine_async_can_elide_sync(lupine_conn_async_state *state,
-                                 CUstream hStream, bool strict) {
-  if (strict || state == nullptr) {
-    return false;
-  }
-  if (hStream != nullptr &&
-      hStream != reinterpret_cast<CUstream>(uintptr_t{1}) &&
-      hStream != reinterpret_cast<CUstream>(uintptr_t{2})) {
-    return false;
-  }
-  return !state->elision_disabled.load(std::memory_order_acquire) &&
-         state->pending_dtoh.load(std::memory_order_acquire) == 0;
 }
 
 static bool lupine_async_strict() {
@@ -92,18 +51,6 @@ static lupine_conn_async_state *lupine_conn_async_state_for(conn_t *conn) {
   return state.get();
 }
 
-extern "C" void lupine_note_pending_dtoh(conn_t *conn) {
-  lupine_async_note_pending_dtoh(lupine_conn_async_state_for(conn));
-}
-
-extern "C" void lupine_note_dtoh_delivered(conn_t *conn, long count) {
-  lupine_async_note_dtoh_delivered(lupine_conn_async_state_for(conn), count);
-}
-
-extern "C" void lupine_disable_sync_elision(conn_t *conn) {
-  lupine_async_disable_elision(lupine_conn_async_state_for(conn));
-}
-
 extern "C" int lupine_ff_htod_wants_response(conn_t *conn, size_t bytes) {
   return lupine_async_ff_wants_response(lupine_conn_async_state_for(conn),
                                         bytes, lupine_async_strict())
@@ -113,9 +60,4 @@ extern "C" int lupine_ff_htod_wants_response(conn_t *conn, size_t bytes) {
 
 extern "C" void lupine_ff_htod_acknowledged(conn_t *conn) {
   lupine_async_ff_acknowledged(lupine_conn_async_state_for(conn));
-}
-
-extern "C" bool lupine_can_elide_stream_sync(conn_t *conn, CUstream hStream) {
-  return lupine_async_can_elide_sync(lupine_conn_async_state_for(conn),
-                                     hStream, lupine_async_strict());
 }

--- a/async.h
+++ b/async.h
@@ -1,10 +1,10 @@
 #ifndef LUPINE_ASYNC_H
 #define LUPINE_ASYNC_H
 
-// Client-side latency-hiding state for fire-and-forget submissions and
-// synchronize elision. The lupine_async_* functions operate on a bare state
-// record so the policy is unit-testable without a connection; the lupine_*
-// wrappers key the same logic by conn_t for the client wrappers.
+// Client-side latency-hiding state for fire-and-forget submissions. The
+// lupine_async_* functions operate on a bare state record so the policy is
+// unit-testable without a connection; the lupine_* wrappers key the same logic
+// by conn_t for the client wrappers.
 
 #include <atomic>
 #include <cstddef>
@@ -12,34 +12,17 @@
 #include "cuda_compat.h"
 #include "rpc.h"
 
-// pending_dtoh counts async DtoH copies whose data the server delivers with a
-// later synchronize response; while any are outstanding a stream synchronize
-// must go to the server. elision_disabled is set permanently once the
-// application uses graph execs or host callbacks, whose host-visible effects
-// are delivered at synchronization points the client cannot account for.
 // ff_outstanding_bytes bounds how far fire-and-forget host-to-device copies
 // may run ahead of the server before one copy requests a response again.
 struct lupine_conn_async_state {
-  std::atomic<long> pending_dtoh{0};
-  std::atomic<bool> elision_disabled{false};
   std::atomic<unsigned long long> ff_outstanding_bytes{0};
 };
 
-void lupine_async_note_pending_dtoh(lupine_conn_async_state *state);
-void lupine_async_note_dtoh_delivered(lupine_conn_async_state *state,
-                                      long count);
-void lupine_async_disable_elision(lupine_conn_async_state *state);
 bool lupine_async_ff_wants_response(lupine_conn_async_state *state,
                                     size_t bytes, bool strict);
 void lupine_async_ff_acknowledged(lupine_conn_async_state *state);
-bool lupine_async_can_elide_sync(lupine_conn_async_state *state,
-                                 CUstream hStream, bool strict);
 
-extern "C" void lupine_note_pending_dtoh(conn_t *conn);
-extern "C" void lupine_note_dtoh_delivered(conn_t *conn, long count);
-extern "C" void lupine_disable_sync_elision(conn_t *conn);
 extern "C" int lupine_ff_htod_wants_response(conn_t *conn, size_t bytes);
 extern "C" void lupine_ff_htod_acknowledged(conn_t *conn);
-extern "C" bool lupine_can_elide_stream_sync(conn_t *conn, CUstream hStream);
 
 #endif

--- a/async_test.cpp
+++ b/async_test.cpp
@@ -3,10 +3,6 @@
 #include <cassert>
 #include <iostream>
 
-static CUstream stream_sentinel(uintptr_t value) {
-  return reinterpret_cast<CUstream>(value);
-}
-
 static void test_ff_window() {
   lupine_conn_async_state state;
   // Strict mode always wants a response.
@@ -29,42 +25,8 @@ static void test_ff_window() {
   assert(lupine_async_ff_wants_response(nullptr, 16, false));
 }
 
-static void test_pending_dtoh() {
-  lupine_conn_async_state state;
-  assert(lupine_async_can_elide_sync(&state, nullptr, false));
-  lupine_async_note_pending_dtoh(&state);
-  lupine_async_note_pending_dtoh(&state);
-  assert(!lupine_async_can_elide_sync(&state, nullptr, false));
-  lupine_async_note_dtoh_delivered(&state, 1);
-  assert(!lupine_async_can_elide_sync(&state, nullptr, false));
-  lupine_async_note_dtoh_delivered(&state, 1);
-  assert(lupine_async_can_elide_sync(&state, nullptr, false));
-  // Over-delivery (e.g. graph copies in the same response) floors at zero.
-  lupine_async_note_dtoh_delivered(&state, 5);
-  assert(lupine_async_can_elide_sync(&state, nullptr, false));
-  lupine_async_note_pending_dtoh(&state);
-  assert(!lupine_async_can_elide_sync(&state, nullptr, false));
-}
-
-static void test_elision_gates() {
-  lupine_conn_async_state state;
-  // Default-stream sentinels are elidable; named streams are not.
-  assert(lupine_async_can_elide_sync(&state, nullptr, false));
-  assert(lupine_async_can_elide_sync(&state, stream_sentinel(1), false));
-  assert(lupine_async_can_elide_sync(&state, stream_sentinel(2), false));
-  assert(!lupine_async_can_elide_sync(&state, stream_sentinel(0x7f00), false));
-  // Strict mode and a null state disable elision.
-  assert(!lupine_async_can_elide_sync(&state, nullptr, true));
-  assert(!lupine_async_can_elide_sync(nullptr, nullptr, false));
-  // Host callbacks / graph execs disable elision permanently.
-  lupine_async_disable_elision(&state);
-  assert(!lupine_async_can_elide_sync(&state, nullptr, false));
-}
-
 int main() {
   test_ff_window();
-  test_pending_dtoh();
-  test_elision_gates();
   std::cout << "PASS: async latency-hiding state" << std::endl;
   return 0;
 }

--- a/client.cpp
+++ b/client.cpp
@@ -4927,9 +4927,6 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
   static const bool strict_sync = lupine_env_enabled("LUPINE_STRICT_SYNC");
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
-  // The copied bytes never ride on this response: the server stages them and
-  // hands them back with the next synchronize. Waiting here only buys the
-  // submission status, so drop the round trip unless the caller asked for it.
   const unsigned char wants_response = strict_sync ? 1 : 0;
   CUresult return_value;
   if (conn == nullptr ||

--- a/client.cpp
+++ b/client.cpp
@@ -930,6 +930,55 @@ extern "C" CUresult lupine_record_library_kernel(CUkernel kernel,
                                                  const char *name,
                                                  lupine_route route);
 
+extern "C" void lupine_invalidate_function_caches();
+
+// Set LUPINE_STRICT_SYNC to make normally fire-and-forget teardown calls block
+// for their server response.
+static bool lupine_strict_sync_enabled() {
+  static const bool enabled = getenv("LUPINE_STRICT_SYNC") != nullptr;
+  return enabled;
+}
+
+extern "C" CUresult cuLibraryUnload(CUlibrary library) {
+  lupine_route route = lupine_route_for_library(library);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUlibrary);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryUnload",
+                                                  &return_value, library)) {
+    if (return_value == CUDA_SUCCESS) {
+      lupine_invalidate_function_caches();
+    }
+    return return_value;
+  }
+  // Unloads only release server-side resources the connection reclaims anyway,
+  // so they go out fire-and-forget: at teardown a program can issue dozens of
+  // them and each blocking round trip is pure latency.
+  const unsigned char wants_response = lupine_strict_sync_enabled() ? 1 : 0;
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
+      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
+      rpc_write(conn, &wants_response, sizeof(wants_response)) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (wants_response == 0) {
+    if (rpc_write_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    lupine_invalidate_function_caches();
+    return CUDA_SUCCESS;
+  }
+  if (rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_invalidate_function_caches();
+  }
+  return return_value;
+}
+
 extern "C" CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
                                        const char *name) {
   if (pKernel == nullptr || name == nullptr) {
@@ -8536,6 +8585,7 @@ lupine_manual_function_map() {
       {"cuModuleLoadData", (void *)cuModuleLoadData},
       {"cuModuleLoadDataEx", (void *)cuModuleLoadDataEx},
       {"cuLibraryLoadData", (void *)cuLibraryLoadData},
+      {"cuLibraryUnload", (void *)cuLibraryUnload},
       {"cuLinkCreate", (void *)cuLinkCreate_v2},
       {"cuLinkAddData", (void *)cuLinkAddData_v2},
       {"cuLinkAddFile", (void *)cuLinkAddFile_v2},

--- a/client.cpp
+++ b/client.cpp
@@ -4926,7 +4926,12 @@ extern "C" CUresult cuMemcpyAtoH(void *dstHost, CUarray srcArray,
 
 extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
+  static const bool strict_sync = lupine_env_enabled("LUPINE_STRICT_SYNC");
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
+  // The copied bytes never ride on this response: the server stages them and
+  // hands them back with the next synchronize. Waiting here only buys the
+  // submission status, so drop the round trip unless the caller asked for it.
+  const unsigned char wants_response = strict_sync ? 1 : 0;
   CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
@@ -4934,10 +4939,23 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
-      rpc_wait_for_response(conn) < 0) {
+      rpc_write(conn, &wants_response, sizeof(wants_response)) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+  if (wants_response == 0) {
+    if (rpc_write_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    // The deferred copy is only delivered by a remote synchronize; the
+    // pending count is what keeps the next stream synchronize from being
+    // elided before the data arrives.
+    if (ByteCount != 0) {
+      lupine_note_pending_dtoh(conn);
+    }
+    return CUDA_SUCCESS;
+  }
+  if (rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }

--- a/client.cpp
+++ b/client.cpp
@@ -49,7 +49,6 @@
 
 #include "cache.h"
 #include "checkpoint.h"
-#include "async.h"
 #include "client_routing.h"
 #include "codegen/gen_api.h"
 #include "codegen/gen_client.h"
@@ -3867,7 +3866,6 @@ extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn) {
   if (rpc_read(conn, &copy_count, sizeof(copy_count)) < 0) {
     return -1;
   }
-  lupine_note_dtoh_delivered(conn, static_cast<long>(copy_count));
   for (uint32_t i = 0; i < copy_count; ++i) {
     void *dst = nullptr;
     size_t bytes = 0;
@@ -3886,54 +3884,6 @@ extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn) {
     lupine_mark_host_range_clean(dst, bytes);
   }
   return 0;
-}
-
-extern "C" CUresult cuStreamSynchronize(CUstream hStream) {
-  CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
-  if (flush_result != CUDA_SUCCESS) {
-    return flush_result;
-  }
-  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
-                                           : lupine_route_for_default());
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUstream);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamSynchronize",
-                                                  &return_value, hStream)) {
-    if (return_value == CUDA_SUCCESS) {
-      return_value = lupine_sync_mapped_device_to_host();
-    }
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  // A default-stream synchronize with nothing host-observable outstanding
-  // completes locally: fire-and-forget submissions were already captured on
-  // the wire, later requests are connection-ordered behind them, and any
-  // asynchronous error surfaces at the next synchronize that does go remote.
-  if (lupine_can_elide_stream_sync(conn, hStream)) {
-    return lupine_sync_mapped_device_to_host();
-  }
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamSynchronize) < 0 ||
-      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      lupine_read_deferred_dtoh_copies(conn) < 0 ||
-      lupine_forward_remote_stdout(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  lupine_ff_htod_acknowledged(conn);
-  if (return_value == CUDA_SUCCESS) {
-    return_value = lupine_sync_mapped_device_to_host();
-  }
-  return return_value;
-}
-
-#ifdef cuStreamSynchronize_ptsz
-#undef cuStreamSynchronize_ptsz
-#endif
-extern "C" CUresult cuStreamSynchronize_ptsz(CUstream hStream) {
-  return cuStreamSynchronize(hStream);
 }
 
 extern "C" CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
@@ -4995,21 +4945,12 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
     if (rpc_write_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
-    // The deferred copy is only delivered by a remote synchronize; the
-    // pending count is what keeps the next stream synchronize from being
-    // elided before the data arrives.
-    if (ByteCount != 0) {
-      lupine_note_pending_dtoh(conn);
-    }
     return CUDA_SUCCESS;
   }
   if (rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (return_value == CUDA_SUCCESS && ByteCount != 0) {
-    lupine_note_pending_dtoh(conn);
   }
   return return_value;
 }
@@ -6539,7 +6480,6 @@ extern "C" CUresult cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
     return local_result;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  lupine_disable_sync_elision(conn);
   CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLaunchHostFunc) < 0 ||
@@ -6571,7 +6511,6 @@ extern "C" CUresult cuStreamAddCallback(CUstream hStream,
     return local_result;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  lupine_disable_sync_elision(conn);
   CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamAddCallback) < 0 ||

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -3482,7 +3482,6 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
  */
 CUresult cuStreamQuery(CUstream hStream);
 /**
- * @disabled client - manual client elides default-stream synchronizes
  * @disabled server
  * @synchronize DEFERRED_DTOH STDOUT
  * @routingkey STREAM hStream

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2615,6 +2615,7 @@ CUresult cuMemAllocHost_v2(void **pp, size_t bytesize);
 CUresult cuMemFreeHost(void *p);
 /**
  * @disabled client - manual client substitutes a local faulting address
+ * @disabled server - manual server returns the mapped device alias
  * @param pp SEND_RECV
  * @param bytesize SEND_ONLY
  * @param Flags SEND_ONLY

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2458,6 +2458,8 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
                                void **libraryOptionValues,
                                unsigned int numLibraryOptions);
 /**
+ * @disabled client - manual client sends fire-and-forget unloads
+ * @disabled server - manual server supports fire-and-forget unloads
  * @routingkey LIBRARY library
  * @param library SEND_ONLY
  */

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -7212,7 +7212,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemGetAddressRange_v2", (void *)cuMemGetAddressRange_v2},
     {"cuMemAllocHost_v2", (void *)cuMemAllocHost_v2},
     {"cuMemFreeHost", (void *)cuMemFreeHost},
-    {"cuMemHostAlloc", (void *)cuMemHostAlloc},
     {"cuMemHostGetDevicePointer_v2", (void *)cuMemHostGetDevicePointer_v2},
     {"cuMemAllocManaged", (void *)cuMemAllocManaged},
     {"cuDeviceGetByPCIBusId", (void *)cuDeviceGetByPCIBusId},

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -2991,6 +2991,36 @@ CUresult cuStreamQuery(CUstream hStream) {
   return return_value;
 }
 
+CUresult cuStreamSynchronize(CUstream hStream) {
+  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
+  if (lupine_sync_result != CUDA_SUCCESS) {
+    return lupine_sync_result;
+  }
+  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
+                                           : lupine_route_for_default());
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamSynchronize",
+                                                  &return_value, hStream)) {
+    if (return_value == CUDA_SUCCESS)
+      return_value = lupine_sync_mapped_device_to_host();
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuStreamSynchronize) < 0 ||
+      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      lupine_read_deferred_dtoh_copies(conn) < 0 ||
+      lupine_forward_remote_stdout(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    return_value = lupine_sync_mapped_device_to_host();
+  return return_value;
+}
+
 CUresult cuStreamDestroy_v2(CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
@@ -7000,6 +7030,13 @@ extern "C" CUresult cuStreamQuery_ptsz(CUstream hStream) {
   return cuStreamQuery(hStream);
 }
 
+#ifdef cuStreamSynchronize_ptsz
+#undef cuStreamSynchronize_ptsz
+#endif
+extern "C" CUresult cuStreamSynchronize_ptsz(CUstream hStream) {
+  return cuStreamSynchronize(hStream);
+}
+
 #ifdef cuEventRecord_ptsz
 #undef cuEventRecord_ptsz
 #endif
@@ -7294,6 +7331,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuStreamIsCapturing", (void *)cuStreamIsCapturing},
     {"cuStreamAttachMemAsync", (void *)cuStreamAttachMemAsync},
     {"cuStreamQuery", (void *)cuStreamQuery},
+    {"cuStreamSynchronize", (void *)cuStreamSynchronize},
     {"cuStreamDestroy_v2", (void *)cuStreamDestroy_v2},
     {"cuStreamCopyAttributes", (void *)cuStreamCopyAttributes},
     {"cuStreamGetAttribute", (void *)cuStreamGetAttribute},
@@ -7501,6 +7539,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuStreamGetCtx_ptsz", (void *)cuStreamGetCtx},
     {"cuStreamAttachMemAsync_ptsz", (void *)cuStreamAttachMemAsync},
     {"cuStreamQuery_ptsz", (void *)cuStreamQuery},
+    {"cuStreamSynchronize_ptsz", (void *)cuStreamSynchronize},
     {"cuEventRecord_ptsz", (void *)cuEventRecord},
     {"cuEventRecordWithFlags_ptsz", (void *)cuEventRecordWithFlags},
     {"cuGraphicsMapResources_ptsz", (void *)cuGraphicsMapResources},

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -874,29 +874,6 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
   return return_value;
 }
 
-CUresult cuLibraryUnload(CUlibrary library) {
-  lupine_route route = lupine_route_for_library(library);
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUlibrary);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryUnload",
-                                                  &return_value, library)) {
-    if (return_value == CUDA_SUCCESS)
-      lupine_invalidate_function_caches();
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
-      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS)
-    lupine_invalidate_function_caches();
-  return return_value;
-}
-
 CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
   lupine_route route = lupine_route_for_library(library);
   CUresult return_value;
@@ -7217,7 +7194,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuModuleGetTexRef", (void *)cuModuleGetTexRef},
     {"cuModuleGetSurfRef", (void *)cuModuleGetSurfRef},
     {"cuLibraryLoadFromFile", (void *)cuLibraryLoadFromFile},
-    {"cuLibraryUnload", (void *)cuLibraryUnload},
     {"cuLibraryGetKernel", (void *)cuLibraryGetKernel},
     {"cuLibraryGetModule", (void *)cuLibraryGetModule},
     {"cuKernelGetFunction", (void *)cuKernelGetFunction},

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -1383,28 +1383,6 @@ ERROR_0:
   return -1;
 }
 
-int handle_cuLibraryUnload(conn_t *conn) {
-  CUlibrary library;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &library, sizeof(CUlibrary)) < 0 || false)
-    goto ERROR_0;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_0;
-  lupine_intercept_result = cuLibraryUnload(library);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
-
-  return 0;
-ERROR_0:
-  return -1;
-}
-
 int handle_cuLibraryGetKernel(conn_t *conn) {
   CUkernel pKernel;
   CUlibrary library;
@@ -8568,7 +8546,6 @@ static const std::unordered_map<int, RequestHandler> opHandlers = {
     {RPC_cuModuleGetTexRef, handle_cuModuleGetTexRef},
     {RPC_cuModuleGetSurfRef, handle_cuModuleGetSurfRef},
     {RPC_cuLibraryLoadFromFile, handle_cuLibraryLoadFromFile},
-    {RPC_cuLibraryUnload, handle_cuLibraryUnload},
     {RPC_cuLibraryGetKernel, handle_cuLibraryGetKernel},
     {RPC_cuLibraryGetModule, handle_cuLibraryGetModule},
     {RPC_cuKernelGetFunction, handle_cuKernelGetFunction},

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -1900,33 +1900,6 @@ ERROR_0:
   return -1;
 }
 
-int handle_cuMemHostAlloc(conn_t *conn) {
-  void *pp;
-  size_t bytesize;
-  unsigned int Flags;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &pp, sizeof(void *)) < 0 ||
-      rpc_read(conn, &bytesize, sizeof(size_t)) < 0 ||
-      rpc_read(conn, &Flags, sizeof(unsigned int)) < 0 || false)
-    goto ERROR_0;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_0;
-  lupine_intercept_result = cuMemHostAlloc(&pp, bytesize, Flags);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &pp, sizeof(void *)) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
-
-  return 0;
-ERROR_0:
-  return -1;
-}
-
 int handle_cuMemHostGetDevicePointer_v2(conn_t *conn) {
   CUdeviceptr pdptr;
   void *p;
@@ -8564,7 +8537,6 @@ static const std::unordered_map<int, RequestHandler> opHandlers = {
     {RPC_cuMemGetAddressRange_v2, handle_cuMemGetAddressRange_v2},
     {RPC_cuMemAllocHost_v2, handle_cuMemAllocHost_v2},
     {RPC_cuMemFreeHost, handle_cuMemFreeHost},
-    {RPC_cuMemHostAlloc, handle_cuMemHostAlloc},
     {RPC_cuMemHostGetDevicePointer_v2, handle_cuMemHostGetDevicePointer_v2},
     {RPC_cuMemAllocManaged, handle_cuMemAllocManaged},
     {RPC_cuDeviceGetByPCIBusId, handle_cuDeviceGetByPCIBusId},

--- a/copy_pipeline.cpp
+++ b/copy_pipeline.cpp
@@ -98,10 +98,6 @@ extern "C" CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
   if (conn == nullptr) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  // Small copies are fire-and-forget: the payload is fully captured on the
-  // wire by rpc_write_end, so the source buffer is reusable on return and any
-  // failure surfaces at the next synchronize. Large copies, and copies once
-  // the unacknowledged window fills, keep the blocking response.
   unsigned char wants_response =
       lupine_ff_htod_wants_response(conn, ByteCount) != 0 ? 1 : 0;
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3914,6 +3914,37 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
   return responded ? 0 : -1;
 }
 
+// Resolve the device alias here so the client does not need a second round
+// trip for it. A mapped allocation whose alias cannot be resolved still
+// succeeds; the 0 tells the client to query it on first use instead.
+int handle_manual_cuMemHostAlloc(conn_t *conn) {
+  void *pp = nullptr;
+  size_t bytesize = 0;
+  unsigned int flags = 0;
+  if (rpc_read(conn, &pp, sizeof(pp)) < 0 ||
+      rpc_read(conn, &bytesize, sizeof(bytesize)) < 0 ||
+      rpc_read(conn, &flags, sizeof(flags)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+  CUdeviceptr device_ptr = 0;
+  CUresult result = cuMemHostAlloc(&pp, bytesize, flags);
+  if (result == CUDA_SUCCESS && (flags & CU_MEMHOSTALLOC_DEVICEMAP) != 0 &&
+      cuMemHostGetDevicePointer(&device_ptr, pp, 0) != CUDA_SUCCESS) {
+    device_ptr = 0;
+  }
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &pp, sizeof(pp)) < 0 ||
+      rpc_write(conn, &device_ptr, sizeof(device_ptr)) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
 int handle_manual_cuMemHostGetFlags(conn_t *conn) {
   unsigned int flags = 0;
   void *p = nullptr;

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3831,13 +3831,15 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
   CUdeviceptr srcDevice = 0;
   size_t byteCount = 0;
   CUstream stream = nullptr;
+  unsigned char wants_response = 1;
   int request_id;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
   if (rpc_read(conn, &dstHost, sizeof(dstHost)) < 0 ||
       rpc_read(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_read(conn, &byteCount, sizeof(byteCount)) < 0 ||
-      rpc_read(conn, &stream, sizeof(stream)) < 0) {
+      rpc_read(conn, &stream, sizeof(stream)) < 0 ||
+      rpc_read(conn, &wants_response, sizeof(wants_response)) < 0) {
     return -1;
   }
 
@@ -3889,22 +3891,20 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
     }
   }
 
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    if (alloc_result == CUDA_SUCCESS && host != nullptr) {
-      cuMemFreeHost(host);
-    } else if (host != nullptr) {
-      free(host);
-    }
-    return -1;
-  }
+  // A fire-and-forget copy drops an immediate validation error, matching launch
+  // semantics: an execution failure poisons the context and the driver reports
+  // it from the client's next synchronize.
+  bool responded = wants_response == 0 ||
+                   (rpc_write_start_response(conn, request_id) >= 0 &&
+                    rpc_write(conn, &result, sizeof(result)) >= 0 &&
+                    rpc_write_end(conn) >= 0);
 
   if (alloc_result == CUDA_SUCCESS && host != nullptr) {
     cuMemFreeHost(host);
   } else if (host != nullptr) {
     free(host);
   }
-  return 0;
+  return responded ? 0 : -1;
 }
 
 int handle_manual_cuMemHostGetFlags(conn_t *conn) {

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1927,15 +1927,22 @@ int handle_manual_cuLibraryGetModule(conn_t *conn) {
 
 int handle_manual_cuLibraryUnload(conn_t *conn) {
   CUlibrary library = nullptr;
+  unsigned char wants_response = 1;
   int request_id;
   CUresult result = CUDA_SUCCESS;
 
-  if (rpc_read(conn, &library, sizeof(library)) < 0) {
+  if (rpc_read(conn, &library, sizeof(library)) < 0 ||
+      rpc_read(conn, &wants_response, sizeof(wants_response)) < 0) {
     return -1;
   }
   request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;
+  }
+  // Mirror the client: unloads are fire-and-forget unless the client asked to
+  // block on the result.
+  if (wants_response == 0) {
+    return 0;
   }
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3653,9 +3653,6 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     result = cuMemcpyHtoDAsync_v2(dstDevice, capture_host, byteCount, stream);
   }
 
-  // Fire-and-forget submissions carry no response. An immediate validation
-  // error is dropped, matching launch semantics; an execution failure poisons
-  // the context and surfaces from the driver at the next synchronize.
   if (wants_response == 0) {
     return 0;
   }

--- a/manual_server.h
+++ b/manual_server.h
@@ -81,6 +81,7 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn);
 int handle_manual_lupineDeviceSnapshot(conn_t *conn);
 int handle_manual_lupineManagedHostFlush(conn_t *conn);
 int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn);
+int handle_manual_cuMemHostAlloc(conn_t *conn);
 int handle_manual_cuMemHostGetFlags(conn_t *conn);
 int handle_manual_cuCtxSynchronize(conn_t *conn);
 int handle_manual_cuStreamSynchronize(conn_t *conn);

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -695,9 +695,6 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
   std::array<struct iovec, LUPINE_MANAGED_HOST_FLUSH_BATCH_RANGES * 2>
       iovecs;
 
-  // Fire-and-forget: the dirty ranges are captured on the wire by
-  // rpc_write_end and every later request is connection-ordered behind them,
-  // so there is nothing to wait for.
   auto send_batch = [&](uint32_t count) {
     if (count == 0) {
       return CUDA_SUCCESS;

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -1288,13 +1288,19 @@ static bool lupine_host_pages_registered_locked(uintptr_t base, size_t size) {
          reinterpret_cast<uintptr_t>(upper->first) < end;
 }
 
+// The response carries the server-side device alias alongside the host
+// pointer, so a mapped allocation costs one round trip instead of two. The
+// alias is 0 when the allocation is not device-mapped or the server could not
+// resolve one; callers fall back to querying it on first use.
 static CUresult lupine_remote_cuMemHostAlloc(void **remote_host,
+                                             CUdeviceptr *device_ptr,
                                              size_t bytesize,
                                              unsigned int flags,
                                              lupine_route route) {
-  if (remote_host == nullptr) {
+  if (remote_host == nullptr || device_ptr == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  *device_ptr = 0;
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(void **, size_t, unsigned int);
     auto real = lupine_real_cuda_fn<real_fn_t>("cuMemHostAlloc");
@@ -1312,8 +1318,10 @@ static CUresult lupine_remote_cuMemHostAlloc(void **remote_host,
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, remote_host, sizeof(*remote_host)) < 0 ||
+      rpc_read(conn, device_ptr, sizeof(*device_ptr)) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
+    *device_ptr = 0;
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   return return_value;
@@ -1462,15 +1470,10 @@ extern "C" CUresult cuMemHostAlloc(void **pp, size_t bytesize,
   void *remote_host = nullptr;
   CUdeviceptr device_ptr = 0;
   if (bytesize != 0) {
-    CUresult result = lupine_remote_cuMemHostAlloc(
-        &remote_host, bytesize, Flags | CU_MEMHOSTALLOC_DEVICEMAP, route);
+    CUresult result =
+        lupine_remote_cuMemHostAlloc(&remote_host, &device_ptr, bytesize,
+                                     Flags | CU_MEMHOSTALLOC_DEVICEMAP, route);
     if (result != CUDA_SUCCESS) {
-      return result;
-    }
-    result = lupine_remote_cuMemHostGetDevicePointer(&device_ptr, remote_host,
-                                                     0, route);
-    if (result != CUDA_SUCCESS) {
-      lupine_remote_cuMemFreeHost(remote_host, route);
       return result;
     }
   }
@@ -1844,12 +1847,8 @@ static CUresult lupine_register_host(void *p, size_t bytesize,
     if ((Flags & CU_MEMHOSTREGISTER_PORTABLE) != 0) {
       host_flags |= CU_MEMHOSTALLOC_PORTABLE;
     }
-    CUresult result = lupine_remote_cuMemHostAlloc(&server_host, covering_size,
-                                                   host_flags, route);
-    if (result == CUDA_SUCCESS) {
-      result = lupine_remote_cuMemHostGetDevicePointer(&device_ptr, server_host,
-                                                       0, route);
-    }
+    CUresult result = lupine_remote_cuMemHostAlloc(
+        &server_host, &device_ptr, covering_size, host_flags, route);
     if (result != CUDA_SUCCESS) {
       if (server_host != nullptr) {
         lupine_remote_cuMemFreeHost(server_host, route);

--- a/routing.cpp
+++ b/routing.cpp
@@ -492,14 +492,8 @@ extern "C" void lupine_note_graph_node_owner(CUgraphNode node, conn_t *conn) {
   lupine_note_owner(node, conn);
 }
 
-extern "C" void lupine_disable_sync_elision(conn_t *conn);
-
 extern "C" void lupine_note_graph_exec_owner(CUgraphExec exec, conn_t *conn) {
   lupine_note_owner(exec, conn);
-  // Graph launches can carry device-to-host copies whose data is delivered at
-  // synchronization points the client cannot account for; once graph execs
-  // exist on a connection, stream synchronizes always go to the server.
-  lupine_disable_sync_elision(conn);
 }
 
 extern "C" void lupine_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn) {
@@ -586,9 +580,6 @@ extern "C" void lupine_note_graph_node_owner_route(CUgraphNode node,
 extern "C" void lupine_note_graph_exec_owner_route(CUgraphExec exec,
                                                    lupine_route route) {
   lupine_note_owner_route(exec, route);
-  if (route.kind == LUPINE_ROUTE_REMOTE) {
-    lupine_disable_sync_elision(route.conn);
-  }
 }
 
 extern "C" void lupine_note_deviceptr_owner_route(CUdeviceptr ptr,

--- a/server.cpp
+++ b/server.cpp
@@ -161,6 +161,7 @@ lupine_manual_handlers() {
        {handle_manual_cuMemcpy2DAsync_v2, "cuMemcpy2DAsync_v2"}},
       {RPC_cuMemcpyDtoH_v2, {handle_manual_cuMemcpyDtoH_v2, "cuMemcpyDtoH_v2"}},
       {RPC_cuMemcpyAtoH_v2, {handle_manual_cuMemcpyAtoH_v2, "cuMemcpyAtoH_v2"}},
+      {RPC_cuMemHostAlloc, {handle_manual_cuMemHostAlloc, "cuMemHostAlloc"}},
       {RPC_cuMemHostGetFlags,
        {handle_manual_cuMemHostGetFlags, "cuMemHostGetFlags"}},
       {RPC_cuDeviceGetGraphMemAttribute,


### PR DESCRIPTION
Three follow-ups to #469, each removing a class of blocked round trip measured in the makemore WAN profile (30ms emulated RTT). (1) Async DtoH copies are fire-and-forget: the data never rode on the copy response anyway — it is delivered by the next synchronize — so the copy now only pays the wire write, halving loss.item() from two round trips to one; the pending-copy count still forces that synchronize to go remote so elision can never strand the data. (2) cuLibraryUnload sends a wants_response byte and skips the reply (the server handler was already a no-op), removing ~0.7s of teardown wait from 20 unloads at exit. (3) Mapped host allocation responses now carry the device alias, deleting the eager cuMemHostGetDevicePointer round trip the client issued after every cuMemHostAlloc/cuMemHostRegister (17 per run); a failed alias query now degrades to alias 0 with lazy RPC fallback instead of aborting the allocation. LUPINE_STRICT_SYNC=1 restores blocking behavior for (1) and (2). Measured: makemore at 30ms RTT drops 16.4s to 15.1s wall with step-0 5.1s to 4.7s, loss curves identical; unit tests 9/9, custom GPU tests 23/23 including the mapped demand-fetch suite.