### PR TITLE
Serve event, library, and kernel handles synthetically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(CLIENT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/ipc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/handles.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/routing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.cpp
@@ -117,6 +118,7 @@ set(CLIENT_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.h
     ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.h
     ${CMAKE_CURRENT_SOURCE_DIR}/client_routing.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/handles.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ipc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_client.h
     ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.h
@@ -236,6 +238,16 @@ else()
     add_test(NAME ipc_test COMMAND ipc_test)
     lupine_scaled_timeout(ipc_timeout 10)
     set_tests_properties(ipc_test PROPERTIES TIMEOUT ${ipc_timeout})
+
+    add_executable(handles_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/handles.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/handles_test.cpp
+    )
+    target_link_libraries(handles_test PRIVATE pthread)
+    lupine_apply_sanitizer(handles_test)
+    add_test(NAME handles_test COMMAND handles_test)
+    lupine_scaled_timeout(handles_timeout 10)
+    set_tests_properties(handles_test PROPERTIES TIMEOUT ${handles_timeout})
 
     add_library(test_lupinecr_provider SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/test/test_checkpoint_provider.c

--- a/cache.cpp
+++ b/cache.cpp
@@ -2,6 +2,14 @@
 
 #include <array>
 #include <atomic>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 namespace {
 
@@ -52,7 +60,254 @@ lane_context_cache_entry *lane_context_cache_entry_for(int route_id) {
   return &lane_context_cache()[slot];
 }
 
+constexpr char kKernelTableMagic[8] = {'L', 'U', 'P', 'K', 'T', 'A', 'B', '1'};
+
+struct sha256_state {
+  uint32_t h[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                   0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+  uint64_t length = 0;
+  unsigned char block[64] = {};
+  size_t filled = 0;
+};
+
+uint32_t rotate_right(uint32_t value, unsigned bits) {
+  return (value >> bits) | (value << (32 - bits));
+}
+
+void sha256_compress(sha256_state &state, const unsigned char *block) {
+  static const uint32_t k[64] = {
+      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+      0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+      0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+      0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+      0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+      0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+      0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+      0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+      0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+      0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+      0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+  uint32_t w[64];
+  for (int i = 0; i < 16; ++i) {
+    w[i] = (static_cast<uint32_t>(block[i * 4]) << 24) |
+           (static_cast<uint32_t>(block[i * 4 + 1]) << 16) |
+           (static_cast<uint32_t>(block[i * 4 + 2]) << 8) |
+           static_cast<uint32_t>(block[i * 4 + 3]);
+  }
+  for (int i = 16; i < 64; ++i) {
+    uint32_t s0 = rotate_right(w[i - 15], 7) ^ rotate_right(w[i - 15], 18) ^
+                  (w[i - 15] >> 3);
+    uint32_t s1 = rotate_right(w[i - 2], 17) ^ rotate_right(w[i - 2], 19) ^
+                  (w[i - 2] >> 10);
+    w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+  }
+  uint32_t v[8];
+  memcpy(v, state.h, sizeof(v));
+  for (int i = 0; i < 64; ++i) {
+    uint32_t s1 =
+        rotate_right(v[4], 6) ^ rotate_right(v[4], 11) ^ rotate_right(v[4], 25);
+    uint32_t ch = (v[4] & v[5]) ^ (~v[4] & v[6]);
+    uint32_t temp1 = v[7] + s1 + ch + k[i] + w[i];
+    uint32_t s0 =
+        rotate_right(v[0], 2) ^ rotate_right(v[0], 13) ^ rotate_right(v[0], 22);
+    uint32_t maj = (v[0] & v[1]) ^ (v[0] & v[2]) ^ (v[1] & v[2]);
+    uint32_t temp2 = s0 + maj;
+    v[7] = v[6];
+    v[6] = v[5];
+    v[5] = v[4];
+    v[4] = v[3] + temp1;
+    v[3] = v[2];
+    v[2] = v[1];
+    v[1] = v[0];
+    v[0] = temp1 + temp2;
+  }
+  for (int i = 0; i < 8; ++i) {
+    state.h[i] += v[i];
+  }
+}
+
+void sha256_update(sha256_state &state, const unsigned char *data,
+                   size_t size) {
+  state.length += size;
+  while (size != 0) {
+    size_t take = sizeof(state.block) - state.filled;
+    take = take < size ? take : size;
+    memcpy(state.block + state.filled, data, take);
+    state.filled += take;
+    data += take;
+    size -= take;
+    if (state.filled == sizeof(state.block)) {
+      sha256_compress(state, state.block);
+      state.filled = 0;
+    }
+  }
+}
+
+std::string sha256_hex(const unsigned char *data, size_t size) {
+  sha256_state state;
+  sha256_update(state, data, size);
+  uint64_t bits = state.length * 8;
+  unsigned char padding[72] = {0x80};
+  size_t pad = state.filled < 56 ? 56 - state.filled : 120 - state.filled;
+  sha256_update(state, padding, pad);
+  unsigned char tail[8];
+  for (int i = 0; i < 8; ++i) {
+    tail[i] = static_cast<unsigned char>(bits >> (56 - i * 8));
+  }
+  sha256_update(state, tail, sizeof(tail));
+
+  static const char digits[] = "0123456789abcdef";
+  std::string hex;
+  hex.reserve(64);
+  for (uint32_t word : state.h) {
+    for (int shift = 28; shift >= 0; shift -= 4) {
+      hex.push_back(digits[(word >> shift) & 0xF]);
+    }
+  }
+  return hex;
+}
+
+std::string kernel_table_cache_dir() {
+  const char *configured = getenv("LUPINE_CACHE_DIR");
+  std::string root;
+  if (configured != nullptr && configured[0] != '\0') {
+    root = configured;
+  } else {
+    const char *xdg = getenv("XDG_CACHE_HOME");
+    if (xdg != nullptr && xdg[0] != '\0') {
+      root = std::string(xdg) + "/lupine";
+    } else {
+      const char *home = getenv("HOME");
+      if (home == nullptr || home[0] == '\0') {
+        return std::string();
+      }
+      root = std::string(home) + "/.cache/lupine";
+    }
+  }
+  return root + "/kernels";
+}
+
+bool make_directories(const std::string &path) {
+  for (size_t i = 1; i <= path.size(); ++i) {
+    if (i != path.size() && path[i] != '/') {
+      continue;
+    }
+    std::string prefix = path.substr(0, i);
+    if (mkdir(prefix.c_str(), 0755) != 0 && errno != EEXIST) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string kernel_table_cache_path(const unsigned char *image, size_t size,
+                                    uint32_t driver_version) {
+  std::string dir = kernel_table_cache_dir();
+  if (dir.empty() || image == nullptr || size == 0) {
+    return std::string();
+  }
+  return dir + "/" + sha256_hex(image, size) + "-" +
+         std::to_string(driver_version) + ".ktab";
+}
+
+template <typename T> bool read_pod(std::istream &stream, T *value) {
+  return stream.read(reinterpret_cast<char *>(value), sizeof(T)).good();
+}
+
+template <typename T> void write_pod(std::ostream &stream, const T &value) {
+  stream.write(reinterpret_cast<const char *>(&value), sizeof(T));
+}
+
 } // namespace
+
+bool lupine_kernel_table_cache_load(
+    const unsigned char *image, size_t size, uint32_t driver_version,
+    std::vector<lupine_kernel_table_entry> *out) {
+  if (out == nullptr) {
+    return false;
+  }
+  out->clear();
+  std::string path = kernel_table_cache_path(image, size, driver_version);
+  if (path.empty()) {
+    return false;
+  }
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    return false;
+  }
+  char magic[sizeof(kKernelTableMagic)] = {};
+  uint32_t count = 0;
+  if (!file.read(magic, sizeof(magic)).good() ||
+      memcmp(magic, kKernelTableMagic, sizeof(magic)) != 0 ||
+      !read_pod(file, &count) || count > 1u << 20) {
+    return false;
+  }
+  for (uint32_t i = 0; i < count; ++i) {
+    uint32_t name_length = 0;
+    uint32_t param_count = 0;
+    lupine_kernel_table_entry entry;
+    if (!read_pod(file, &name_length) || name_length == 0 ||
+        name_length > 64 * 1024) {
+      out->clear();
+      return false;
+    }
+    entry.name.resize(name_length);
+    if (!file.read(entry.name.data(), name_length).good() ||
+        !read_pod(file, &param_count) || param_count > 4096) {
+      out->clear();
+      return false;
+    }
+    entry.params.resize(static_cast<size_t>(param_count) * 2);
+    if (param_count != 0 &&
+        !file.read(reinterpret_cast<char *>(entry.params.data()),
+                   static_cast<std::streamsize>(entry.params.size() *
+                                                sizeof(uint64_t)))
+             .good()) {
+      out->clear();
+      return false;
+    }
+    out->push_back(std::move(entry));
+  }
+  return !out->empty();
+}
+
+void lupine_kernel_table_cache_store(
+    const unsigned char *image, size_t size, uint32_t driver_version,
+    const std::vector<lupine_kernel_table_entry> &table) {
+  std::string path = kernel_table_cache_path(image, size, driver_version);
+  if (path.empty() || table.empty() ||
+      !make_directories(kernel_table_cache_dir())) {
+    return;
+  }
+  std::string temporary =
+      path + ".tmp." + std::to_string(static_cast<long>(getpid()));
+  {
+    std::ofstream file(temporary, std::ios::binary | std::ios::trunc);
+    if (!file) {
+      return;
+    }
+    file.write(kKernelTableMagic, sizeof(kKernelTableMagic));
+    write_pod(file, static_cast<uint32_t>(table.size()));
+    for (const auto &entry : table) {
+      write_pod(file, static_cast<uint32_t>(entry.name.size()));
+      file.write(entry.name.data(),
+                 static_cast<std::streamsize>(entry.name.size()));
+      write_pod(file, static_cast<uint32_t>(entry.params.size() / 2));
+      file.write(
+          reinterpret_cast<const char *>(entry.params.data()),
+          static_cast<std::streamsize>(entry.params.size() * sizeof(uint64_t)));
+    }
+    file.flush();
+    if (!file) {
+      file.close();
+      remove(temporary.c_str());
+      return;
+    }
+  }
+  if (rename(temporary.c_str(), path.c_str()) != 0) {
+    remove(temporary.c_str());
+  }
+}
 
 bool lupine_current_context_device_cache_lookup(CUcontext context,
                                                 CUdevice *device) {

--- a/cache.h
+++ b/cache.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 struct lupine_kernel_param_layout {
@@ -12,6 +13,24 @@ struct lupine_kernel_param_layout {
   std::vector<size_t> offsets;
   std::vector<size_t> sizes;
 };
+
+struct lupine_kernel_table_entry {
+  std::string name;
+  // One offset/size pair per kernel parameter.
+  std::vector<uint64_t> params;
+};
+
+// A library image's kernel names and parameter layouts, persisted across runs
+// so the next load can answer cuLibraryGetKernel and the parameter walk before
+// the server's response arrives. Handles are per-load and never stored; only
+// what the image itself fixes. The file is a hint that the response overrides,
+// keyed by image bytes and the server's driver version.
+bool lupine_kernel_table_cache_load(
+    const unsigned char *image, size_t size, uint32_t driver_version,
+    std::vector<lupine_kernel_table_entry> *out);
+void lupine_kernel_table_cache_store(
+    const unsigned char *image, size_t size, uint32_t driver_version,
+    const std::vector<lupine_kernel_table_entry> &table);
 
 bool lupine_current_context_device_cache_lookup(CUcontext context,
                                                 CUdevice *device);

--- a/client.cpp
+++ b/client.cpp
@@ -52,6 +52,7 @@
 #include "client_routing.h"
 #include "codegen/gen_api.h"
 #include "codegen/gen_client.h"
+#include "handles.h"
 #include "ipc.h"
 #include "lupine_attr_sizes.h"
 #include "lupine_fatbin.h"
@@ -3837,8 +3838,65 @@ extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn) {
   return 0;
 }
 
+namespace {
+
+struct lupine_pending_event_create {
+  uintptr_t synthetic;
+};
+
+// Runs on the reader thread, so it touches nothing but the handle table: any
+// lock a wrapper can hold across a round trip would deadlock here, because
+// this thread is the one that delivers that round trip's response.
+int lupine_fulfill_event_create(conn_t *conn, void *context) {
+  auto *pending = static_cast<lupine_pending_event_create *>(context);
+  CUevent event = nullptr;
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  int status = 0;
+  if (conn == nullptr || rpc_read(conn, &event, sizeof(event)) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0) {
+    status = -1;
+  }
+  if (status < 0 || result != CUDA_SUCCESS) {
+    event = nullptr;
+  }
+  lupine_handle_fulfill(LUPINE_HANDLE_EVENT, pending->synthetic,
+                        reinterpret_cast<uintptr_t>(event));
+  delete pending;
+  return status;
+}
+
+} // namespace
+
+extern "C" int lupine_handle_defer_event_create(conn_t *conn,
+                                                uintptr_t synthetic) {
+  auto *pending = new lupine_pending_event_create{synthetic};
+  if (rpc_write_end_deferred(conn, lupine_fulfill_event_create, pending) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+extern "C" CUevent lupine_handle_resolve_event(CUevent event) {
+  uintptr_t synthetic = reinterpret_cast<uintptr_t>(event);
+  if (!lupine_handle_is_synthetic(synthetic)) {
+    return event;
+  }
+  lupine_route route = lupine_route_for_event(event);
+  auto real = reinterpret_cast<CUevent>(
+      lupine_handle_resolve(LUPINE_HANDLE_EVENT, synthetic));
+  if (real != nullptr) {
+    lupine_note_event_owner_route(real, route);
+  }
+  return real;
+}
+
 extern "C" CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
                                       unsigned int Flags) {
+  CUevent hEvent_rpc = lupine_handle_resolve_event(hEvent);
+  if (hEvent != nullptr && hEvent_rpc == nullptr) {
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  hEvent = hEvent_rpc;
   lupine_route route = hStream == nullptr ? lupine_route_for_default()
                                           : lupine_route_for_stream(hStream);
   lupine_route event_route = lupine_route_for_event(hEvent);

--- a/client.cpp
+++ b/client.cpp
@@ -144,6 +144,9 @@ lupine_read_kernel_param_layout(CUkernel kernel,
                                 lupine_kernel_param_layout *layout);
 static CUresult lupine_warm_func_param_info(CUfunction function);
 static CUresult lupine_warm_kernel_param_info(CUkernel kernel);
+static CUresult lupine_library_get_kernel_remote(CUkernel *pKernel,
+                                                 CUlibrary library,
+                                                 const char *name);
 
 struct lupine_graph_kernel_node_params_storage {
   CUDA_KERNEL_NODE_PARAMS params = {};
@@ -495,6 +498,37 @@ lupine_library_kernel_names() {
   return *cache;
 }
 
+// A kernel synthetic is minted from the library synthetic that owns it plus
+// the name, so it can be resolved later even if the library's kernel table
+// turns out not to list that name.
+struct lupine_synthetic_kernel_record {
+  uintptr_t library = 0;
+  std::string name;
+};
+
+static libcuckoo::cuckoohash_map<uintptr_t, lupine_synthetic_kernel_record> &
+lupine_synthetic_kernels() {
+  static auto *records =
+      new libcuckoo::cuckoohash_map<uintptr_t,
+                                    lupine_synthetic_kernel_record>();
+  return *records;
+}
+
+static uintptr_t lupine_kernel_synthetic_for(uintptr_t library,
+                                             const std::string &name) {
+  uintptr_t synthetic =
+      lupine_handle_mint_named(LUPINE_HANDLE_KERNEL, library, name.c_str());
+  if (synthetic == 0) {
+    return 0;
+  }
+  lupine_synthetic_kernels().insert_or_assign(
+      synthetic, lupine_synthetic_kernel_record{library, name});
+  lupine_note_function_owner_route(
+      reinterpret_cast<CUfunction>(synthetic),
+      lupine_route_for_library(reinterpret_cast<CUlibrary>(library)));
+  return synthetic;
+}
+
 static std::mutex &lupine_host_function_mutex() {
   static auto *mutex = new std::mutex();
   return *mutex;
@@ -565,7 +599,7 @@ static int lupine_connect_endpoint(conn_t *conn,
       lupine_tcp_connect(endpoint.host.c_str(), endpoint.port.c_str());
   if (sockfd == LUPINE_INVALID_SOCKET) {
     LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
-                     << endpoint.port << " failed");
+                                      << endpoint.port << " failed");
     return -1;
   }
 
@@ -949,15 +983,47 @@ extern "C" CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
   // Served from the kernel table piggybacked on the cuLibraryLoadData
   // response; ownership recording and param-info warming already happened at
   // prefill time.
+  lupine_library_kernel_name_key key{library, std::string(name)};
   CUkernel cached = nullptr;
-  if (lupine_library_kernel_names().find(
-          lupine_library_kernel_name_key{library, std::string(name)},
-          cached)) {
+  if (lupine_library_kernel_names().find(key, cached)) {
     *pKernel = cached;
     return CUDA_SUCCESS;
   }
+  // A load still in flight has no authoritative name list yet, so hand back a
+  // synthetic and let the response decide whether the name exists.
+  uintptr_t synthetic = reinterpret_cast<uintptr_t>(library);
+  uintptr_t loaded = 0;
+  if (lupine_handle_family_of(synthetic) == LUPINE_HANDLE_LIBRARY &&
+      !lupine_handle_try_resolve(LUPINE_HANDLE_LIBRARY, synthetic, &loaded)) {
+    uintptr_t kernel = lupine_kernel_synthetic_for(synthetic, key.name);
+    if (kernel == 0) {
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    *pKernel = reinterpret_cast<CUkernel>(kernel);
+    return CUDA_SUCCESS;
+  }
+  CUlibrary resolved = lupine_handle_resolve_library(library);
+  if (resolved == nullptr) {
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  if (lupine_library_kernel_names().find(key, cached)) {
+    *pKernel = cached;
+    return CUDA_SUCCESS;
+  }
+  return_value = lupine_library_get_kernel_remote(pKernel, resolved, name);
+  if (return_value == CUDA_SUCCESS) {
+    lupine_library_kernel_names().insert_or_assign(key, *pKernel);
+  }
+  return return_value;
+}
+
+static CUresult lupine_library_get_kernel_remote(CUkernel *pKernel,
+                                                 CUlibrary library,
+                                                 const char *name) {
+  lupine_route route = lupine_route_for_library(library);
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
+  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
@@ -968,7 +1034,7 @@ extern "C" CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  if (return_value == CUDA_SUCCESS && pKernel != nullptr) {
+  if (return_value == CUDA_SUCCESS && *pKernel != nullptr) {
     return_value = lupine_record_library_kernel(*pKernel, library, name, route);
   }
   return return_value;
@@ -1255,6 +1321,14 @@ static CUresult lupine_resolve_library_kernel_for_route(CUfunction function,
                                                         CUfunction *resolved) {
   if (resolved == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (lupine_handle_family_of(reinterpret_cast<uintptr_t>(function)) ==
+      LUPINE_HANDLE_KERNEL) {
+    function = reinterpret_cast<CUfunction>(
+        lupine_handle_resolve_kernel(reinterpret_cast<CUkernel>(function)));
+    if (function == nullptr) {
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
   }
   *resolved = function;
   int route_id = lupine_route_identity(route);
@@ -1576,6 +1650,11 @@ static CUfunction lupine_resolve_host_function(CUfunction function) {
 }
 
 static CUfunction lupine_translate_private_function(CUfunction function) {
+  if (lupine_handle_family_of(reinterpret_cast<uintptr_t>(function)) ==
+      LUPINE_HANDLE_KERNEL) {
+    return reinterpret_cast<CUfunction>(
+        lupine_handle_resolve_kernel(reinterpret_cast<CUkernel>(function)));
+  }
   {
     std::lock_guard<std::mutex> lock(lupine_private_node_mutex());
     auto it = lupine_private_node_map().find(function);
@@ -1675,7 +1754,8 @@ static bool lupine_device_attribute_is_virtualized(CUdevice_attribute attrib) {
 // instead of one per query. Attempted once per connection; on any failure the
 // per-call RPC paths still work, so this is purely best-effort.
 static void lupine_prefill_device_snapshot(conn_t *conn) {
-  if (conn == nullptr || !lupine_device_snapshot_attempts().insert(conn, true)) {
+  if (conn == nullptr ||
+      !lupine_device_snapshot_attempts().insert(conn, true)) {
     return;
   }
   CUresult result = CUDA_ERROR_UNKNOWN;
@@ -1922,8 +2002,7 @@ extern "C" CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUcontext *, CUdevice);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuDevicePrimaryCtxRetain", &return_value, pctx,
-          remote_dev)) {
+          route, "cuDevicePrimaryCtxRetain", &return_value, pctx, remote_dev)) {
     if (return_value == CUDA_SUCCESS && pctx != nullptr) {
       lupine_note_context_owner_route(*pctx, route);
     }
@@ -2004,9 +2083,8 @@ extern "C" CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev,
   return return_value;
 }
 
-extern "C" CUresult cuDevicePrimaryCtxGetState(CUdevice dev,
-                                               unsigned int *flags,
-                                               int *active) {
+extern "C" CUresult
+cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags, int *active) {
   CUdevice remote_dev = dev;
   lupine_route route = lupine_route_for_device(&remote_dev);
   if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE) {
@@ -2015,8 +2093,8 @@ extern "C" CUresult cuDevicePrimaryCtxGetState(CUdevice dev,
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdevice, unsigned int *, int *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuDevicePrimaryCtxGetState", &return_value, remote_dev,
-          flags, active)) {
+          route, "cuDevicePrimaryCtxGetState", &return_value, remote_dev, flags,
+          active)) {
     return return_value;
   }
   if (flags != nullptr && active != nullptr) {
@@ -2116,6 +2194,28 @@ static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
     return cached.result;
   }
 
+  // A layout the load response did not prefill has to come from the server,
+  // which only knows the real handle.
+  uintptr_t synthetic = 0;
+  if (lupine_handle_family_of(handle) == LUPINE_HANDLE_KERNEL) {
+    synthetic = handle;
+    handle = reinterpret_cast<uintptr_t>(
+        lupine_handle_resolve_kernel(reinterpret_cast<CUkernel>(handle)));
+    if (handle == 0) {
+      return CUDA_ERROR_INVALID_HANDLE;
+    }
+    key.handle = handle;
+    if (lupine_param_info_cache().find(key, cached)) {
+      lupine_param_info_cache().insert_or_assign(
+          lupine_param_info_key{synthetic, param_index, kernel}, cached);
+      if (cached.result == CUDA_SUCCESS) {
+        *param_offset = cached.offset;
+        *param_size = cached.size;
+      }
+      return cached.result;
+    }
+  }
+
   CUfunction function = reinterpret_cast<CUfunction>(handle);
   lupine_route route = lupine_route_for_function(function);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -2149,8 +2249,12 @@ static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
   }
 
   if (result == CUDA_SUCCESS || result == CUDA_ERROR_INVALID_VALUE) {
-    lupine_param_info_cache().insert_or_assign(
-        key, lupine_param_info_value{result, offset, size});
+    lupine_param_info_value value{result, offset, size};
+    lupine_param_info_cache().insert_or_assign(key, value);
+    if (synthetic != 0) {
+      lupine_param_info_cache().insert_or_assign(
+          lupine_param_info_key{synthetic, param_index, kernel}, value);
+    }
   }
   if (result == CUDA_SUCCESS) {
     *param_offset = offset;
@@ -2177,6 +2281,13 @@ extern "C" CUresult cuKernelGetFunction(CUfunction *pFunc, CUkernel kernel) {
   if (pFunc == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  // The context-specific function is only knowable from the server, so this
+  // call blocks either way and hands back the real handle.
+  CUkernel kernel_rpc = lupine_handle_resolve_kernel(kernel);
+  if (kernel != nullptr && kernel_rpc == nullptr) {
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  kernel = kernel_rpc;
   CUcontext current_context = nullptr;
   CUresult context_status = cuCtxGetCurrent(&current_context);
   if (context_status != CUDA_SUCCESS) {
@@ -2243,6 +2354,11 @@ extern "C" CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
   if (pi == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  CUkernel kernel_rpc = lupine_handle_resolve_kernel(kernel);
+  if (kernel != nullptr && kernel_rpc == nullptr) {
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  kernel = kernel_rpc;
   lupine_route route = lupine_route_for_device(&dev);
   if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE) {
     return CUDA_ERROR_INVALID_DEVICE;
@@ -2254,12 +2370,12 @@ extern "C" CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
     return CUDA_SUCCESS;
   }
 
-  using real_fn_t = CUresult (*)(int *, CUfunction_attribute, CUkernel,
-                                 CUdevice);
+  using real_fn_t =
+      CUresult (*)(int *, CUfunction_attribute, CUkernel, CUdevice);
   CUresult return_value;
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuKernelGetAttribute", &return_value, pi, attrib, kernel,
-          dev)) {
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuKernelGetAttribute",
+                                                  &return_value, pi, attrib,
+                                                  kernel, dev)) {
     if (return_value == CUDA_SUCCESS) {
       lupine_kernel_attribute_cache().insert_or_assign(key, *pi);
     }
@@ -2386,6 +2502,10 @@ static bool lupine_is_private_function(CUfunction function) {
 }
 
 static bool lupine_is_library_kernel(CUfunction function) {
+  if (lupine_handle_family_of(reinterpret_cast<uintptr_t>(function)) ==
+      LUPINE_HANDLE_KERNEL) {
+    return true;
+  }
   std::lock_guard<std::mutex> lock(lupine_library_kernel_mutex());
   return lupine_library_kernels().find(reinterpret_cast<CUkernel>(function)) !=
          lupine_library_kernels().end();
@@ -4218,6 +4338,255 @@ extern "C" CUresult cuModuleLoadDataEx(CUmodule *module, const void *image,
   return cuModuleLoadData(module, image);
 }
 
+// Everything cuLibraryLoadData needs after the fact: the request's inputs plus
+// the response's library handle and kernel table. It travels from the wrapper
+// to the reader thread and then to whichever thread first resolves the
+// library.
+struct lupine_library_load {
+  uintptr_t synthetic = 0;
+  conn_t *conn = nullptr;
+  uint32_t kind = 0;
+  const void *code = nullptr;
+  uint32_t driver_version = 0;
+  std::vector<unsigned char> image;
+  std::vector<lupine_kernel_table_entry> hint;
+  CUlibrary library = nullptr;
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  std::vector<lupine_kernel_table_entry> table;
+  std::vector<CUkernel> kernels;
+};
+
+static uint32_t lupine_server_driver_version(conn_t *conn) {
+  static auto *versions = new libcuckoo::cuckoohash_map<conn_t *, uint32_t>();
+  uint32_t cached = 0;
+  if (versions->find(conn, cached)) {
+    return cached;
+  }
+  int version = 0;
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &version, sizeof(version)) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0 ||
+      result != CUDA_SUCCESS) {
+    version = 0;
+  }
+  versions->insert_or_assign(conn, static_cast<uint32_t>(version));
+  return static_cast<uint32_t>(version);
+}
+
+static void
+lupine_prefill_kernel_param_info(uintptr_t handle,
+                                 const std::vector<uint64_t> &params) {
+  size_t count = params.size() / 2;
+  for (size_t index = 0; index < count; ++index) {
+    lupine_param_info_cache().insert_or_assign(
+        lupine_param_info_key{handle, index, true},
+        lupine_param_info_value{CUDA_SUCCESS,
+                                static_cast<size_t>(params[index * 2]),
+                                static_cast<size_t>(params[index * 2 + 1])});
+  }
+  lupine_param_info_cache().insert_or_assign(
+      lupine_param_info_key{handle, count, true},
+      lupine_param_info_value{CUDA_ERROR_INVALID_VALUE, 0, 0});
+}
+
+// Names and layouts remembered from a previous run of the same image. Minting
+// the kernel synthetics now lets cuLibraryGetKernel and the parameter walk
+// finish before the load response arrives; the response is still the
+// authority, and lupine_apply_library_load reconciles the two.
+static void lupine_prefill_library_hint(
+    uintptr_t synthetic, const std::vector<lupine_kernel_table_entry> &hint) {
+  for (const auto &entry : hint) {
+    uintptr_t kernel = lupine_kernel_synthetic_for(synthetic, entry.name);
+    if (kernel == 0) {
+      continue;
+    }
+    lupine_prefill_kernel_param_info(kernel, entry.params);
+    lupine_library_kernel_names().insert_or_assign(
+        lupine_library_kernel_name_key{reinterpret_cast<CUlibrary>(synthetic),
+                                       entry.name},
+        reinterpret_cast<CUkernel>(kernel));
+  }
+}
+
+static int lupine_read_library_load_response(
+    conn_t *conn, lupine_library_load *loaded,
+    const std::vector<rpc_jit_output_binding> &bindings) {
+  if (rpc_read(conn, &loaded->library, sizeof(CUlibrary)) < 0 ||
+      rpc_read_jit_outputs(conn, bindings) < 0) {
+    return -1;
+  }
+  uint32_t table_count = 0;
+  if (rpc_read(conn, &table_count, sizeof(table_count)) < 0) {
+    return -1;
+  }
+  for (uint32_t i = 0; i < table_count; ++i) {
+    lupine_kernel_table_entry entry;
+    CUkernel kernel = nullptr;
+    uint32_t name_length = 0;
+    uint32_t param_count = 0;
+    if (rpc_read(conn, &name_length, sizeof(name_length)) < 0 ||
+        name_length == 0 || name_length > 64 * 1024) {
+      return -1;
+    }
+    entry.name.resize(name_length);
+    if (rpc_read(conn, entry.name.data(), name_length) < 0 ||
+        rpc_read(conn, &kernel, sizeof(kernel)) < 0 ||
+        rpc_read(conn, &param_count, sizeof(param_count)) < 0) {
+      return -1;
+    }
+    entry.name.resize(name_length - 1);
+    entry.params.resize(static_cast<size_t>(param_count) * 2);
+    if (param_count != 0 &&
+        rpc_read(conn, entry.params.data(),
+                 entry.params.size() * sizeof(uint64_t)) < 0) {
+      return -1;
+    }
+    loaded->table.push_back(std::move(entry));
+    loaded->kernels.push_back(kernel);
+  }
+  return rpc_read(conn, &loaded->result, sizeof(CUresult)) < 0 ? -1 : 0;
+}
+
+// Runs on the first thread to resolve the library, never on the reader thread:
+// the routing and kernel caches it writes are held across round trips
+// elsewhere, and the reader thread is the one that delivers those.
+static void lupine_apply_library_load(uintptr_t synthetic, uintptr_t real,
+                                      void *payload, void *) {
+  std::unique_ptr<lupine_library_load> loaded(
+      static_cast<lupine_library_load *>(payload));
+  auto library = reinterpret_cast<CUlibrary>(real);
+  if (library == nullptr) {
+    lupine_handle_forget_owned(LUPINE_HANDLE_KERNEL, synthetic);
+    return;
+  }
+  lupine_route route = lupine_remote_route_for_conn(loaded->conn);
+  lupine_note_library_owner(library, loaded->conn);
+  lupine_record_library_image(library, route, loaded->kind,
+                              loaded->image.data(), loaded->image.size(),
+                              loaded->code);
+
+  std::unordered_map<std::string, const std::vector<uint64_t> *> hinted;
+  for (const auto &entry : loaded->hint) {
+    hinted.emplace(entry.name, &entry.params);
+  }
+  bool hint_matches = hinted.size() == loaded->table.size();
+  for (size_t i = 0; i < loaded->table.size(); ++i) {
+    const lupine_kernel_table_entry &entry = loaded->table[i];
+    CUkernel kernel = loaded->kernels[i];
+    if (kernel == nullptr) {
+      continue;
+    }
+    auto hint = hinted.find(entry.name);
+    if (hint == hinted.end() || *hint->second != entry.params) {
+      hint_matches = false;
+    }
+    uintptr_t kernel_synthetic =
+        lupine_kernel_synthetic_for(synthetic, entry.name);
+    lupine_prefill_kernel_param_info(reinterpret_cast<uintptr_t>(kernel),
+                                     entry.params);
+    if (kernel_synthetic != 0) {
+      lupine_prefill_kernel_param_info(kernel_synthetic, entry.params);
+    }
+    if (lupine_record_library_kernel(kernel, library, entry.name.c_str(),
+                                     route) != CUDA_SUCCESS) {
+      continue;
+    }
+    lupine_library_kernel_names().insert_or_assign(
+        lupine_library_kernel_name_key{library, entry.name}, kernel);
+    if (kernel_synthetic != 0) {
+      lupine_library_kernel_names().insert_or_assign(
+          lupine_library_kernel_name_key{reinterpret_cast<CUlibrary>(synthetic),
+                                         entry.name},
+          reinterpret_cast<CUkernel>(kernel_synthetic));
+      lupine_handle_fulfill(LUPINE_HANDLE_KERNEL, kernel_synthetic,
+                            reinterpret_cast<uintptr_t>(kernel));
+    }
+  }
+  if (!loaded->hint.empty() && !hint_matches) {
+    LUPINE_LOG_ERROR("LUPINE cached kernel table for library "
+                     << library << " disagreed with the server; using the "
+                     << "server's table");
+  }
+  if (!loaded->table.empty() && !hint_matches) {
+    lupine_kernel_table_cache_store(loaded->image.data(), loaded->image.size(),
+                                    loaded->driver_version, loaded->table);
+  }
+}
+
+extern "C" CUlibrary lupine_handle_resolve_library(CUlibrary library) {
+  uintptr_t synthetic = reinterpret_cast<uintptr_t>(library);
+  if (lupine_handle_family_of(synthetic) != LUPINE_HANDLE_LIBRARY) {
+    return library;
+  }
+  return reinterpret_cast<CUlibrary>(lupine_handle_resolve_applied(
+      LUPINE_HANDLE_LIBRARY, synthetic, lupine_apply_library_load, nullptr));
+}
+
+extern "C" CUkernel lupine_handle_resolve_kernel(CUkernel kernel) {
+  uintptr_t synthetic = reinterpret_cast<uintptr_t>(kernel);
+  if (lupine_handle_family_of(synthetic) != LUPINE_HANDLE_KERNEL) {
+    return kernel;
+  }
+  uintptr_t real = 0;
+  if (lupine_handle_try_resolve(LUPINE_HANDLE_KERNEL, synthetic, &real)) {
+    return reinterpret_cast<CUkernel>(real);
+  }
+  lupine_synthetic_kernel_record owner;
+  if (!lupine_synthetic_kernels().find(synthetic, owner)) {
+    return nullptr;
+  }
+  CUlibrary library =
+      lupine_handle_resolve_library(reinterpret_cast<CUlibrary>(owner.library));
+  if (library == nullptr) {
+    return nullptr;
+  }
+  if (lupine_handle_try_resolve(LUPINE_HANDLE_KERNEL, synthetic, &real)) {
+    return reinterpret_cast<CUkernel>(real);
+  }
+  // The name was not in the library's table, so it has to be asked for by
+  // name; an unknown name fulfills with zero and reports an invalid handle.
+  CUkernel resolved = nullptr;
+  if (lupine_library_get_kernel_remote(&resolved, library,
+                                       owner.name.c_str()) != CUDA_SUCCESS) {
+    resolved = nullptr;
+  }
+  lupine_handle_fulfill(LUPINE_HANDLE_KERNEL, synthetic,
+                        reinterpret_cast<uintptr_t>(resolved));
+  return resolved;
+}
+
+extern "C" void lupine_forget_library_synthetic(CUlibrary library) {
+  uintptr_t synthetic = reinterpret_cast<uintptr_t>(library);
+  if (lupine_handle_family_of(synthetic) != LUPINE_HANDLE_LIBRARY) {
+    return;
+  }
+  lupine_handle_forget_owned(LUPINE_HANDLE_KERNEL, synthetic);
+  delete static_cast<lupine_library_load *>(
+      lupine_handle_forget_payload(LUPINE_HANDLE_LIBRARY, synthetic));
+}
+
+static int lupine_fulfill_library_load(conn_t *conn, void *context) {
+  auto *loaded = static_cast<lupine_library_load *>(context);
+  int status = 0;
+  if (conn == nullptr ||
+      lupine_read_library_load_response(conn, loaded, {}) < 0) {
+    loaded->result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+    status = -1;
+  }
+  if (loaded->result != CUDA_SUCCESS) {
+    loaded->library = nullptr;
+  }
+  if (!lupine_handle_fulfill_payload(
+          LUPINE_HANDLE_LIBRARY, loaded->synthetic,
+          reinterpret_cast<uintptr_t>(loaded->library), loaded)) {
+    delete loaded;
+  }
+  return status;
+}
+
 extern "C" CUresult
 cuLibraryLoadData(CUlibrary *library, const void *code,
                   CUjit_option *jitOptions, void **jitOptionsValues,
@@ -4254,103 +4623,81 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
                                   libraryOptionValues, numLibraryOptions);
   }
 
+  // Output options are answered from the response, so a caller that asks for
+  // one has to wait for it; everything else gets a synthetic handle now and
+  // the real one when the response lands.
   auto bindings = lupine_capture_jit_client_bindings(numJitOptions, jitOptions,
                                                      jitOptionsValues);
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  uintptr_t synthetic = lupine_handle_mint(LUPINE_HANDLE_LIBRARY);
+  if (synthetic == 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  auto *loaded = new lupine_library_load();
+  loaded->synthetic = synthetic;
+  loaded->conn = conn;
+  loaded->kind = kind;
+  loaded->code = code;
+  loaded->driver_version = lupine_server_driver_version(conn);
+  loaded->image = std::move(image_bytes);
+  lupine_note_library_owner(reinterpret_cast<CUlibrary>(synthetic), conn);
+  if (bindings.empty() &&
+      lupine_kernel_table_cache_load(loaded->image.data(), loaded->image.size(),
+                                     loaded->driver_version, &loaded->hint)) {
+    lupine_prefill_library_hint(synthetic, loaded->hint);
+  }
+
   std::vector<uintptr_t> jit_raw_values;
   std::vector<uintptr_t> library_raw_values;
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  size_t image_size = image_bytes.size();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
+  size_t image_size = loaded->image.size();
+  if (rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
       rpc_write(conn, &kind, sizeof(kind)) < 0 ||
       rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
-      rpc_write_payload(conn, image_bytes.data(), image_size) < 0 ||
+      rpc_write_payload(conn, loaded->image.data(), image_size) < 0 ||
       rpc_write_jit_options(conn, &numJitOptions, jitOptions, jitOptionsValues,
                             &jit_raw_values) < 0 ||
       rpc_write_library_options(conn, &numLibraryOptions, libraryOptions,
-                                libraryOptionValues, &library_raw_values) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, library, sizeof(CUlibrary)) < 0 ||
-      rpc_read_jit_outputs(conn, bindings) < 0) {
+                                libraryOptionValues, &library_raw_values) < 0) {
+    delete loaded;
+    lupine_forget_library_synthetic(reinterpret_cast<CUlibrary>(synthetic));
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
 
-  // The server piggybacks the library's kernel table onto this response:
-  // names, handles, and full parameter layouts. Prefilling the param-info and
-  // name caches here means cuLibraryGetKernel and the per-kernel param walk
-  // never issue their own round trips.
-  struct lupine_wire_kernel_record {
-    std::string name;
-    CUkernel kernel = nullptr;
-    uint32_t param_count = 0;
-    std::vector<uint64_t> params;
-  };
-  uint32_t table_count = 0;
-  std::vector<lupine_wire_kernel_record> table;
-  if (rpc_read(conn, &table_count, sizeof(table_count)) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  for (uint32_t i = 0; i < table_count; ++i) {
-    lupine_wire_kernel_record record;
-    uint32_t name_len = 0;
-    if (rpc_read(conn, &name_len, sizeof(name_len)) < 0 || name_len == 0 ||
-        name_len > 64 * 1024) {
+  if (bindings.empty()) {
+    if (rpc_write_end_deferred(conn, lupine_fulfill_library_load, loaded) < 0) {
+      lupine_forget_library_synthetic(reinterpret_cast<CUlibrary>(synthetic));
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
-    record.name.resize(name_len);
-    if (rpc_read(conn, record.name.data(), name_len) < 0 ||
-        rpc_read(conn, &record.kernel, sizeof(record.kernel)) < 0 ||
-        rpc_read(conn, &record.param_count, sizeof(record.param_count)) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-    record.name.resize(name_len - 1);
-    record.params.resize(static_cast<size_t>(record.param_count) * 2);
-    if (record.param_count != 0 &&
-        rpc_read(conn, record.params.data(),
-                 record.params.size() * sizeof(uint64_t)) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-    table.push_back(std::move(record));
+    *library = reinterpret_cast<CUlibrary>(synthetic);
+    return CUDA_SUCCESS;
   }
 
-  if (rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+  if (rpc_wait_for_response(conn) < 0 ||
+      lupine_read_library_load_response(conn, loaded, bindings) < 0 ||
       rpc_read_end(conn) < 0) {
+    delete loaded;
+    lupine_forget_library_synthetic(reinterpret_cast<CUlibrary>(synthetic));
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  if (return_value == CUDA_SUCCESS) {
-    lupine_note_library_owner(*library, conn);
-    lupine_record_library_image(*library, lupine_remote_route_for_conn(conn),
-                                kind, image_bytes.data(), image_bytes.size(),
-                                code);
-    lupine_route route = lupine_remote_route_for_conn(conn);
-    for (const auto &record : table) {
-      if (record.kernel == nullptr) {
-        continue;
-      }
-      for (uint32_t index = 0; index < record.param_count; ++index) {
-        lupine_param_info_cache().insert_or_assign(
-            lupine_param_info_key{reinterpret_cast<uintptr_t>(record.kernel),
-                                  index, true},
-            lupine_param_info_value{CUDA_SUCCESS,
-                                    static_cast<size_t>(
-                                        record.params[index * 2]),
-                                    static_cast<size_t>(
-                                        record.params[index * 2 + 1])});
-      }
-      lupine_param_info_cache().insert_or_assign(
-          lupine_param_info_key{reinterpret_cast<uintptr_t>(record.kernel),
-                                record.param_count, true},
-          lupine_param_info_value{CUDA_ERROR_INVALID_VALUE, 0, 0});
-      if (lupine_record_library_kernel(record.kernel, *library,
-                                       record.name.c_str(), route) ==
-          CUDA_SUCCESS) {
-        lupine_library_kernel_names().insert_or_assign(
-            lupine_library_kernel_name_key{*library, record.name},
-            record.kernel);
-      }
-    }
+  CUresult return_value = loaded->result;
+  if (return_value != CUDA_SUCCESS) {
+    loaded->library = nullptr;
   }
+  if (!lupine_handle_fulfill_payload(
+          LUPINE_HANDLE_LIBRARY, synthetic,
+          reinterpret_cast<uintptr_t>(loaded->library), loaded)) {
+    delete loaded;
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value != CUDA_SUCCESS) {
+    lupine_forget_library_synthetic(reinterpret_cast<CUlibrary>(synthetic));
+    return return_value;
+  }
+  *library = reinterpret_cast<CUlibrary>(synthetic);
+  lupine_handle_resolve_library(*library);
   return return_value;
 }
 
@@ -6746,9 +7093,9 @@ extern "C" CUresult cuStreamIsCapturing(CUstream hStream,
                                           : lupine_route_for_default();
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUstream, CUstreamCaptureStatus *);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuStreamIsCapturing", &return_value, hStream,
-          captureStatus)) {
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamIsCapturing",
+                                                  &return_value, hStream,
+                                                  captureStatus)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -7815,6 +8162,12 @@ extern "C" CUresult cuStreamBatchMemOp(CUstream stream, unsigned int count,
 extern "C" CUresult cuKernelGetLibrary(CUlibrary *pLib, CUkernel kernel) {
   if (pLib == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
+  }
+  lupine_synthetic_kernel_record owner;
+  if (lupine_synthetic_kernels().find(reinterpret_cast<uintptr_t>(kernel),
+                                      owner)) {
+    *pLib = reinterpret_cast<CUlibrary>(owner.library);
+    return CUDA_SUCCESS;
   }
   {
     std::lock_guard<std::mutex> lock(lupine_library_kernel_mutex());

--- a/client_routing.h
+++ b/client_routing.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 #define LUPINE_CUDA_COMPAT_TYPES_ONLY
 #include "cuda_compat.h"
@@ -97,6 +98,13 @@ extern "C" void *lupine_real_cuda_symbol(const char *name);
 extern "C" bool lupine_local_cuda_symbol_if_routed(lupine_route route,
                                                    const char *symbol,
                                                    void **symbol_out);
+
+// Sends a cuEventCreate request whose response fulfills the synthetic handle
+// from the reader thread; the caller does not wait. Takes over the request
+// builder exactly like rpc_wait_for_response does.
+extern "C" int lupine_handle_defer_event_create(conn_t *conn,
+                                                uintptr_t synthetic);
+extern "C" CUevent lupine_handle_resolve_event(CUevent event);
 
 extern "C" void lupine_note_context_owner(CUcontext ctx, conn_t *conn);
 extern "C" void lupine_note_module_owner(CUmodule module, conn_t *conn);

--- a/client_routing.h
+++ b/client_routing.h
@@ -105,6 +105,9 @@ extern "C" bool lupine_local_cuda_symbol_if_routed(lupine_route route,
 extern "C" int lupine_handle_defer_event_create(conn_t *conn,
                                                 uintptr_t synthetic);
 extern "C" CUevent lupine_handle_resolve_event(CUevent event);
+extern "C" CUlibrary lupine_handle_resolve_library(CUlibrary library);
+extern "C" CUkernel lupine_handle_resolve_kernel(CUkernel kernel);
+extern "C" void lupine_forget_library_synthetic(CUlibrary library);
 
 extern "C" void lupine_note_context_owner(CUcontext ctx, conn_t *conn);
 extern "C" void lupine_note_module_owner(CUmodule module, conn_t *conn);

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2657,7 +2657,7 @@ CUresult cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId);
 CUresult cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev);
 /**
  * @param pHandle SEND_RECV
- * @param event SEND_ONLY
+ * @param event SEND_ONLY HANDLE:EVENT
  */
 CUresult cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event);
 /**
@@ -3405,7 +3405,7 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx);
  * @disabled - manual client handles cross-server event waits
  * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
- * @param hEvent SEND_ONLY
+ * @param hEvent SEND_ONLY HANDLE:EVENT
  * @param Flags SEND_ONLY
  */
 CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
@@ -3523,6 +3523,7 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
                               const CUstreamAttrValue *value);
 /**
  * @routingkey CURRENT_CONTEXT
+ * @handlecreate EVENT phEvent
  * @recordowner EVENT phEvent
  * @param phEvent SEND_RECV
  * @param Flags SEND_ONLY
@@ -3530,13 +3531,13 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
 CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags);
 /**
  * @routingkey STREAM hStream
- * @param hEvent SEND_ONLY
+ * @param hEvent SEND_ONLY HANDLE:EVENT
  * @param hStream SEND_ONLY
  */
 CUresult cuEventRecord(CUevent hEvent, CUstream hStream);
 /**
  * @routingkey STREAM hStream
- * @param hEvent SEND_ONLY
+ * @param hEvent SEND_ONLY HANDLE:EVENT
  * @param hStream SEND_ONLY
  * @param flags SEND_ONLY
  */
@@ -3546,25 +3547,25 @@ CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
  * @disabled server
  * @synchronize DEFERRED_DTOH
  * @routingkey EVENT hEvent
- * @param hEvent SEND_ONLY
+ * @param hEvent SEND_ONLY HANDLE:EVENT
  */
 CUresult cuEventQuery(CUevent hEvent);
 /**
  * @disabled server
  * @synchronize DEFERRED_DTOH STDOUT
  * @routingkey EVENT hEvent
- * @param hEvent SEND_ONLY
+ * @param hEvent SEND_ONLY HANDLE:EVENT
  */
 CUresult cuEventSynchronize(CUevent hEvent);
 /**
  * @routingkey EVENT hEvent
- * @param hEvent SEND_ONLY
+ * @param hEvent SEND_ONLY HANDLE:EVENT
  */
 CUresult cuEventDestroy_v2(CUevent hEvent);
 /**
  * @param pMilliseconds SEND_RECV
- * @param hStart SEND_ONLY
- * @param hEnd SEND_ONLY
+ * @param hStart SEND_ONLY HANDLE:EVENT
+ * @param hEnd SEND_ONLY HANDLE:EVENT
  */
 CUresult cuEventElapsedTime(float *pMilliseconds, CUevent hStart, CUevent hEnd);
 /**
@@ -3970,7 +3971,7 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
  * @param dependencies SEND_ONLY LENGTH:numDependencies
- * @param event SEND_ONLY
+ * @param event SEND_ONLY HANDLE:EVENT
  */
 CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                    const CUgraphNode *dependencies,
@@ -3982,7 +3983,7 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out);
 /**
  * @param hNode SEND_ONLY
- * @param event SEND_ONLY
+ * @param event SEND_ONLY HANDLE:EVENT
  */
 CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event);
 /**
@@ -3991,7 +3992,7 @@ CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event);
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
  * @param dependencies SEND_ONLY LENGTH:numDependencies
- * @param event SEND_ONLY
+ * @param event SEND_ONLY HANDLE:EVENT
  */
 CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                  const CUgraphNode *dependencies,
@@ -4003,7 +4004,7 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out);
 /**
  * @param hNode SEND_ONLY
- * @param event SEND_ONLY
+ * @param event SEND_ONLY HANDLE:EVENT
  */
 CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event);
 /**
@@ -4303,14 +4304,14 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec,
 /**
  * @param hGraphExec SEND_ONLY
  * @param hNode SEND_ONLY
- * @param event SEND_ONLY
+ * @param event SEND_ONLY HANDLE:EVENT
  */
 CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
                                             CUgraphNode hNode, CUevent event);
 /**
  * @param hGraphExec SEND_ONLY
  * @param hNode SEND_ONLY
- * @param event SEND_ONLY
+ * @param event SEND_ONLY HANDLE:EVENT
  */
 CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec,
                                           CUgraphNode hNode, CUevent event);

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2461,14 +2461,14 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
  * @disabled server - manual server keeps the library loaded, see the handler
  * @async
  * @routingkey LIBRARY library
- * @param library SEND_ONLY
+ * @param library SEND_ONLY HANDLE:LIBRARY
  */
 CUresult cuLibraryUnload(CUlibrary library);
 /**
  * @disabled client - manual client serves the library kernel table
  * @routingkey LIBRARY library
  * @param pKernel RECV_ONLY
- * @param library SEND_ONLY
+ * @param library SEND_ONLY HANDLE:LIBRARY
  * @param name SEND_ONLY NULL_TERMINATED
  */
 CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
@@ -2477,25 +2477,25 @@ CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
  * @routingkey LIBRARY library
  * @recordowner MODULE pMod
  * @param pMod RECV_ONLY
- * @param library SEND_ONLY
+ * @param library SEND_ONLY HANDLE:LIBRARY
  */
 CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library);
 /**
  * @disabled client - manual client caches functions per kernel and context
  * @param pFunc RECV_ONLY
- * @param kernel SEND_ONLY
+ * @param kernel SEND_ONLY HANDLE:KERNEL
  */
 CUresult cuKernelGetFunction(CUfunction *pFunc, CUkernel kernel);
 /**
  * @disabled client
  * @param pLib RECV_ONLY
- * @param kernel SEND_ONLY
+ * @param kernel SEND_ONLY HANDLE:KERNEL
  */
 CUresult cuKernelGetLibrary(CUlibrary *pLib, CUkernel kernel);
 /**
  * @disabled client - manual client caches the parameter layout per kernel
  * @routingkey FUNCTION kernel
- * @param kernel SEND_ONLY
+ * @param kernel SEND_ONLY HANDLE:KERNEL
  * @param paramIndex SEND_ONLY
  * @param paramOffset RECV_ONLY
  * @param paramSize RECV_ONLY
@@ -2517,7 +2517,7 @@ CUresult cuFuncGetParamInfo(CUfunction func, size_t paramIndex,
  * @recordowner DEVICEPTR dptr
  * @param dptr RECV_ONLY NULLABLE
  * @param bytes RECV_ONLY NULLABLE
- * @param library SEND_ONLY
+ * @param library SEND_ONLY HANDLE:LIBRARY
  * @param name SEND_ONLY NULL_TERMINATED
  */
 CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
@@ -2527,7 +2527,7 @@ CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
  * @recordowner DEVICEPTR dptr
  * @param dptr RECV_ONLY NULLABLE
  * @param bytes RECV_ONLY NULLABLE
- * @param library SEND_ONLY
+ * @param library SEND_ONLY HANDLE:LIBRARY
  * @param name SEND_ONLY NULL_TERMINATED
  */
 CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
@@ -2535,7 +2535,7 @@ CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
 /**
  * @routingkey LIBRARY library
  * @param fptr RECV_ONLY
- * @param library SEND_ONLY
+ * @param library SEND_ONLY HANDLE:LIBRARY
  * @param symbol SEND_ONLY NULL_TERMINATED
  */
 CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
@@ -2544,7 +2544,7 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
  * @disabled client - manual client caches attributes per kernel and device
  * @param pi SEND_RECV
  * @param attrib SEND_ONLY
- * @param kernel SEND_ONLY
+ * @param kernel SEND_ONLY HANDLE:KERNEL
  * @param dev SEND_ONLY
  */
 CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
@@ -2552,13 +2552,13 @@ CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
 /**
  * @param attrib SEND_ONLY
  * @param val SEND_ONLY
- * @param kernel SEND_ONLY
+ * @param kernel SEND_ONLY HANDLE:KERNEL
  * @param dev SEND_ONLY
  */
 CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
                               CUkernel kernel, CUdevice dev);
 /**
- * @param kernel SEND_ONLY
+ * @param kernel SEND_ONLY HANDLE:KERNEL
  * @param config SEND_ONLY
  * @param dev SEND_ONLY
  */

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -32,9 +32,13 @@ from ops import (
 # know what a family's handles are.
 HANDLE_FAMILIES = {
     "EVENT": "LUPINE_HANDLE_EVENT",
+    "LIBRARY": "LUPINE_HANDLE_LIBRARY",
+    "KERNEL": "LUPINE_HANDLE_KERNEL",
 }
 HANDLE_RESOLVERS = {
     "EVENT": "lupine_handle_resolve_event",
+    "LIBRARY": "lupine_handle_resolve_library",
+    "KERNEL": "lupine_handle_resolve_kernel",
 }
 HANDLE_CREATORS = {
     "EVENT": "lupine_handle_defer_event_create",
@@ -884,6 +888,8 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
         f.write("    if (return_value == CUDA_SUCCESS) lupine_forget_stream_owner(hStream);\n")
     if function.name.format() == "cuEventDestroy_v2":
         f.write("    if (return_value == CUDA_SUCCESS) lupine_handle_forget(LUPINE_HANDLE_EVENT, (uintptr_t)hEvent);\n")
+    if function.name.format() == "cuLibraryUnload":
+        f.write("    if (return_value == CUDA_SUCCESS) lupine_forget_library_synthetic(library);\n")
     # Record the global's size so offset pointers into it route by range.
     if function.name.format() in {"cuModuleGetGlobal_v2", "cuLibraryGetGlobal", "cuLibraryGetManaged"}:
         f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr && bytes != nullptr) lupine_note_deviceptr_allocation_route(*dptr, *bytes, route);\n")
@@ -902,7 +908,7 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
     if function.name.format() in KERNEL_PARAM_LAYOUT_INVALIDATORS:
         f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_function_caches();\n")
     if function.name.format() == "cuKernelSetAttribute":
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel, (int)attrib, (int)dev);\n")
+        f.write("    if (return_value == CUDA_SUCCESS) lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel_rpc, (int)attrib, (int)dev);\n")
     if function.name.format() == "cuFuncSetAttribute":
         f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_kernel_attribute_cache();\n")
     if function.name.format() == "cuModuleGetFunction":

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -21,9 +21,24 @@ from ops import (
     CrossServerCopyAnnotation,
     DevicePtrTranslationAnnotation,
     FunctionAnnotationMetadata,
+    HandleCreateAnnotation,
+    HandleResolveAnnotation,
     RoutingFallbackAnnotation,
     SynchronizeAnnotation,
 )
+
+# Synthetic handle families and the client glue that mints, resolves and
+# forgets them. The handle table itself is type blind; only these entry points
+# know what a family's handles are.
+HANDLE_FAMILIES = {
+    "EVENT": "LUPINE_HANDLE_EVENT",
+}
+HANDLE_RESOLVERS = {
+    "EVENT": "lupine_handle_resolve_event",
+}
+HANDLE_CREATORS = {
+    "EVENT": "lupine_handle_defer_event_create",
+}
 
 # this table is manually generated from the cuda.h headers
 MANUAL_REMAPPINGS = [
@@ -329,6 +344,15 @@ def parse_annotation(
                 parameter=annotation_param(params, parts[2]),
             )
             continue
+        if line.startswith("@handlecreate"):
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            metadata.handle_create = HandleCreateAnnotation(
+                parameter=annotation_param(params, parts[2]),
+                family=parts[1].upper(),
+            )
+            continue
         if line.startswith("@recordowner"):
             parts = line.split()
             if len(parts) < 3:
@@ -375,6 +399,13 @@ def parse_annotation(
             if "TRANSLATE_DEVICEPTR" in args:
                 metadata.translate_deviceptrs.append(
                     DevicePtrTranslationAnnotation(parameter=param)
+                )
+            handle_arg = next((arg for arg in args if arg.startswith("HANDLE:")), None)
+            if handle_arg is not None:
+                metadata.resolve_handles.append(
+                    HandleResolveAnnotation(
+                        parameter=param, family=handle_arg.split(":", 1)[1].upper()
+                    )
                 )
             # if there's a length or size arg, use the type, otherwise use the ptr_to type
             length_arg = next((arg for arg in args if arg.startswith("LENGTH:")), None)
@@ -681,8 +712,14 @@ def client_translated_deviceptr_names(
     return {translation.parameter.name for translation in metadata.translate_deviceptrs}
 
 
+def client_resolved_handle_names(metadata: FunctionAnnotationMetadata) -> set[str]:
+    return {handle.parameter.name for handle in metadata.resolve_handles}
+
+
 def client_param_expr(metadata: FunctionAnnotationMetadata, param: Parameter) -> str:
     if param.name in client_translated_deviceptr_names(metadata):
+        return f"{param.name}_rpc"
+    if param.name in client_resolved_handle_names(metadata):
         return f"{param.name}_rpc"
     return param.name
 
@@ -746,6 +783,29 @@ def client_call_args(function: Function, metadata: FunctionAnnotationMetadata) -
 
 
 def write_client_rpc_write(f, operation: Operation, metadata: FunctionAnnotationMetadata):
+    if (
+        metadata.handle_create is not None
+        and operation.parameter.name == metadata.handle_create.parameter.name
+    ):
+        f.write(
+            "        rpc_write(conn, &{param_name}_rpc, sizeof({param_type})) < 0 ||\n".format(
+                param_name=operation.parameter.name,
+                param_type=metadata.handle_create.parameter.type.ptr_to.format(),
+            )
+        )
+        return
+    if (
+        isinstance(operation, OpaqueTypeOperation)
+        and operation.send
+        and operation.parameter.name in client_resolved_handle_names(metadata)
+    ):
+        f.write(
+            "        rpc_write(conn, &{param_name}_rpc, sizeof({param_type})) < 0 ||\n".format(
+                param_name=operation.parameter.name,
+                param_type=operation.type_.format(),
+            )
+        )
+        return
     if (
         isinstance(operation, OpaqueTypeOperation)
         and operation.send
@@ -822,6 +882,8 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
         f.write("    if (return_value == CUDA_SUCCESS) lupine_forget_deviceptr_owner(dptr);\n")
     if function.name.format() == "cuStreamDestroy_v2":
         f.write("    if (return_value == CUDA_SUCCESS) lupine_forget_stream_owner(hStream);\n")
+    if function.name.format() == "cuEventDestroy_v2":
+        f.write("    if (return_value == CUDA_SUCCESS) lupine_handle_forget(LUPINE_HANDLE_EVENT, (uintptr_t)hEvent);\n")
     # Record the global's size so offset pointers into it route by range.
     if function.name.format() in {"cuModuleGetGlobal_v2", "cuLibraryGetGlobal", "cuLibraryGetManaged"}:
         f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr && bytes != nullptr) lupine_note_deviceptr_allocation_route(*dptr, *bytes, route);\n")
@@ -1161,6 +1223,102 @@ def validate_async_annotation(
             )
 
 
+def validate_handle_annotations(
+    function: Function, metadata: FunctionAnnotationMetadata
+) -> None:
+    name = function.name.format()
+    return_type = function.return_type.format()
+    for handle in metadata.resolve_handles:
+        if handle.family not in HANDLE_FAMILIES:
+            raise RuntimeError(f"{name}: unknown handle family {handle.family}")
+        if return_type != "CUresult":
+            raise RuntimeError(
+                f"{name}: HANDLE params require a CUresult return type, "
+                f"got {return_type}"
+            )
+        if isinstance(handle.parameter.type, (Pointer, Array)):
+            raise RuntimeError(
+                f"{name}: HANDLE param {handle.parameter.name} must be passed by value"
+            )
+        operation = next(
+            (
+                op
+                for op in metadata.operations
+                if op.parameter.name == handle.parameter.name
+            ),
+            None,
+        )
+        if not isinstance(operation, OpaqueTypeOperation) or not operation.send:
+            raise RuntimeError(
+                f"{name}: HANDLE param {handle.parameter.name} must be SEND_ONLY"
+            )
+    create = metadata.handle_create
+    if create is None:
+        return
+    if create.family not in HANDLE_FAMILIES:
+        raise RuntimeError(f"{name}: unknown handle family {create.family}")
+    if return_type != "CUresult":
+        raise RuntimeError(
+            f"{name}: @handlecreate requires a CUresult return type, got {return_type}"
+        )
+    if metadata.async_fire_forget:
+        raise RuntimeError(
+            f"{name}: @handlecreate needs the response that @async suppresses"
+        )
+    if not isinstance(create.parameter.type, Pointer):
+        raise RuntimeError(
+            f"{name}: @handlecreate parameter {create.parameter.name} must be a pointer"
+        )
+    operation = next(
+        (
+            op
+            for op in metadata.operations
+            if op.parameter.name == create.parameter.name
+        ),
+        None,
+    )
+    if not isinstance(operation, DereferenceOperation) or not operation.recv:
+        raise RuntimeError(
+            f"{name}: @handlecreate parameter {create.parameter.name} must be received"
+        )
+
+
+def write_client_handle_create(f, function, operations, metadata):
+    create = metadata.handle_create
+    name = function.name.format()
+    param_name = create.parameter.name
+    handle_type = create.parameter.type.ptr_to.format()
+    family = HANDLE_FAMILIES[create.family]
+    f.write(f"    if ({param_name} == nullptr)\n")
+    f.write("        return CUDA_ERROR_INVALID_VALUE;\n")
+    f.write(f"    {handle_type} {param_name}_rpc = nullptr;\n")
+    f.write(
+        f"    uintptr_t {param_name}_synthetic = lupine_handle_mint({family});\n"
+    )
+    f.write(
+        "    if (conn == nullptr ||\n"
+        f"        rpc_write_start_request(conn, RPC_{name}) < 0 ||\n"
+    )
+    for operation in operations:
+        write_client_rpc_write(f, operation, metadata)
+    f.write(
+        f"        {HANDLE_CREATORS[create.family]}(conn, {param_name}_synthetic) < 0) {{\n"
+    )
+    f.write(f"        lupine_handle_forget({family}, {param_name}_synthetic);\n")
+    f.write(
+        "        return {error_return};\n".format(
+            error_return=error_const(function.return_type.format())
+        )
+    )
+    f.write("    }\n")
+    f.write(
+        f"    *{param_name} = ({handle_type}){param_name}_synthetic;\n"
+    )
+    f.write("    return_value = CUDA_SUCCESS;\n")
+    write_client_post_call(f, function, metadata)
+    f.write("    return return_value;\n")
+
+
 def main():
     options = ParserOptions(
         preprocessor=make_gcc_preprocessor(
@@ -1211,6 +1369,7 @@ def main():
             print(f"Error parsing annotation for {function.name}: {e}")
             continue
         validate_async_annotation(function, metadata)
+        validate_handle_annotations(function, metadata)
         functions_with_annotations.append(
             (function, annotation, metadata.operations, metadata)
         )
@@ -1289,6 +1448,7 @@ def main():
             "#include <vector>\n\n"
             '#include "gen_api.h"\n\n'
             '#include "client_routing.h"\n'
+            '#include "handles.h"\n'
             '#include "rpc.h"\n\n'
             "extern int rpc_size();\n"
             "extern conn_t *rpc_client_get_connection(unsigned int index);\n"
@@ -1366,6 +1526,22 @@ def main():
                     "        return lupine_sync_result;\n"
                     "    }\n"
                 )
+
+            for handle in metadata.resolve_handles:
+                handle_name = handle.parameter.name
+                f.write(
+                    "    {type} {name}_rpc = {resolver}({name});\n".format(
+                        type=handle.parameter.type.format(),
+                        name=handle_name,
+                        resolver=HANDLE_RESOLVERS[handle.family],
+                    )
+                )
+                f.write(
+                    "    if ({name} != nullptr && {name}_rpc == nullptr)\n".format(
+                        name=handle_name
+                    )
+                )
+                f.write("        return CUDA_ERROR_INVALID_HANDLE;\n")
 
             for translation in metadata.translate_deviceptrs:
                 name = translation.parameter.name
@@ -1545,6 +1721,11 @@ def main():
                     operation.client_preflight(
                         f, invalid_argument_const(function.return_type.format())
                     )
+
+            if metadata.handle_create is not None:
+                write_client_handle_create(f, function, operations, metadata)
+                f.write("}\n\n")
+                continue
 
             if metadata.async_fire_forget:
                 error_return = error_const(function.return_type.format())

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -876,11 +876,16 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
 }
 
 CUresult cuLibraryUnload(CUlibrary library) {
-  lupine_route route = lupine_route_for_library(library);
+  CUlibrary library_rpc = lupine_handle_resolve_library(library);
+  if (library != nullptr && library_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_library(library_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUlibrary);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryUnload",
-                                                  &return_value, library)) {
+                                                  &return_value, library_rpc)) {
+    if (return_value == CUDA_SUCCESS)
+      lupine_forget_library_synthetic(library);
     if (return_value == CUDA_SUCCESS)
       lupine_invalidate_function_caches();
     return return_value;
@@ -888,22 +893,27 @@ CUresult cuLibraryUnload(CUlibrary library) {
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
-      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
+      rpc_write(conn, &library_rpc, sizeof(CUlibrary)) < 0 ||
       rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   return_value = CUDA_SUCCESS;
+  if (return_value == CUDA_SUCCESS)
+    lupine_forget_library_synthetic(library);
   if (return_value == CUDA_SUCCESS)
     lupine_invalidate_function_caches();
   return return_value;
 }
 
 CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
-  lupine_route route = lupine_route_for_library(library);
+  CUlibrary library_rpc = lupine_handle_resolve_library(library);
+  if (library != nullptr && library_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_library(library_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUmodule *, CUlibrary);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuLibraryGetModule", &return_value, pMod, library)) {
+          route, "cuLibraryGetModule", &return_value, pMod, library_rpc)) {
     if (return_value == CUDA_SUCCESS && pMod != nullptr) {
       lupine_note_module_owner_route(*pMod, route);
     }
@@ -912,7 +922,7 @@ CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryGetModule) < 0 ||
-      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
+      rpc_write(conn, &library_rpc, sizeof(CUlibrary)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pMod, sizeof(CUmodule)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -926,13 +936,16 @@ CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
 
 CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
                             const char *name) {
-  lupine_route route = lupine_route_for_library(library);
+  CUlibrary library_rpc = lupine_handle_resolve_library(library);
+  if (library != nullptr && library_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_library(library_rpc);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUdeviceptr *, size_t *, CUlibrary, const char *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryGetGlobal",
                                                   &return_value, dptr, bytes,
-                                                  library, name)) {
+                                                  library_rpc, name)) {
     if (return_value == CUDA_SUCCESS && dptr != nullptr) {
       lupine_note_deviceptr_owner_route(*dptr, route);
     }
@@ -948,7 +961,7 @@ CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
       rpc_write_start_request(conn, RPC_cuLibraryGetGlobal) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
-      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
+      rpc_write(conn, &library_rpc, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &dptr_null_check, sizeof(CUdeviceptr *)) < 0 ||
@@ -968,13 +981,16 @@ CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
 
 CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
                              CUlibrary library, const char *name) {
-  lupine_route route = lupine_route_for_library(library);
+  CUlibrary library_rpc = lupine_handle_resolve_library(library);
+  if (library != nullptr && library_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_library(library_rpc);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUdeviceptr *, size_t *, CUlibrary, const char *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryGetManaged",
                                                   &return_value, dptr, bytes,
-                                                  library, name)) {
+                                                  library_rpc, name)) {
     if (return_value == CUDA_SUCCESS && dptr != nullptr) {
       lupine_note_deviceptr_owner_route(*dptr, route);
     }
@@ -990,7 +1006,7 @@ CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
       rpc_write_start_request(conn, RPC_cuLibraryGetManaged) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
-      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
+      rpc_write(conn, &library_rpc, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &dptr_null_check, sizeof(CUdeviceptr *)) < 0 ||
@@ -1010,19 +1026,22 @@ CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
 
 CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
                                      const char *symbol) {
-  lupine_route route = lupine_route_for_library(library);
+  CUlibrary library_rpc = lupine_handle_resolve_library(library);
+  if (library != nullptr && library_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_library(library_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(void **, CUlibrary, const char *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuLibraryGetUnifiedFunction", &return_value, fptr, library,
-          symbol)) {
+          route, "cuLibraryGetUnifiedFunction", &return_value, fptr,
+          library_rpc, symbol)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t symbol_len = std::strlen(symbol) + 1;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
-      rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
+      rpc_write(conn, &library_rpc, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &symbol_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, symbol, symbol_len) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1035,6 +1054,9 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
 
 CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
                               CUkernel kernel, CUdevice dev) {
+  CUkernel kernel_rpc = lupine_handle_resolve_kernel(kernel);
+  if (kernel != nullptr && kernel_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = lupine_route_for_device(&dev);
   if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)
     return CUDA_ERROR_INVALID_DEVICE;
@@ -1042,10 +1064,10 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
   using real_fn_t = CUresult (*)(CUfunction_attribute, int, CUkernel, CUdevice);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuKernelSetAttribute",
                                                   &return_value, attrib, val,
-                                                  kernel, dev)) {
+                                                  kernel_rpc, dev)) {
     if (return_value == CUDA_SUCCESS)
-      lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel,
-                                          (int)attrib, (int)dev);
+      lupine_kernel_attribute_cache_erase(lupine_route_identity(route),
+                                          kernel_rpc, (int)attrib, (int)dev);
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -1053,34 +1075,37 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
       rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
       rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_write(conn, &val, sizeof(int)) < 0 ||
-      rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
+      rpc_write(conn, &kernel_rpc, sizeof(CUkernel)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (return_value == CUDA_SUCCESS)
-    lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel,
-                                        (int)attrib, (int)dev);
+    lupine_kernel_attribute_cache_erase(lupine_route_identity(route),
+                                        kernel_rpc, (int)attrib, (int)dev);
   return return_value;
 }
 
 CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
                                 CUdevice dev) {
+  CUkernel kernel_rpc = lupine_handle_resolve_kernel(kernel);
+  if (kernel != nullptr && kernel_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = lupine_route_for_device(&dev);
   if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)
     return CUDA_ERROR_INVALID_DEVICE;
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUkernel, CUfunc_cache, CUdevice);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuKernelSetCacheConfig", &return_value, kernel, config,
+          route, "cuKernelSetCacheConfig", &return_value, kernel_rpc, config,
           dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuKernelSetCacheConfig) < 0 ||
-      rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
+      rpc_write(conn, &kernel_rpc, sizeof(CUkernel)) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -15,6 +15,7 @@
 #include "gen_api.h"
 
 #include "client_routing.h"
+#include "handles.h"
 #include "rpc.h"
 
 extern int rpc_size();
@@ -1275,18 +1276,21 @@ CUresult cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev) {
 }
 
 CUresult cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event) {
-  lupine_route route = lupine_route_for_event(event);
+  CUevent event_rpc = lupine_handle_resolve_event(event);
+  if (event != nullptr && event_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_event(event_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUipcEventHandle *, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuIpcGetEventHandle", &return_value, pHandle, event)) {
+          route, "cuIpcGetEventHandle", &return_value, pHandle, event_rpc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuIpcGetEventHandle) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUipcEventHandle)) < 0 ||
-      rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &event_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pHandle, sizeof(CUipcEventHandle)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3144,14 +3148,19 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  if (phEvent == nullptr)
+    return CUDA_ERROR_INVALID_VALUE;
+  CUevent phEvent_rpc = nullptr;
+  uintptr_t phEvent_synthetic = lupine_handle_mint(LUPINE_HANDLE_EVENT);
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventCreate) < 0 ||
-      rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &phEvent_rpc, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, phEvent, sizeof(CUevent)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
+      lupine_handle_defer_event_create(conn, phEvent_synthetic) < 0) {
+    lupine_handle_forget(LUPINE_HANDLE_EVENT, phEvent_synthetic);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  *phEvent = (CUevent)phEvent_synthetic;
+  return_value = CUDA_SUCCESS;
   if (return_value == CUDA_SUCCESS && phEvent != nullptr) {
     lupine_note_event_owner_route(*phEvent, route);
   }
@@ -3159,17 +3168,20 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
 }
 
 CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
+  CUevent hEvent_rpc = lupine_handle_resolve_event(hEvent);
+  if (hEvent != nullptr && hEvent_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUevent, CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuEventRecord", &return_value, hEvent, hStream)) {
+          route, "cuEventRecord", &return_value, hEvent_rpc, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &hEvent_rpc, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3180,19 +3192,22 @@ CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
 
 CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
                                 unsigned int flags) {
+  CUevent hEvent_rpc = lupine_handle_resolve_event(hEvent);
+  if (hEvent != nullptr && hEvent_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUevent, CUstream, unsigned int);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuEventRecordWithFlags", &return_value, hEvent, hStream,
+          route, "cuEventRecordWithFlags", &return_value, hEvent_rpc, hStream,
           flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &hEvent_rpc, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3207,18 +3222,21 @@ CUresult cuEventQuery(CUevent hEvent) {
   if (lupine_sync_result != CUDA_SUCCESS) {
     return lupine_sync_result;
   }
-  lupine_route route = lupine_route_for_event(hEvent);
+  CUevent hEvent_rpc = lupine_handle_resolve_event(hEvent);
+  if (hEvent != nullptr && hEvent_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_event(hEvent_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventQuery",
-                                                  &return_value, hEvent)) {
+                                                  &return_value, hEvent_rpc)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &hEvent_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3234,11 +3252,14 @@ CUresult cuEventSynchronize(CUevent hEvent) {
   if (lupine_sync_result != CUDA_SUCCESS) {
     return lupine_sync_result;
   }
-  lupine_route route = lupine_route_for_event(hEvent);
+  CUevent hEvent_rpc = lupine_handle_resolve_event(hEvent);
+  if (hEvent != nullptr && hEvent_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_event(hEvent_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventSynchronize",
-                                                  &return_value, hEvent)) {
+                                                  &return_value, hEvent_rpc)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
     return return_value;
@@ -3246,7 +3267,7 @@ CUresult cuEventSynchronize(CUevent hEvent) {
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuEventSynchronize) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &hEvent_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
       lupine_forward_remote_stdout(conn) < 0 ||
@@ -3259,40 +3280,53 @@ CUresult cuEventSynchronize(CUevent hEvent) {
 }
 
 CUresult cuEventDestroy_v2(CUevent hEvent) {
-  lupine_route route = lupine_route_for_event(hEvent);
+  CUevent hEvent_rpc = lupine_handle_resolve_event(hEvent);
+  if (hEvent != nullptr && hEvent_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_event(hEvent_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventDestroy_v2",
-                                                  &return_value, hEvent)) {
+                                                  &return_value, hEvent_rpc)) {
+    if (return_value == CUDA_SUCCESS)
+      lupine_handle_forget(LUPINE_HANDLE_EVENT, (uintptr_t)hEvent);
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &hEvent_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    lupine_handle_forget(LUPINE_HANDLE_EVENT, (uintptr_t)hEvent);
   return return_value;
 }
 
 CUresult cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart,
                                CUevent hEnd) {
-  lupine_route route = lupine_route_for_event(hStart);
+  CUevent hStart_rpc = lupine_handle_resolve_event(hStart);
+  if (hStart != nullptr && hStart_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  CUevent hEnd_rpc = lupine_handle_resolve_event(hEnd);
+  if (hEnd != nullptr && hEnd_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
+  lupine_route route = lupine_route_for_event(hStart_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(float *, CUevent, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuEventElapsedTime_v2", &return_value, pMilliseconds, hStart,
-          hEnd)) {
+          route, "cuEventElapsedTime_v2", &return_value, pMilliseconds,
+          hStart_rpc, hEnd_rpc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuEventElapsedTime_v2) < 0 ||
       rpc_write(conn, pMilliseconds, sizeof(float)) < 0 ||
-      rpc_write(conn, &hStart, sizeof(CUevent)) < 0 ||
-      rpc_write(conn, &hEnd, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &hStart_rpc, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &hEnd_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pMilliseconds, sizeof(float)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4225,13 +4259,16 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                    const CUgraphNode *dependencies,
                                    size_t numDependencies, CUevent event) {
+  CUevent event_rpc = lupine_handle_resolve_event(event);
+  if (event != nullptr && event_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
                                  size_t, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddEventRecordNode", &return_value, phGraphNode,
-          hGraph, dependencies, numDependencies, event)) {
+          hGraph, dependencies, numDependencies, event_rpc)) {
     if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
       lupine_note_graph_node_owner_route(*phGraphNode, route);
     }
@@ -4249,7 +4286,7 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       (numDependencies * sizeof(const CUgraphNode) != 0 &&
        rpc_write(conn, dependencies,
                  numDependencies * sizeof(const CUgraphNode)) < 0) ||
-      rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &event_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4284,19 +4321,22 @@ CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
 }
 
 CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event) {
+  CUevent event_rpc = lupine_handle_resolve_event(event);
+  if (event != nullptr && event_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphEventRecordNodeSetEvent", &return_value, hNode,
-          event)) {
+          event_rpc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
-      rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &event_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -4307,13 +4347,16 @@ CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event) {
 CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                  const CUgraphNode *dependencies,
                                  size_t numDependencies, CUevent event) {
+  CUevent event_rpc = lupine_handle_resolve_event(event);
+  if (event != nullptr && event_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
                                  size_t, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddEventWaitNode", &return_value, phGraphNode, hGraph,
-          dependencies, numDependencies, event)) {
+          dependencies, numDependencies, event_rpc)) {
     if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
       lupine_note_graph_node_owner_route(*phGraphNode, route);
     }
@@ -4331,7 +4374,7 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       (numDependencies * sizeof(const CUgraphNode) != 0 &&
        rpc_write(conn, dependencies,
                  numDependencies * sizeof(const CUgraphNode)) < 0) ||
-      rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &event_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4366,18 +4409,22 @@ CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
 }
 
 CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event) {
+  CUevent event_rpc = lupine_handle_resolve_event(event);
+  if (event != nullptr && event_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuGraphEventWaitNodeSetEvent", &return_value, hNode, event)) {
+          route, "cuGraphEventWaitNodeSetEvent", &return_value, hNode,
+          event_rpc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
-      rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &event_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -5265,12 +5312,15 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec,
 
 CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
                                             CUgraphNode hNode, CUevent event) {
+  CUevent event_rpc = lupine_handle_resolve_event(event);
+  if (event != nullptr && event_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphExecEventRecordNodeSetEvent", &return_value,
-          hGraphExec, hNode, event)) {
+          hGraphExec, hNode, event_rpc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -5279,7 +5329,7 @@ CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
           0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
-      rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &event_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -5289,12 +5339,15 @@ CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
 
 CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec,
                                           CUgraphNode hNode, CUevent event) {
+  CUevent event_rpc = lupine_handle_resolve_event(event);
+  if (event != nullptr && event_rpc == nullptr)
+    return CUDA_ERROR_INVALID_HANDLE;
   lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphExecEventWaitNodeSetEvent", &return_value, hGraphExec,
-          hNode, event)) {
+          hNode, event_rpc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -5302,7 +5355,7 @@ CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec,
       rpc_write_start_request(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
-      rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
+      rpc_write(conn, &event_rpc, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -1073,6 +1073,18 @@ class DevicePtrTranslationAnnotation:
 
 
 @dataclass
+class HandleResolveAnnotation:
+    parameter: Parameter
+    family: str
+
+
+@dataclass
+class HandleCreateAnnotation:
+    parameter: Parameter
+    family: str
+
+
+@dataclass
 class RoutingFallbackAnnotation:
     kind: str
     parameter: Parameter
@@ -1100,9 +1112,17 @@ class FunctionAnnotationMetadata:
     record_owners: list[OwnerAnnotation] = None
     cross_server_copy: Optional[CrossServerCopyAnnotation] = None
     translate_deviceptrs: list[DevicePtrTranslationAnnotation] = None
+    # HANDLE:<FAMILY> params carry client-minted synthetic handles that the
+    # wrapper maps back to the server's handle before marshalling.
+    resolve_handles: list[HandleResolveAnnotation] = None
+    # @handlecreate <FAMILY> <param>: the wrapper mints the handle, returns it
+    # immediately, and the response fulfills it from the reader thread.
+    handle_create: Optional[HandleCreateAnnotation] = None
 
     def __post_init__(self):
         if self.record_owners is None:
             self.record_owners = []
         if self.translate_deviceptrs is None:
             self.translate_deviceptrs = []
+        if self.resolve_handles is None:
+            self.resolve_handles = []

--- a/handles.cpp
+++ b/handles.cpp
@@ -2,6 +2,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 
 namespace {
@@ -9,6 +10,8 @@ namespace {
 struct lupine_handle_entry {
   uintptr_t real = 0;
   bool ready = false;
+  void *payload = nullptr;
+  bool applying = false;
 };
 
 struct lupine_handle_table {
@@ -17,6 +20,8 @@ struct lupine_handle_table {
   uint64_t counter = 0;
   std::unordered_map<uintptr_t, lupine_handle_entry>
       entries[LUPINE_HANDLE_FAMILY_COUNT];
+  std::unordered_map<uintptr_t, std::unordered_map<std::string, uintptr_t>>
+      named[LUPINE_HANDLE_FAMILY_COUNT];
 };
 
 lupine_handle_table &table() {
@@ -28,19 +33,7 @@ bool valid_family(lupine_handle_family family) {
   return family < LUPINE_HANDLE_FAMILY_COUNT;
 }
 
-} // namespace
-
-extern "C" bool lupine_handle_is_synthetic(uintptr_t value) {
-  return (static_cast<uint64_t>(value) & LUPINE_HANDLE_TAG_MASK) ==
-         (LUPINE_HANDLE_TAG << LUPINE_HANDLE_TAG_SHIFT);
-}
-
-extern "C" uintptr_t lupine_handle_mint(lupine_handle_family family) {
-  if (!valid_family(family)) {
-    return 0;
-  }
-  lupine_handle_table &state = table();
-  std::lock_guard<std::mutex> lock(state.mutex);
+uintptr_t mint_locked(lupine_handle_table &state, lupine_handle_family family) {
   uintptr_t synthetic =
       static_cast<uintptr_t>((LUPINE_HANDLE_TAG << LUPINE_HANDLE_TAG_SHIFT) |
                              ((static_cast<uint64_t>(family) & 0xFFull) << 40) |
@@ -49,22 +42,73 @@ extern "C" uintptr_t lupine_handle_mint(lupine_handle_family family) {
   return synthetic;
 }
 
+} // namespace
+
+extern "C" bool lupine_handle_is_synthetic(uintptr_t value) {
+  return (static_cast<uint64_t>(value) & LUPINE_HANDLE_TAG_MASK) ==
+         (LUPINE_HANDLE_TAG << LUPINE_HANDLE_TAG_SHIFT);
+}
+
+extern "C" lupine_handle_family lupine_handle_family_of(uintptr_t value) {
+  if (!lupine_handle_is_synthetic(value)) {
+    return LUPINE_HANDLE_FAMILY_COUNT;
+  }
+  auto family = static_cast<lupine_handle_family>(
+      (static_cast<uint64_t>(value) >> 40) & 0xFFull);
+  return valid_family(family) ? family : LUPINE_HANDLE_FAMILY_COUNT;
+}
+
+extern "C" uintptr_t lupine_handle_mint(lupine_handle_family family) {
+  if (!valid_family(family)) {
+    return 0;
+  }
+  lupine_handle_table &state = table();
+  std::lock_guard<std::mutex> lock(state.mutex);
+  return mint_locked(state, family);
+}
+
+extern "C" uintptr_t lupine_handle_mint_named(lupine_handle_family family,
+                                              uintptr_t owner,
+                                              const char *name) {
+  if (!valid_family(family) || name == nullptr) {
+    return 0;
+  }
+  lupine_handle_table &state = table();
+  std::lock_guard<std::mutex> lock(state.mutex);
+  auto &owned = state.named[family][owner];
+  auto existing = owned.find(name);
+  if (existing != owned.end()) {
+    return existing->second;
+  }
+  uintptr_t synthetic = mint_locked(state, family);
+  owned.emplace(name, synthetic);
+  return synthetic;
+}
+
 extern "C" void lupine_handle_fulfill(lupine_handle_family family,
                                       uintptr_t synthetic, uintptr_t real) {
+  lupine_handle_fulfill_payload(family, synthetic, real, nullptr);
+}
+
+extern "C" bool lupine_handle_fulfill_payload(lupine_handle_family family,
+                                              uintptr_t synthetic,
+                                              uintptr_t real, void *payload) {
   if (!valid_family(family)) {
-    return;
+    return false;
   }
   lupine_handle_table &state = table();
   {
     std::lock_guard<std::mutex> lock(state.mutex);
     auto entry = state.entries[family].find(synthetic);
     if (entry == state.entries[family].end()) {
-      return;
+      return false;
     }
     entry->second.real = real;
+    entry->second.payload = payload;
     entry->second.ready = true;
   }
   state.ready.notify_all();
+  return true;
 }
 
 extern "C" bool lupine_handle_try_resolve(lupine_handle_family family,
@@ -97,6 +141,13 @@ extern "C" bool lupine_handle_try_resolve(lupine_handle_family family,
 
 extern "C" uintptr_t lupine_handle_resolve(lupine_handle_family family,
                                            uintptr_t synthetic) {
+  return lupine_handle_resolve_applied(family, synthetic, nullptr, nullptr);
+}
+
+extern "C" uintptr_t lupine_handle_resolve_applied(lupine_handle_family family,
+                                                   uintptr_t synthetic,
+                                                   lupine_handle_apply_fn apply,
+                                                   void *context) {
   if (!lupine_handle_is_synthetic(synthetic) || !valid_family(family)) {
     return lupine_handle_is_synthetic(synthetic) ? 0 : synthetic;
   }
@@ -105,21 +156,72 @@ extern "C" uintptr_t lupine_handle_resolve(lupine_handle_family family,
   auto &entries = state.entries[family];
   state.ready.wait(lock, [&] {
     auto entry = entries.find(synthetic);
-    return entry == entries.end() || entry->second.ready;
+    return entry == entries.end() ||
+           (entry->second.ready && !entry->second.applying);
   });
   auto entry = entries.find(synthetic);
-  return entry == entries.end() ? 0 : entry->second.real;
+  if (entry == entries.end()) {
+    return 0;
+  }
+  if (entry->second.payload == nullptr || apply == nullptr) {
+    return entry->second.real;
+  }
+  void *payload = entry->second.payload;
+  uintptr_t real = entry->second.real;
+  entry->second.payload = nullptr;
+  entry->second.applying = true;
+  lock.unlock();
+  apply(synthetic, real, payload, context);
+  lock.lock();
+  entry = entries.find(synthetic);
+  if (entry != entries.end()) {
+    entry->second.applying = false;
+  }
+  lock.unlock();
+  state.ready.notify_all();
+  return real;
 }
 
 extern "C" void lupine_handle_forget(lupine_handle_family family,
                                      uintptr_t synthetic) {
+  lupine_handle_forget_payload(family, synthetic);
+}
+
+extern "C" void *lupine_handle_forget_payload(lupine_handle_family family,
+                                              uintptr_t synthetic) {
   if (!lupine_handle_is_synthetic(synthetic) || !valid_family(family)) {
+    return nullptr;
+  }
+  lupine_handle_table &state = table();
+  void *payload = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    auto entry = state.entries[family].find(synthetic);
+    if (entry != state.entries[family].end()) {
+      payload = entry->second.payload;
+      state.entries[family].erase(entry);
+    }
+  }
+  state.ready.notify_all();
+  return payload;
+}
+
+extern "C" void lupine_handle_forget_owned(lupine_handle_family family,
+                                           uintptr_t owner) {
+  if (!valid_family(family)) {
     return;
   }
   lupine_handle_table &state = table();
   {
     std::lock_guard<std::mutex> lock(state.mutex);
-    state.entries[family].erase(synthetic);
+    auto owned = state.named[family].find(owner);
+    if (owned == state.named[family].end()) {
+      return;
+    }
+    for (const auto &entry : owned->second) {
+      state.entries[family].erase(entry.second);
+    }
+    state.named[family].erase(owned);
   }
   state.ready.notify_all();
 }

--- a/handles.cpp
+++ b/handles.cpp
@@ -1,0 +1,125 @@
+#include "handles.h"
+
+#include <condition_variable>
+#include <mutex>
+#include <unordered_map>
+
+namespace {
+
+struct lupine_handle_entry {
+  uintptr_t real = 0;
+  bool ready = false;
+};
+
+struct lupine_handle_table {
+  std::mutex mutex;
+  std::condition_variable ready;
+  uint64_t counter = 0;
+  std::unordered_map<uintptr_t, lupine_handle_entry>
+      entries[LUPINE_HANDLE_FAMILY_COUNT];
+};
+
+lupine_handle_table &table() {
+  static lupine_handle_table instance;
+  return instance;
+}
+
+bool valid_family(lupine_handle_family family) {
+  return family < LUPINE_HANDLE_FAMILY_COUNT;
+}
+
+} // namespace
+
+extern "C" bool lupine_handle_is_synthetic(uintptr_t value) {
+  return (static_cast<uint64_t>(value) & LUPINE_HANDLE_TAG_MASK) ==
+         (LUPINE_HANDLE_TAG << LUPINE_HANDLE_TAG_SHIFT);
+}
+
+extern "C" uintptr_t lupine_handle_mint(lupine_handle_family family) {
+  if (!valid_family(family)) {
+    return 0;
+  }
+  lupine_handle_table &state = table();
+  std::lock_guard<std::mutex> lock(state.mutex);
+  uintptr_t synthetic =
+      static_cast<uintptr_t>((LUPINE_HANDLE_TAG << LUPINE_HANDLE_TAG_SHIFT) |
+                             ((static_cast<uint64_t>(family) & 0xFFull) << 40) |
+                             ((++state.counter) & 0xFFFFFFFFFFull));
+  state.entries[family][synthetic] = lupine_handle_entry{};
+  return synthetic;
+}
+
+extern "C" void lupine_handle_fulfill(lupine_handle_family family,
+                                      uintptr_t synthetic, uintptr_t real) {
+  if (!valid_family(family)) {
+    return;
+  }
+  lupine_handle_table &state = table();
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    auto entry = state.entries[family].find(synthetic);
+    if (entry == state.entries[family].end()) {
+      return;
+    }
+    entry->second.real = real;
+    entry->second.ready = true;
+  }
+  state.ready.notify_all();
+}
+
+extern "C" bool lupine_handle_try_resolve(lupine_handle_family family,
+                                          uintptr_t synthetic,
+                                          uintptr_t *real) {
+  if (real == nullptr) {
+    return false;
+  }
+  if (!lupine_handle_is_synthetic(synthetic)) {
+    *real = synthetic;
+    return true;
+  }
+  if (!valid_family(family)) {
+    *real = 0;
+    return true;
+  }
+  lupine_handle_table &state = table();
+  std::lock_guard<std::mutex> lock(state.mutex);
+  auto entry = state.entries[family].find(synthetic);
+  if (entry == state.entries[family].end()) {
+    *real = 0;
+    return true;
+  }
+  if (!entry->second.ready) {
+    return false;
+  }
+  *real = entry->second.real;
+  return true;
+}
+
+extern "C" uintptr_t lupine_handle_resolve(lupine_handle_family family,
+                                           uintptr_t synthetic) {
+  if (!lupine_handle_is_synthetic(synthetic) || !valid_family(family)) {
+    return lupine_handle_is_synthetic(synthetic) ? 0 : synthetic;
+  }
+  lupine_handle_table &state = table();
+  std::unique_lock<std::mutex> lock(state.mutex);
+  auto &entries = state.entries[family];
+  state.ready.wait(lock, [&] {
+    auto entry = entries.find(synthetic);
+    return entry == entries.end() || entry->second.ready;
+  });
+  auto entry = entries.find(synthetic);
+  return entry == entries.end() ? 0 : entry->second.real;
+}
+
+extern "C" void lupine_handle_forget(lupine_handle_family family,
+                                     uintptr_t synthetic) {
+  if (!lupine_handle_is_synthetic(synthetic) || !valid_family(family)) {
+    return;
+  }
+  lupine_handle_table &state = table();
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    state.entries[family].erase(synthetic);
+  }
+  state.ready.notify_all();
+}

--- a/handles.h
+++ b/handles.h
@@ -22,11 +22,29 @@ static constexpr uint64_t LUPINE_HANDLE_TAG_MASK = 0xFFFFull
 
 enum lupine_handle_family : uint32_t {
   LUPINE_HANDLE_EVENT = 0,
+  LUPINE_HANDLE_LIBRARY,
+  LUPINE_HANDLE_KERNEL,
   LUPINE_HANDLE_FAMILY_COUNT,
 };
 
+// Applied to the payload published with a real handle. Runs on the first
+// thread to resolve the synthetic and takes ownership of the payload.
+typedef void (*lupine_handle_apply_fn)(uintptr_t synthetic, uintptr_t real,
+                                       void *payload, void *context);
+
 // Allocates an unfulfilled synthetic handle in the given family.
 extern "C" uintptr_t lupine_handle_mint(lupine_handle_family family);
+
+// Returns the synthetic standing in for (owner, name), minting one the first
+// time the pair is seen. Applications compare the handles a lookup hands back,
+// so repeating a lookup must repeat the value.
+extern "C" uintptr_t lupine_handle_mint_named(lupine_handle_family family,
+                                              uintptr_t owner,
+                                              const char *name);
+
+// The family a synthetic was minted in, or LUPINE_HANDLE_FAMILY_COUNT for
+// anything outside the reserved range.
+extern "C" lupine_handle_family lupine_handle_family_of(uintptr_t value);
 
 // Publishes the server's handle for a synthetic. A real of 0 marks the
 // creation as failed; resolve then yields 0 and callers report
@@ -40,6 +58,21 @@ extern "C" void lupine_handle_fulfill(lupine_handle_family family,
 extern "C" uintptr_t lupine_handle_resolve(lupine_handle_family family,
                                            uintptr_t synthetic);
 
+// Publishes the server's handle together with everything else the response
+// carried. The payload is applied once, by the first resolver. Returns false
+// when the synthetic is already gone, leaving the payload with the caller.
+extern "C" bool lupine_handle_fulfill_payload(lupine_handle_family family,
+                                              uintptr_t synthetic,
+                                              uintptr_t real, void *payload);
+
+// Resolves, running apply exactly once for the payload published alongside the
+// handle. Concurrent resolvers block until that apply returns, so nothing
+// observes the real handle before the payload has been folded in.
+extern "C" uintptr_t lupine_handle_resolve_applied(lupine_handle_family family,
+                                                   uintptr_t synthetic,
+                                                   lupine_handle_apply_fn apply,
+                                                   void *context);
+
 // Non-blocking resolve. Returns false when the synthetic exists but has not
 // been fulfilled yet.
 extern "C" bool lupine_handle_try_resolve(lupine_handle_family family,
@@ -48,6 +81,15 @@ extern "C" bool lupine_handle_try_resolve(lupine_handle_family family,
 // Drops a synthetic. Anyone still blocked in resolve wakes and gets 0.
 extern "C" void lupine_handle_forget(lupine_handle_family family,
                                      uintptr_t synthetic);
+
+// Drops a synthetic and hands back a payload that was never applied, which the
+// caller then owns.
+extern "C" void *lupine_handle_forget_payload(lupine_handle_family family,
+                                              uintptr_t synthetic);
+
+// Drops every synthetic minted for owner, along with its name index.
+extern "C" void lupine_handle_forget_owned(lupine_handle_family family,
+                                           uintptr_t owner);
 
 extern "C" bool lupine_handle_is_synthetic(uintptr_t value);
 

--- a/handles.h
+++ b/handles.h
@@ -1,0 +1,54 @@
+#ifndef LUPINE_HANDLES_H
+#define LUPINE_HANDLES_H
+
+#include <cstdint>
+
+// Client-allocated stand-ins for handles the server has not returned yet. A
+// wrapper mints one, hands it straight back to the application, and the real
+// value is fulfilled later from the response; every wrapper that sends the
+// handle onward resolves it back to the server's value first. The server never
+// sees a synthetic value.
+//
+// Reserved-range invariant: a synthetic handle always carries
+// LUPINE_HANDLE_TAG in its top 16 bits. That pattern is non-canonical on
+// x86-64 (bits 63:47 are not all equal) and lies outside the AArch64 user and
+// kernel ranges, so no pointer any server can hand back can land inside the
+// reserved range. lupine_handle_is_synthetic therefore never misclassifies a
+// real handle, and mint never collides with one.
+static constexpr uint64_t LUPINE_HANDLE_TAG = 0xC0DEull;
+static constexpr unsigned LUPINE_HANDLE_TAG_SHIFT = 48;
+static constexpr uint64_t LUPINE_HANDLE_TAG_MASK = 0xFFFFull
+                                                   << LUPINE_HANDLE_TAG_SHIFT;
+
+enum lupine_handle_family : uint32_t {
+  LUPINE_HANDLE_EVENT = 0,
+  LUPINE_HANDLE_FAMILY_COUNT,
+};
+
+// Allocates an unfulfilled synthetic handle in the given family.
+extern "C" uintptr_t lupine_handle_mint(lupine_handle_family family);
+
+// Publishes the server's handle for a synthetic. A real of 0 marks the
+// creation as failed; resolve then yields 0 and callers report
+// CUDA_ERROR_INVALID_HANDLE at the point of use.
+extern "C" void lupine_handle_fulfill(lupine_handle_family family,
+                                      uintptr_t synthetic, uintptr_t real);
+
+// Returns the server's handle, blocking until it is fulfilled. Values outside
+// the reserved range pass through unchanged; forgotten or never-minted
+// synthetics resolve to 0.
+extern "C" uintptr_t lupine_handle_resolve(lupine_handle_family family,
+                                           uintptr_t synthetic);
+
+// Non-blocking resolve. Returns false when the synthetic exists but has not
+// been fulfilled yet.
+extern "C" bool lupine_handle_try_resolve(lupine_handle_family family,
+                                          uintptr_t synthetic, uintptr_t *real);
+
+// Drops a synthetic. Anyone still blocked in resolve wakes and gets 0.
+extern "C" void lupine_handle_forget(lupine_handle_family family,
+                                     uintptr_t synthetic);
+
+extern "C" bool lupine_handle_is_synthetic(uintptr_t value);
+
+#endif

--- a/handles_test.cpp
+++ b/handles_test.cpp
@@ -153,6 +153,104 @@ bool test_forget_releases_waiters() {
   return true;
 }
 
+bool test_named_mint_is_stable_per_owner_and_name() {
+  uintptr_t library = lupine_handle_mint(LUPINE_HANDLE_LIBRARY);
+  uintptr_t other = lupine_handle_mint(LUPINE_HANDLE_LIBRARY);
+  uintptr_t first =
+      lupine_handle_mint_named(LUPINE_HANDLE_KERNEL, library, "kernel_a");
+  uintptr_t again =
+      lupine_handle_mint_named(LUPINE_HANDLE_KERNEL, library, "kernel_a");
+  uintptr_t sibling =
+      lupine_handle_mint_named(LUPINE_HANDLE_KERNEL, library, "kernel_b");
+  uintptr_t elsewhere =
+      lupine_handle_mint_named(LUPINE_HANDLE_KERNEL, other, "kernel_a");
+  if (first == 0 || first != again) {
+    std::cerr << "FAIL: repeated named mint did not return the same handle\n";
+    return false;
+  }
+  if (first == sibling || first == elsewhere || sibling == elsewhere) {
+    std::cerr << "FAIL: distinct names or owners shared a handle\n";
+    return false;
+  }
+  if (lupine_handle_family_of(first) != LUPINE_HANDLE_KERNEL ||
+      lupine_handle_family_of(library) != LUPINE_HANDLE_LIBRARY ||
+      lupine_handle_family_of(0x1234) != LUPINE_HANDLE_FAMILY_COUNT) {
+    std::cerr << "FAIL: family_of misread a handle\n";
+    return false;
+  }
+
+  lupine_handle_fulfill(LUPINE_HANDLE_KERNEL, first, 0x5150);
+  if (lupine_handle_resolve(LUPINE_HANDLE_KERNEL, again) != 0x5150) {
+    std::cerr << "FAIL: named handle did not resolve to its real value\n";
+    return false;
+  }
+
+  lupine_handle_forget_owned(LUPINE_HANDLE_KERNEL, library);
+  uintptr_t reminted =
+      lupine_handle_mint_named(LUPINE_HANDLE_KERNEL, library, "kernel_a");
+  if (reminted == first || reminted == 0) {
+    std::cerr << "FAIL: forget_owned did not drop the name index\n";
+    return false;
+  }
+  uintptr_t survivor = 0;
+  if (lupine_handle_try_resolve(LUPINE_HANDLE_KERNEL, elsewhere, &survivor)) {
+    std::cerr << "FAIL: forget_owned reached another owner's handles\n";
+    return false;
+  }
+  lupine_handle_forget_owned(LUPINE_HANDLE_KERNEL, library);
+  lupine_handle_forget_owned(LUPINE_HANDLE_KERNEL, other);
+  lupine_handle_forget(LUPINE_HANDLE_LIBRARY, library);
+  lupine_handle_forget(LUPINE_HANDLE_LIBRARY, other);
+  return true;
+}
+
+int applied_payloads = 0;
+
+void count_applied_payload(uintptr_t, uintptr_t, void *payload, void *context) {
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  ++applied_payloads;
+  *static_cast<int *>(context) = *static_cast<int *>(payload);
+  delete static_cast<int *>(payload);
+}
+
+bool test_payload_applies_once_before_any_resolver_returns() {
+  constexpr int kReaders = 8;
+  uintptr_t synthetic = lupine_handle_mint(LUPINE_HANDLE_LIBRARY);
+  applied_payloads = 0;
+  int applied_value = 0;
+
+  std::vector<uintptr_t> resolved(kReaders, 0);
+  std::vector<int> seen(kReaders, -1);
+  std::vector<std::thread> readers;
+  for (int i = 0; i < kReaders; ++i) {
+    readers.emplace_back([&, i] {
+      resolved[i] =
+          lupine_handle_resolve_applied(LUPINE_HANDLE_LIBRARY, synthetic,
+                                        count_applied_payload, &applied_value);
+      seen[i] = applied_payloads;
+    });
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  lupine_handle_fulfill_payload(LUPINE_HANDLE_LIBRARY, synthetic, 0xFACE,
+                                new int(77));
+  for (auto &reader : readers) {
+    reader.join();
+  }
+  lupine_handle_forget(LUPINE_HANDLE_LIBRARY, synthetic);
+
+  if (applied_payloads != 1 || applied_value != 77) {
+    std::cerr << "FAIL: payload was not applied exactly once\n";
+    return false;
+  }
+  for (int i = 0; i < kReaders; ++i) {
+    if (resolved[i] != 0xFACE || seen[i] != 1) {
+      std::cerr << "FAIL: resolver returned before the payload was applied\n";
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace
 
 int main() {
@@ -162,7 +260,9 @@ int main() {
       !test_resolve_passes_through_real_values() ||
       !test_resolve_blocks_until_fulfilled() ||
       !test_creation_failure_resolves_to_zero() ||
-      !test_forget_releases_waiters()) {
+      !test_forget_releases_waiters() ||
+      !test_named_mint_is_stable_per_owner_and_name() ||
+      !test_payload_applies_once_before_any_resolver_returns()) {
     return 1;
   }
   std::cout << "handle table tests passed\n";

--- a/handles_test.cpp
+++ b/handles_test.cpp
@@ -1,0 +1,170 @@
+#include "handles.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+namespace {
+
+bool test_mint_produces_distinct_synthetics() {
+  uintptr_t first = lupine_handle_mint(LUPINE_HANDLE_EVENT);
+  uintptr_t second = lupine_handle_mint(LUPINE_HANDLE_EVENT);
+  if (first == 0 || second == 0 || first == second) {
+    std::cerr << "FAIL: mint did not produce distinct handles\n";
+    return false;
+  }
+  if (!lupine_handle_is_synthetic(first) ||
+      !lupine_handle_is_synthetic(second)) {
+    std::cerr << "FAIL: minted handles are not tagged synthetic\n";
+    return false;
+  }
+  lupine_handle_forget(LUPINE_HANDLE_EVENT, first);
+  lupine_handle_forget(LUPINE_HANDLE_EVENT, second);
+  return true;
+}
+
+bool test_is_synthetic_rejects_real_pointers() {
+  void *heap = malloc(64);
+  uintptr_t candidates[] = {
+      0,
+      1,
+      reinterpret_cast<uintptr_t>(heap),
+      reinterpret_cast<uintptr_t>(&candidates),
+      reinterpret_cast<uintptr_t>(
+          reinterpret_cast<void *>(&test_is_synthetic_rejects_real_pointers)),
+      0x00007FFFFFFFFFFFull,
+      0xFFFFFFFFFFFFFFFFull,
+      0xFFFF800000000000ull,
+  };
+  bool ok = true;
+  for (uintptr_t candidate : candidates) {
+    if (lupine_handle_is_synthetic(candidate)) {
+      std::cerr << "FAIL: real-looking value " << std::hex << candidate
+                << " classified synthetic\n";
+      ok = false;
+    }
+  }
+  free(heap);
+  return ok;
+}
+
+bool test_try_resolve_before_and_after_fulfill() {
+  uintptr_t synthetic = lupine_handle_mint(LUPINE_HANDLE_EVENT);
+  uintptr_t real = 0;
+  if (lupine_handle_try_resolve(LUPINE_HANDLE_EVENT, synthetic, &real)) {
+    std::cerr << "FAIL: try_resolve succeeded before fulfill\n";
+    return false;
+  }
+  lupine_handle_fulfill(LUPINE_HANDLE_EVENT, synthetic, 0xABCD1234);
+  if (!lupine_handle_try_resolve(LUPINE_HANDLE_EVENT, synthetic, &real) ||
+      real != 0xABCD1234) {
+    std::cerr << "FAIL: try_resolve did not return the fulfilled handle\n";
+    return false;
+  }
+  if (lupine_handle_resolve(LUPINE_HANDLE_EVENT, synthetic) != 0xABCD1234) {
+    std::cerr << "FAIL: resolve did not return the fulfilled handle\n";
+    return false;
+  }
+  lupine_handle_forget(LUPINE_HANDLE_EVENT, synthetic);
+  return true;
+}
+
+bool test_resolve_passes_through_real_values() {
+  uintptr_t real = 0;
+  if (lupine_handle_resolve(LUPINE_HANDLE_EVENT, 0x1234) != 0x1234 ||
+      !lupine_handle_try_resolve(LUPINE_HANDLE_EVENT, 0x1234, &real) ||
+      real != 0x1234) {
+    std::cerr << "FAIL: real values did not pass through\n";
+    return false;
+  }
+  return true;
+}
+
+bool test_resolve_blocks_until_fulfilled() {
+  constexpr int kHandles = 16;
+  std::vector<uintptr_t> synthetics;
+  for (int i = 0; i < kHandles; ++i) {
+    synthetics.push_back(lupine_handle_mint(LUPINE_HANDLE_EVENT));
+  }
+
+  std::vector<uintptr_t> resolved(kHandles, 0);
+  std::vector<std::thread> readers;
+  for (int i = 0; i < kHandles; ++i) {
+    readers.emplace_back([&, i] {
+      resolved[i] = lupine_handle_resolve(LUPINE_HANDLE_EVENT, synthetics[i]);
+    });
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  for (int i = 0; i < kHandles; ++i) {
+    lupine_handle_fulfill(LUPINE_HANDLE_EVENT, synthetics[i],
+                          0x1000 + static_cast<uintptr_t>(i));
+  }
+  for (auto &reader : readers) {
+    reader.join();
+  }
+
+  for (int i = 0; i < kHandles; ++i) {
+    if (resolved[i] != 0x1000 + static_cast<uintptr_t>(i)) {
+      std::cerr << "FAIL: resolve returned the wrong handle\n";
+      return false;
+    }
+    lupine_handle_forget(LUPINE_HANDLE_EVENT, synthetics[i]);
+  }
+  return true;
+}
+
+bool test_creation_failure_resolves_to_zero() {
+  uintptr_t synthetic = lupine_handle_mint(LUPINE_HANDLE_EVENT);
+  std::thread fulfiller([&] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    lupine_handle_fulfill(LUPINE_HANDLE_EVENT, synthetic, 0);
+  });
+  uintptr_t real = lupine_handle_resolve(LUPINE_HANDLE_EVENT, synthetic);
+  fulfiller.join();
+  lupine_handle_forget(LUPINE_HANDLE_EVENT, synthetic);
+  if (real != 0) {
+    std::cerr << "FAIL: failed creation did not resolve to zero\n";
+    return false;
+  }
+  return true;
+}
+
+bool test_forget_releases_waiters() {
+  uintptr_t synthetic = lupine_handle_mint(LUPINE_HANDLE_EVENT);
+  std::thread forgetter([&] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    lupine_handle_forget(LUPINE_HANDLE_EVENT, synthetic);
+  });
+  uintptr_t real = lupine_handle_resolve(LUPINE_HANDLE_EVENT, synthetic);
+  forgetter.join();
+  if (real != 0) {
+    std::cerr << "FAIL: forget did not release the waiter with zero\n";
+    return false;
+  }
+  uintptr_t ignored = 1;
+  if (!lupine_handle_try_resolve(LUPINE_HANDLE_EVENT, synthetic, &ignored) ||
+      ignored != 0) {
+    std::cerr << "FAIL: forgotten handle did not resolve to zero\n";
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+int main() {
+  if (!test_mint_produces_distinct_synthetics() ||
+      !test_is_synthetic_rejects_real_pointers() ||
+      !test_try_resolve_before_and_after_fulfill() ||
+      !test_resolve_passes_through_real_values() ||
+      !test_resolve_blocks_until_fulfilled() ||
+      !test_creation_failure_resolves_to_zero() ||
+      !test_forget_releases_waiters()) {
+    return 1;
+  }
+  std::cout << "handle table tests passed\n";
+  return 0;
+}

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <string.h>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #ifndef _WIN32
@@ -71,10 +72,10 @@ lupine_socket_t lupine_tcp_connect(const char *host, const char *port) {
     if (delay_ms > kMaxBackoffMs) {
       delay_ms = kMaxBackoffMs;
     }
-    LUPINE_LOG_ERROR("Connecting to "
-                     << host << " port " << port << " failed, retrying in "
-                     << delay_ms << "ms (" << (kMaxRetries - attempt)
-                     << " retries left)");
+    LUPINE_LOG_ERROR("Connecting to " << host << " port " << port
+                                      << " failed, retrying in " << delay_ms
+                                      << "ms (" << (kMaxRetries - attempt)
+                                      << " retries left)");
     std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
   }
 }
@@ -188,28 +189,32 @@ static void rpc_destroy_thread_lane(uint64_t lane_id) { (void)lane_id; }
 namespace {
 
 struct rpc_deferred_response {
-  conn_t *conn;
-  int request_id;
   rpc_deferred_response_fn handler;
   void *context;
 };
 
-std::vector<rpc_deferred_response> rpc_deferred_responses;
+// A library load registers dozens of deferred responses at a time, so the
+// reader thread looks them up by connection and request id rather than
+// scanning.
+std::unordered_map<conn_t *, std::unordered_map<int, rpc_deferred_response>>
+    rpc_deferred_responses;
 pthread_mutex_t rpc_deferred_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 bool rpc_take_deferred_response(conn_t *conn, int request_id,
                                 rpc_deferred_response *out) {
   bool found = false;
   pthread_mutex_lock(&rpc_deferred_mutex);
-  for (size_t i = 0; i < rpc_deferred_responses.size(); ++i) {
-    if (rpc_deferred_responses[i].conn != conn ||
-        rpc_deferred_responses[i].request_id != request_id) {
-      continue;
+  auto pending = rpc_deferred_responses.find(conn);
+  if (pending != rpc_deferred_responses.end()) {
+    auto entry = pending->second.find(request_id);
+    if (entry != pending->second.end()) {
+      *out = entry->second;
+      pending->second.erase(entry);
+      found = true;
     }
-    *out = rpc_deferred_responses[i];
-    rpc_deferred_responses.erase(rpc_deferred_responses.begin() + i);
-    found = true;
-    break;
+    if (pending->second.empty()) {
+      rpc_deferred_responses.erase(pending);
+    }
   }
   pthread_mutex_unlock(&rpc_deferred_mutex);
   return found;
@@ -220,14 +225,17 @@ void rpc_abandon_deferred_responses(conn_t *conn) {
     rpc_deferred_response entry;
     bool found = false;
     pthread_mutex_lock(&rpc_deferred_mutex);
-    for (size_t i = 0; i < rpc_deferred_responses.size(); ++i) {
-      if (rpc_deferred_responses[i].conn != conn) {
-        continue;
+    auto pending = rpc_deferred_responses.find(conn);
+    if (pending != rpc_deferred_responses.end()) {
+      auto first = pending->second.begin();
+      if (first != pending->second.end()) {
+        entry = first->second;
+        pending->second.erase(first);
+        found = true;
       }
-      entry = rpc_deferred_responses[i];
-      rpc_deferred_responses.erase(rpc_deferred_responses.begin() + i);
-      found = true;
-      break;
+      if (pending->second.empty()) {
+        rpc_deferred_responses.erase(pending);
+      }
     }
     pthread_mutex_unlock(&rpc_deferred_mutex);
     if (!found) {
@@ -246,7 +254,7 @@ int rpc_write_end_deferred(conn_t *conn, rpc_deferred_response_fn handler,
   }
   int request_id = conn->write_id;
   pthread_mutex_lock(&rpc_deferred_mutex);
-  rpc_deferred_responses.push_back({conn, request_id, handler, context});
+  rpc_deferred_responses[conn][request_id] = {handler, context};
   pthread_mutex_unlock(&rpc_deferred_mutex);
   if (rpc_write_end(conn) < 0) {
     rpc_deferred_response entry;

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -185,6 +185,79 @@ extern "C" void lupine_invalidate_current_context_cache();
 static void rpc_destroy_thread_lane(uint64_t lane_id) { (void)lane_id; }
 #endif
 
+namespace {
+
+struct rpc_deferred_response {
+  conn_t *conn;
+  int request_id;
+  rpc_deferred_response_fn handler;
+  void *context;
+};
+
+std::vector<rpc_deferred_response> rpc_deferred_responses;
+pthread_mutex_t rpc_deferred_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+bool rpc_take_deferred_response(conn_t *conn, int request_id,
+                                rpc_deferred_response *out) {
+  bool found = false;
+  pthread_mutex_lock(&rpc_deferred_mutex);
+  for (size_t i = 0; i < rpc_deferred_responses.size(); ++i) {
+    if (rpc_deferred_responses[i].conn != conn ||
+        rpc_deferred_responses[i].request_id != request_id) {
+      continue;
+    }
+    *out = rpc_deferred_responses[i];
+    rpc_deferred_responses.erase(rpc_deferred_responses.begin() + i);
+    found = true;
+    break;
+  }
+  pthread_mutex_unlock(&rpc_deferred_mutex);
+  return found;
+}
+
+void rpc_abandon_deferred_responses(conn_t *conn) {
+  for (;;) {
+    rpc_deferred_response entry;
+    bool found = false;
+    pthread_mutex_lock(&rpc_deferred_mutex);
+    for (size_t i = 0; i < rpc_deferred_responses.size(); ++i) {
+      if (rpc_deferred_responses[i].conn != conn) {
+        continue;
+      }
+      entry = rpc_deferred_responses[i];
+      rpc_deferred_responses.erase(rpc_deferred_responses.begin() + i);
+      found = true;
+      break;
+    }
+    pthread_mutex_unlock(&rpc_deferred_mutex);
+    if (!found) {
+      return;
+    }
+    entry.handler(nullptr, entry.context);
+  }
+}
+
+} // namespace
+
+int rpc_write_end_deferred(conn_t *conn, rpc_deferred_response_fn handler,
+                           void *context) {
+  if (conn == nullptr || handler == nullptr) {
+    return -1;
+  }
+  int request_id = conn->write_id;
+  pthread_mutex_lock(&rpc_deferred_mutex);
+  rpc_deferred_responses.push_back({conn, request_id, handler, context});
+  pthread_mutex_unlock(&rpc_deferred_mutex);
+  if (rpc_write_end(conn) < 0) {
+    rpc_deferred_response entry;
+    if (rpc_take_deferred_response(conn, request_id, &entry)) {
+      entry.handler(nullptr, entry.context);
+    }
+    return -1;
+  }
+  return 0;
+}
+
 static void rpc_mark_connection_closed(conn_t *conn) {
   conn->closed = 1;
 #ifdef LUPINE_RPC_CLIENT
@@ -236,12 +309,30 @@ void *_rpc_read_id_dispatch(void *p) {
     }
 
     conn->read_id = request_id;
+
+    rpc_deferred_response deferred;
+    if (rpc_take_deferred_response(conn, request_id, &deferred)) {
+      bool ok = rpc_http2_read(conn, &conn->read_lane_id,
+                               sizeof(conn->read_lane_id)) ==
+                    (int)sizeof(conn->read_lane_id) &&
+                rpc_http2_read(conn, &conn->read_op, sizeof(conn->read_op)) ==
+                    (int)sizeof(conn->read_op) &&
+                conn->read_op == -1;
+      pthread_mutex_unlock(&conn->read_mutex);
+      ok = deferred.handler(ok ? conn : nullptr, deferred.context) == 0 && ok;
+      if (rpc_read_end(conn) < 0 || !ok) {
+        break;
+      }
+      continue;
+    }
+
     if (pthread_cond_broadcast(&conn->read_cond) < 0 ||
         pthread_mutex_unlock(&conn->read_mutex) < 0) {
       break;
     }
   }
   rpc_mark_connection_closed(conn);
+  rpc_abandon_deferred_responses(conn);
   pthread_cond_broadcast(&conn->read_cond);
   conn->rpc_thread = 0;
   return NULL;

--- a/rpc.h
+++ b/rpc.h
@@ -73,6 +73,24 @@ struct conn_t {
 
 extern int rpc_dispatch(conn_t *conn, int parity);
 extern int rpc_read_start(conn_t *conn, int write_id);
+
+// Consumes a response no caller is waiting for. The handler reads the response
+// body exactly as a caller would after rpc_read_start; a null conn means the
+// response will never arrive and the handler must only release its context.
+//
+// Locking argument: the reader thread publishes conn->read_id and reads the
+// lane/op header under read_mutex, then drops read_mutex and runs the handler
+// with the frame still reserved (read_id != 0), finishing with rpc_read_end.
+// That is the same claim protocol a waiting caller follows, so no other thread
+// can read from the wire concurrently, and it is the reader thread itself that
+// claims the frame, so an unwaited response can never wedge the connection. A
+// handler therefore must not block on any lock that another thread can hold
+// across an RPC round trip, because it runs on the only thread that can
+// deliver that round trip's response.
+typedef int (*rpc_deferred_response_fn)(conn_t *conn, void *context);
+extern int rpc_write_end_deferred(conn_t *conn,
+                                  rpc_deferred_response_fn handler,
+                                  void *context);
 extern int rpc_read(conn_t *conn, void *data, size_t size);
 extern int rpc_drain(conn_t *conn, size_t size);
 extern int rpc_read_end(conn_t *conn);


### PR DESCRIPTION
Implements stages 1-3 of #470: a type-blind client-side synthetic handle table (handles.cpp, non-canonical 0xC0DE-tagged range, mint/fulfill/resolve with reader-thread fulfillment reusing the transport's existing frame-claim protocol), the events family (cuEventCreate returns a synthetic immediately; the real handle is fulfilled from a response no caller waits on), and the library/kernel families with identity-stable (library,name)-keyed kernel synthetics plus a persistent per-cubin kernel-table cache under ~/.cache/lupine. The server never sees a synthetic value; wrappers resolve at entry, which also closes the latent cross-server handle-collision hazard for these families. Measured at 30ms emulated RTT (makemore, loss curves identical, 9/9 unit incl. handles_test, 23/23 custom GPU tests): cuLibraryLoadData, cuEventCreate, cuLibraryGetKernel, and cuKernelGetParamInfo disappear from the blocked-RPC profile entirely (previously ~2.3s of serialized init round trips). Honest caveats for review: warm-cache wall improves only 21.5s to 20.8s and step-0 4.7s to 4.4s — the eliminated client waits were partially hidden behind server-side JIT and torch-local work that still has to happen — and cold runs currently pay ~6.5s building the image-hash cache (27.3s wall), which needs a streaming-hash fix before merge. The dominant remaining blocked time is the 215 torch-internal stream synchronizes (6.8s/run), deliberately not elided.