### PR TITLE
Bound async HtoD staging with HTTP/2 flow control

### DIFF
--- a/copy_pipeline.cpp
+++ b/copy_pipeline.cpp
@@ -247,6 +247,7 @@ struct lupine_async_htod_slot {
   CUevent completion = nullptr;
   CUcontext event_context = nullptr;
   lupine_async_htod_state state = lupine_async_htod_state::available;
+  uint64_t held_window_bytes = 0;
 };
 
 struct lupine_async_htod_spill {
@@ -256,9 +257,11 @@ struct lupine_async_htod_spill {
   CUcontext event_context = nullptr;
   bool completion_recorded = false;
   bool work_queued = false;
+  uint64_t held_window_bytes = 0;
 };
 
 struct lupine_staging_state {
+  conn_t *conn = nullptr;
   std::mutex lifecycle_mutex;
   std::mutex mutex;
   std::condition_variable condition;
@@ -440,6 +443,27 @@ static bool lupine_sync_htod_prepare(lupine_sync_htod_pool &pool,
   return true;
 }
 
+// Credits a staging buffer's payload bytes back to the client's send window.
+// Every path that stops tracking a buffer -- retired, quarantined, forgotten --
+// runs through here, so an unprovable DMA costs pinned memory but never leaves
+// window charged to a buffer nothing will ever retire.
+static void lupine_release_staging_window(lupine_staging_state &state,
+                                          uint64_t &held) {
+  uint64_t bytes = held;
+  held = 0;
+  rpc_http2_window_release(state.conn, bytes);
+}
+
+// Reads a payload into staging with the connection's window held, charging the
+// received bytes to the staging buffer rather than crediting them immediately.
+static int lupine_read_staged_payload(conn_t *conn, int framed, void *host,
+                                      size_t bytes, uint64_t &held) {
+  rpc_http2_window_hold_begin(conn);
+  int result = rpc_read_payload_part(conn, framed, host, bytes);
+  held += rpc_http2_window_hold_end(conn);
+  return result;
+}
+
 static CUresult lupine_async_htod_destroy_event(CUevent *event,
                                                 CUcontext context) {
   if (event == nullptr || *event == nullptr) {
@@ -495,10 +519,12 @@ static void lupine_async_htod_reclaim(lupine_staging_state &state,
     CUresult result = cuEventQuery(slot.completion);
     if (result == CUDA_SUCCESS) {
       slot.state = lupine_async_htod_state::available;
+      lupine_release_staging_window(state, slot.held_window_bytes);
     } else if (result != CUDA_ERROR_NOT_READY) {
       // An error cannot prove the DMA is finished. Never make this allocation
       // reusable until its context is explicitly retired.
       slot.state = lupine_async_htod_state::quarantined;
+      lupine_release_staging_window(state, slot.held_window_bytes);
       LUPINE_LOG_ERROR("Async HtoD slot event query failed: " << result);
     }
   }
@@ -516,10 +542,12 @@ static void lupine_async_htod_reclaim(lupine_staging_state &state,
     if (result != CUDA_SUCCESS) {
       // As with a ring slot, retain the allocation when completion is unknown.
       spill->completion_recorded = false;
+      lupine_release_staging_window(state, spill->held_window_bytes);
       LUPINE_LOG_ERROR("Async HtoD spill event query failed: " << result);
       ++spill;
       continue;
     }
+    lupine_release_staging_window(state, spill->held_window_bytes);
     lupine_async_htod_destroy_event(&spill->completion, spill->event_context);
     lupine_async_htod_free_host(&spill->ptr, spill->allocation_context);
     spill = state.spills.erase(spill);
@@ -631,17 +659,26 @@ static CUresult lupine_async_htod_publish_slot(lupine_staging_state &state,
   CUresult result = cuEventRecord(slot->completion, stream);
   slot->state = result == CUDA_SUCCESS ? lupine_async_htod_state::in_flight
                                        : lupine_async_htod_state::quarantined;
+  if (result != CUDA_SUCCESS) {
+    lupine_release_staging_window(state, slot->held_window_bytes);
+  }
   return result;
 }
 
-static CUresult lupine_async_htod_publish_spill(lupine_async_htod_spill &spill,
+static CUresult lupine_async_htod_publish_spill(lupine_staging_state &state,
+                                                lupine_async_htod_spill &spill,
                                                 CUstream stream) {
   CUresult result = cuEventRecord(spill.completion, stream);
   spill.completion_recorded = result == CUDA_SUCCESS;
+  if (result != CUDA_SUCCESS) {
+    lupine_release_staging_window(state, spill.held_window_bytes);
+  }
   return result;
 }
 
-static void lupine_async_htod_discard_spill(lupine_async_htod_spill &spill) {
+static void lupine_async_htod_discard_spill(lupine_staging_state &state,
+                                            lupine_async_htod_spill &spill) {
+  lupine_release_staging_window(state, spill.held_window_bytes);
   lupine_async_htod_destroy_event(&spill.completion, spill.event_context);
   lupine_async_htod_free_host(&spill.ptr, spill.allocation_context);
 }
@@ -670,7 +707,7 @@ static CUresult lupine_async_htod_enqueue_spill(
     result = cuEventCreate(&spill.completion, CU_EVENT_DISABLE_TIMING);
   }
   if (result != CUDA_SUCCESS) {
-    lupine_async_htod_discard_spill(spill);
+    lupine_async_htod_discard_spill(state, spill);
     state.spills.pop_back();
     return result;
   }
@@ -678,11 +715,12 @@ static CUresult lupine_async_htod_enqueue_spill(
   while (offset < bytes) {
     size_t chunk = std::min(LUPINE_HTOD_CHUNK_BYTES, bytes - offset);
     auto *chunk_host = static_cast<unsigned char *>(spill.ptr) + offset;
-    if (rpc_read_payload_part(conn, framed, chunk_host, chunk) < 0) {
+    if (lupine_read_staged_payload(conn, framed, chunk_host, chunk,
+                                   spill.held_window_bytes) < 0) {
       if (spill.work_queued) {
-        (void)lupine_async_htod_publish_spill(spill, stream);
+        (void)lupine_async_htod_publish_spill(state, spill, stream);
       } else {
-        lupine_async_htod_discard_spill(spill);
+        lupine_async_htod_discard_spill(state, spill);
         state.spills.pop_back();
       }
       if (connection_failed != nullptr) {
@@ -699,7 +737,7 @@ static CUresult lupine_async_htod_enqueue_spill(
     spill.work_queued = true;
     offset += chunk;
     if (result != CUDA_SUCCESS) {
-      (void)lupine_async_htod_publish_spill(spill, stream);
+      (void)lupine_async_htod_publish_spill(state, spill, stream);
       if (rpc_drain_payload(conn, framed, bytes - offset) < 0) {
         if (connection_failed != nullptr) {
           *connection_failed = true;
@@ -714,7 +752,7 @@ static CUresult lupine_async_htod_enqueue_spill(
   if (payload_consumed != nullptr) {
     *payload_consumed = true;
   }
-  return lupine_async_htod_publish_spill(spill, stream);
+  return lupine_async_htod_publish_spill(state, spill, stream);
 }
 
 static void lupine_async_htod_retire_context(lupine_staging_state &state,
@@ -737,6 +775,7 @@ static void lupine_async_htod_retire_context(lupine_staging_state &state,
       }
       if (result != CUDA_SUCCESS) {
         slot.state = lupine_async_htod_state::quarantined;
+        lupine_release_staging_window(state, slot.held_window_bytes);
         LUPINE_LOG_ERROR(
             "Could not prove async HtoD slot completion; quarantining it: "
             << result);
@@ -746,6 +785,7 @@ static void lupine_async_htod_retire_context(lupine_staging_state &state,
     } else if (slot.state == lupine_async_htod_state::quarantined) {
       continue;
     }
+    lupine_release_staging_window(state, slot.held_window_bytes);
     lupine_async_htod_destroy_event(&slot.completion, slot.event_context);
     if (allocation_owned) {
       lupine_async_htod_free_host(&slot.ptr, slot.allocation_context);
@@ -778,12 +818,14 @@ static void lupine_async_htod_retire_context(lupine_staging_state &state,
     }
     if (result != CUDA_SUCCESS) {
       spill->completion_recorded = false;
+      lupine_release_staging_window(state, spill->held_window_bytes);
       LUPINE_LOG_ERROR(
           "Could not prove async HtoD spill completion; quarantining it: "
           << result);
       ++spill;
       continue;
     }
+    lupine_release_staging_window(state, spill->held_window_bytes);
     lupine_async_htod_destroy_event(&spill->completion, spill->event_context);
     lupine_async_htod_free_host(&spill->ptr, spill->allocation_context);
     spill = state.spills.erase(spill);
@@ -808,15 +850,20 @@ static void lupine_async_htod_forget_context(lupine_staging_state &state,
                                              CUcontext context) {
   for (auto &slot : state.slots) {
     if (slot.allocation_context == context || slot.event_context == context) {
+      lupine_release_staging_window(state, slot.held_window_bytes);
       slot = {};
     }
   }
 
   state.spills.erase(std::remove_if(state.spills.begin(), state.spills.end(),
-                                    [context](const auto &spill) {
-                                      return spill.allocation_context ==
-                                                 context ||
-                                             spill.event_context == context;
+                                    [&state, context](auto &spill) {
+                                      if (spill.allocation_context != context &&
+                                          spill.event_context != context) {
+                                        return false;
+                                      }
+                                      lupine_release_staging_window(
+                                          state, spill.held_window_bytes);
+                                      return true;
                                     }),
                      state.spills.end());
 
@@ -852,6 +899,7 @@ bool lupine_server_initialize_connection(conn_t *conn) {
   if (state == nullptr) {
     return false;
   }
+  state->conn = conn;
   return lupine_staging_states().insert(conn, std::move(state));
 }
 
@@ -1719,7 +1767,8 @@ int lupine_server_copy_htod_async(conn_t *conn, int framed,
       break;
     }
     size_t chunk = std::min(slot->size, byteCount - offset);
-    if (rpc_read_payload_part(conn, framed, slot->ptr, chunk) < 0) {
+    if (lupine_read_staged_payload(conn, framed, slot->ptr, chunk,
+                                   slot->held_window_bytes) < 0) {
       return -1;
     }
 

--- a/h2.cpp
+++ b/h2.cpp
@@ -19,7 +19,15 @@
 
 namespace {
 
-constexpr uint32_t kH2InitialWindow = 0x7fffffffU;
+// Responses land straight in caller buffers, so the client keeps an
+// effectively unlimited receive window; the server's window is the staging
+// budget it is willing to have pinned on a client's behalf.
+constexpr uint32_t kH2ClientWindow = 0x7fffffffU;
+constexpr uint32_t kH2ServerWindow =
+    static_cast<uint32_t>(LUPINE_FF_STAGING_WINDOW_BYTES);
+// Ceiling on uncredited bytes, leaving the reader window for the bytes it is
+// blocked on.
+constexpr uint64_t kH2MaxHeldBytes = LUPINE_FF_STAGING_WINDOW_BYTES / 2;
 constexpr uint32_t kH2MaxFrame = (16 * 1024 * 1024) - 1;
 constexpr size_t kH2FrameHeaderLen = 9;
 
@@ -45,6 +53,9 @@ struct h2_transport {
   size_t read_remaining = 0;
   rpc_http2_read_stats read_stats = {};
   uint64_t staged_bytes = 0;
+  bool window_hold = false;
+  uint64_t window_hold_bytes = 0;
+  uint64_t window_held = 0;
   // Reusable scratch holding the one LZ4-framed payload block currently in
   // flight (see h2_materialize_block). Writes are serialized per connection,
   // so a single buffer suffices and memory stays bounded by one block.
@@ -374,12 +385,25 @@ int h2_send_data_callback(nghttp2_session *, nghttp2_frame *frame,
   return 0;
 }
 
-int h2_on_data_chunk_recv_callback(nghttp2_session *, uint8_t,
+int h2_on_data_chunk_recv_callback(nghttp2_session *session, uint8_t,
                                    int32_t stream_id, const uint8_t *data,
                                    size_t len, void *user_data) {
   auto *transport = static_cast<h2_transport *>(user_data);
   if (stream_id != transport->stream_id) {
     return NGHTTP2_ERR_CALLBACK_FAILURE;
+  }
+  if (transport->server) {
+    size_t held = 0;
+    if (transport->window_hold && transport->window_held < kH2MaxHeldBytes) {
+      held = std::min<size_t>(
+          len, static_cast<size_t>(kH2MaxHeldBytes - transport->window_held));
+      transport->window_held += held;
+      transport->window_hold_bytes += held;
+    }
+    if (len > held &&
+        nghttp2_session_consume(session, stream_id, len - held) != 0) {
+      return NGHTTP2_ERR_CALLBACK_FAILURE;
+    }
   }
   receive_bytes(transport, data, len);
   return 0;
@@ -643,25 +667,41 @@ int h2_init_direct(conn_t *conn, bool server, bool probe) {
   nghttp2_session_callbacks_set_on_header_callback(callbacks,
                                                    h2_on_header_callback);
 
-  int session_result = server ? nghttp2_session_server_new(&transport->session,
-                                                           callbacks, transport)
-                              : nghttp2_session_client_new(
-                                    &transport->session, callbacks, transport);
+  // The server credits received DATA back by hand so a fire-and-forget payload
+  // keeps its window charged for as long as its staging buffer lives.
+  nghttp2_option *option = nullptr;
+  if (server) {
+    if (nghttp2_option_new(&option) != 0) {
+      nghttp2_session_callbacks_del(callbacks);
+      delete transport;
+      return -1;
+    }
+    nghttp2_option_set_no_auto_window_update(option, 1);
+  }
+  int session_result =
+      server ? nghttp2_session_server_new2(&transport->session, callbacks,
+                                           transport, option)
+             : nghttp2_session_client_new(&transport->session, callbacks,
+                                          transport);
   nghttp2_session_callbacks_del(callbacks);
+  if (option != nullptr) {
+    nghttp2_option_del(option);
+  }
   if (session_result != 0) {
     delete transport;
     return -1;
   }
 
+  const uint32_t window = server ? kH2ServerWindow : kH2ClientWindow;
   nghttp2_settings_entry settings[] = {
-      {NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE, kH2InitialWindow},
+      {NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE, window},
       {NGHTTP2_SETTINGS_MAX_FRAME_SIZE, kH2MaxFrame},
   };
   if (nghttp2_submit_settings(transport->session, NGHTTP2_FLAG_NONE, settings,
                               2) != 0 ||
-      nghttp2_session_set_local_window_size(
-          transport->session, NGHTTP2_FLAG_NONE, 0,
-          static_cast<int32_t>(kH2InitialWindow)) != 0) {
+      nghttp2_session_set_local_window_size(transport->session,
+                                            NGHTTP2_FLAG_NONE, 0,
+                                            static_cast<int32_t>(window)) != 0) {
     nghttp2_session_del(transport->session);
     delete transport;
     return -1;
@@ -823,6 +863,50 @@ int rpc_http2_get_read_stats(conn_t *conn, rpc_http2_read_stats *stats) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
   *stats = transport->read_stats;
   return 0;
+}
+
+void rpc_http2_window_hold_begin(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  pthread_mutex_lock(&transport->session_mutex);
+  transport->window_hold = true;
+  transport->window_hold_bytes = 0;
+  pthread_mutex_unlock(&transport->session_mutex);
+}
+
+uint64_t rpc_http2_window_hold_end(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return 0;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  pthread_mutex_lock(&transport->session_mutex);
+  uint64_t held = transport->window_hold_bytes;
+  transport->window_hold = false;
+  transport->window_hold_bytes = 0;
+  pthread_mutex_unlock(&transport->session_mutex);
+  return held;
+}
+
+// Whichever thread retires the staging emits the credit itself, under
+// session_mutex alone: the transport never takes a staging lock, and nothing
+// holding session_mutex waits on staging, so a reader starved of window is
+// never queued behind the release that would feed it. kH2MaxHeldBytes closes
+// the other half of the cycle -- staging that never retires cannot shut the
+// window on the reads that would retire it.
+void rpc_http2_window_release(conn_t *conn, uint64_t bytes) {
+  if (conn == nullptr || conn->http2 == nullptr || bytes == 0) {
+    return;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  pthread_mutex_lock(&transport->session_mutex);
+  transport->window_held -= std::min(bytes, transport->window_held);
+  if (nghttp2_session_consume(transport->session, transport->stream_id,
+                              bytes) == 0) {
+    (void)h2_flush_session_locked(transport);
+  }
+  pthread_mutex_unlock(&transport->session_mutex);
 }
 
 int rpc_http2_client_init(conn_t *conn) {

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -474,6 +474,66 @@ void test_payload_larger_than_flow_control_window() {
   require(received == payload_size, "flow-controlled payload was truncated");
 }
 
+// A server-side hold keeps received payload bytes uncredited until the staging
+// they landed in retires. Held bytes saturate at a cap so the reader filling
+// the hold always has credit left for the bytes it is blocked on, and the
+// release hands the rest back.
+void test_server_window_hold_caps_and_releases() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+
+  constexpr size_t kBurst = LUPINE_FF_STAGING_WINDOW_BYTES;
+  std::vector<char> payload(kBurst, 'h');
+  std::vector<char> received(kBurst, '\0');
+  uint64_t held = 0;
+
+  // As on a production connection, the client's dispatch thread is what applies
+  // the server's WINDOW_UPDATE frames; it releases when the server replies.
+  std::thread client_control_reader([&] {
+    unsigned char unused = 0;
+    (void)rpc_http2_read(&pair.client, &unused, sizeof(unused));
+  });
+
+  std::thread reader([&] {
+    rpc_http2_window_hold_begin(&pair.server);
+    require(rpc_http2_read(&pair.server, received.data(), received.size()) ==
+                static_cast<int>(received.size()),
+            "held payload read failed");
+    held = rpc_http2_window_hold_end(&pair.server);
+  });
+  rpc_write_entry entry = {{payload.data(), payload.size()}, 0};
+  require(rpc_http2_writev(&pair.client, &entry, 1) == 0, "held write failed");
+  reader.join();
+  require(received == payload, "held payload mismatch");
+  require(held == LUPINE_FF_STAGING_WINDOW_BYTES / 2,
+          "held bytes did not saturate at the cap");
+
+  // Still holding: the uncapped remainder must have been credited, so another
+  // window's worth of payload still flows.
+  std::fill(received.begin(), received.end(), '\0');
+  std::thread held_reader([&] {
+    require(rpc_http2_read(&pair.server, received.data(), received.size()) ==
+                static_cast<int>(received.size()),
+            "read under an outstanding hold failed");
+  });
+  require(rpc_http2_writev(&pair.client, &entry, 1) == 0,
+          "write under an outstanding hold failed");
+  held_reader.join();
+  require(received == payload, "payload under an outstanding hold mismatch");
+
+  rpc_http2_window_release(&pair.server, held);
+  std::string tail = "released";
+  std::string received_tail;
+  std::thread tail_reader(
+      [&] { received_tail = read_string(&pair.server, tail.size()); });
+  write_all(&pair.client, {tail});
+  tail_reader.join();
+  require(received_tail == tail, "payload after release mismatch");
+
+  write_all(&pair.server, {"z"});
+  client_control_reader.join();
+}
+
 void test_reset_wakes_flow_controlled_writer() {
   h2_pair pair = make_pair();
   exchange_settings(&pair);
@@ -728,6 +788,7 @@ int main() {
   test_large_payload();
   test_framed_payload_round_trip();
   test_payload_larger_than_flow_control_window();
+  test_server_window_hold_caps_and_releases();
   test_reset_wakes_flow_controlled_writer();
 #endif
   std::cout << "h2_test: PASS" << std::endl;

--- a/rpc.h
+++ b/rpc.h
@@ -30,6 +30,11 @@ struct rpc_http2_read_stats {
 
 #define LUPINE_RPC_TERMINATE_LANE 0xFFFF
 
+// The server's HTTP/2 receive window, and with it the ceiling on the pinned
+// staging a client can hold there: async HtoD payload bytes stay uncredited
+// until the staging buffer they landed in retires.
+#define LUPINE_FF_STAGING_WINDOW_BYTES (64ull * 1024 * 1024)
+
 // Wire layout for LUPINE_RPC_lupineDeviceSnapshot. The response is all or
 // nothing: a non-success result carries no payload, otherwise every device
 // record holds a fixed-size name buffer, uuid, total memory, and a
@@ -176,6 +181,16 @@ extern int rpc_http2_compress_lz4(conn_t *conn);
 // the HTTP/2 request headers, or nullptr when no session was supplied.
 extern const char *rpc_http2_session_id(conn_t *conn);
 extern int rpc_http2_get_read_stats(conn_t *conn, rpc_http2_read_stats *stats);
+
+// Server-side flow control for payloads that outlive the read that received
+// them. Between hold_begin and hold_end the transport stops crediting received
+// DATA bytes back to the peer; hold_end returns the byte count the caller now
+// owns and must hand to rpc_http2_window_release once the buffer those bytes
+// landed in is idle. Held bytes are capped, so a caller that never releases
+// costs window but cannot close it.
+extern void rpc_http2_window_hold_begin(conn_t *conn);
+extern uint64_t rpc_http2_window_hold_end(conn_t *conn);
+extern void rpc_http2_window_release(conn_t *conn, uint64_t bytes);
 
 // Optional LZ4 framing for large memory transfer payloads (see compress.cpp).
 extern int lupine_payload_framed(conn_t *conn, size_t total_size);


### PR DESCRIPTION
The server stages every async HtoD payload in pinned host memory until the device DMA completes, and nothing bounded how much staging a client could force it to hold: TCP flow control never engages because the multiplexed lane transport must keep draining the socket, so the pressure lands in pinned allocations instead of the kernel buffer. This switches the server's nghttp2 session to manual window management: payload bytes that land in staging stay uncredited (rpc_http2_window_hold_begin/end) until the staging buffer retires at DMA completion, at which point the retiring lane worker consumes them and flushes the WINDOW_UPDATE itself. The server's receive window (LUPINE_FF_STAGING_WINDOW_BYTES, 64MB — a lowering from the previous effectively-unlimited 2GB) thereby becomes the staging budget, with held bytes capped at half the window so a single request larger than the window cannot deadlock against its own read; the cycle-freedom argument is commented at rpc_http2_window_release. No wire-format change; the client's receive window is untouched so device-to-host traffic is not throttled. The window bounds unacknowledged wire bytes, so with LZ4 framing the pinned staging it backs can be somewhat larger — inherent to transport-level flow control. A new h2_test case drives the block-and-wake path end to end: with the cap held, a client writing a full window must stall and be woken by WINDOW_UPDATEs. This is the transport foundation for the fire-and-forget submission work stacked on top.