### PR TITLE
Record events fire-and-forget via the async annotation

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -3529,12 +3529,14 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
  */
 CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags);
 /**
+ * @async
  * @routingkey STREAM hStream
  * @param hEvent SEND_ONLY
  * @param hStream SEND_ONLY
  */
 CUresult cuEventRecord(CUevent hEvent, CUstream hStream);
 /**
+ * @async
  * @routingkey STREAM hStream
  * @param hEvent SEND_ONLY
  * @param hStream SEND_ONLY

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -3171,11 +3171,10 @@ CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
+      rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
+  }
+  return CUDA_SUCCESS;
 }
 
 CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
@@ -3195,11 +3194,10 @@ CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
+      rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
+  }
+  return CUDA_SUCCESS;
 }
 
 CUresult cuEventQuery(CUevent hEvent) {

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -4115,7 +4115,6 @@ int handle_cuEventRecord(conn_t *conn) {
   CUevent hEvent;
   CUstream hStream;
   int request_id;
-  CUresult lupine_intercept_result;
   if (rpc_read(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
     goto ERROR_0;
@@ -4123,12 +4122,7 @@ int handle_cuEventRecord(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
-  lupine_intercept_result = cuEventRecord(hEvent, hStream);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
+  cuEventRecord(hEvent, hStream);
 
   return 0;
 ERROR_0:
@@ -4140,7 +4134,6 @@ int handle_cuEventRecordWithFlags(conn_t *conn) {
   CUstream hStream;
   unsigned int flags;
   int request_id;
-  CUresult lupine_intercept_result;
   if (rpc_read(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_read(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_read(conn, &flags, sizeof(unsigned int)) < 0 || false)
@@ -4149,12 +4142,7 @@ int handle_cuEventRecordWithFlags(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
-  lupine_intercept_result = cuEventRecordWithFlags(hEvent, hStream, flags);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
+  cuEventRecordWithFlags(hEvent, hStream, flags);
 
   return 0;
 ERROR_0:

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3154,10 +3154,8 @@ int handle_manual_cuEventRecord(conn_t *conn, bool with_flags) {
 
   result = with_flags ? cuEventRecordWithFlags(event, stream, flags)
                       : cuEventRecord(event, stream);
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    return -1;
-  }
+  (void)result;
+  (void)request_id;
   return 0;
 }
 


### PR DESCRIPTION
Timeline profiling of the makemore steady state at 30ms emulated RTT found that with properly non-blocking host-to-device copies (pinned source, non_blocking=True), torch's caching host allocator records a CUDA event after every copy to track buffer reuse — and cuEventRecord/cuEventRecordWithFlags were blocking RPCs, so the copy round trips we removed reappeared under a different op name at the same ~31ms each. Both ops are all-SEND_ONLY with CUresult returns, exactly the @async class; this annotates them and drops the response from the manual server handler (which retains its stream-capture bookkeeping). Event query/synchronize stay blocking, so completion polling semantics are unchanged; a record failure is dropped like any fire-and-forget submission and surfaces at the next synchronize. Measured (makemore with non_blocking=True at 30ms RTT, loss curves identical): 105ms/step to 62-72ms/step, wall 20.65s to 17.25s; the default blocking-copy variant is unchanged (its per-step cost is two genuine stream synchronizes). Unit tests 8/8; custom GPU suite 23/23, including the stream-callback and graph tests that exercise event records. Remaining per-step gap over the 43ms floor (~20ms) is unattributed and under investigation — likely the pin-memory thread's own pipeline.