### PR TITLE
Batch event queries and cache completed events client-side

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(CLIENT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/events.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/routing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/copy_pipeline.cpp
@@ -226,6 +227,16 @@ else()
     add_test(NAME checkpoint_test COMMAND checkpoint_test)
     lupine_scaled_timeout(ckpt_timeout 10)
     set_tests_properties(checkpoint_test PROPERTIES TIMEOUT ${ckpt_timeout})
+
+    add_executable(events_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/events.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/events_test.cpp
+    )
+    target_link_libraries(events_test PRIVATE pthread)
+    lupine_apply_sanitizer(events_test)
+    add_test(NAME events_test COMMAND events_test)
+    lupine_scaled_timeout(events_timeout 10)
+    set_tests_properties(events_test PROPERTIES TIMEOUT ${events_timeout})
 
     add_executable(ipc_test
         ${CMAKE_CURRENT_SOURCE_DIR}/ipc.cpp

--- a/client.cpp
+++ b/client.cpp
@@ -3873,6 +3873,219 @@ extern "C" CUresult cuStreamWaitEvent_ptsz(CUstream hStream, CUevent hEvent,
   return cuStreamWaitEvent(hStream, hEvent, Flags);
 }
 
+// Completion is monotonic between records: once the server reports an event
+// complete for a given record, that stays true until the event is recorded
+// again. A query therefore also asks about every other event the client has
+// outstanding, so a poller walking several events pays one round trip instead
+// of one per event. Deferred device-to-host copies only reach the client on a
+// query that actually reaches the server, so a locally answered query is legal
+// only while no async copy is waiting to be drained.
+namespace {
+
+constexpr uint32_t kLupineEventQueryBatch = LUPINE_EVENT_QUERY_BATCH_MAX;
+
+struct lupine_event_slot {
+  CUevent event;
+  uint64_t recorded;
+  uint64_t completed;
+};
+
+std::mutex &lupine_event_slot_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+lupine_event_slot *lupine_event_slots() {
+  static lupine_event_slot slots[kLupineEventQueryBatch] = {};
+  return slots;
+}
+
+std::atomic<uint64_t> lupine_event_record_seq{0};
+std::atomic<uint64_t> lupine_async_dtoh_issued{0};
+std::atomic<uint64_t> lupine_async_dtoh_drained{0};
+
+void lupine_note_event_recorded(CUevent event) {
+  uint64_t seq = lupine_event_record_seq.fetch_add(1) + 1;
+  lupine_event_slot *slots = lupine_event_slots();
+  std::lock_guard<std::mutex> lock(lupine_event_slot_mutex());
+  lupine_event_slot *victim = &slots[0];
+  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    if (slots[i].event == event) {
+      slots[i].recorded = seq;
+      return;
+    }
+    if (slots[i].recorded < victim->recorded) {
+      victim = &slots[i];
+    }
+  }
+  *victim = {event, seq, 0};
+}
+
+// Fills events/recorded with the batch to ask about, the caller's event first,
+// and returns its length; zero means the answer is already known locally.
+uint32_t lupine_collect_event_query_batch(CUevent primary, conn_t *conn,
+                                          CUevent *events, uint64_t *recorded) {
+  bool copies_pending =
+      lupine_async_dtoh_issued.load(std::memory_order_relaxed) !=
+      lupine_async_dtoh_drained.load(std::memory_order_relaxed);
+  lupine_event_slot *slots = lupine_event_slots();
+  std::lock_guard<std::mutex> lock(lupine_event_slot_mutex());
+  uint32_t count = 1;
+  events[0] = primary;
+  recorded[0] = 0;
+  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    if (slots[i].event != primary) {
+      continue;
+    }
+    if (!copies_pending && slots[i].recorded == slots[i].completed) {
+      return 0;
+    }
+    recorded[0] = slots[i].recorded;
+    break;
+  }
+  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    if (slots[i].event == nullptr || slots[i].event == primary ||
+        slots[i].recorded == slots[i].completed ||
+        lupine_rpc_conn_for_event(slots[i].event) != conn) {
+      continue;
+    }
+    events[count] = slots[i].event;
+    recorded[count] = slots[i].recorded;
+    if (++count == kLupineEventQueryBatch) {
+      break;
+    }
+  }
+  return count;
+}
+
+void lupine_note_event_query_results(const CUevent *events,
+                                     const uint64_t *recorded,
+                                     const CUresult *results, uint32_t count) {
+  lupine_event_slot *slots = lupine_event_slots();
+  std::lock_guard<std::mutex> lock(lupine_event_slot_mutex());
+  for (uint32_t i = 0; i < count; ++i) {
+    if (results[i] != CUDA_SUCCESS || recorded[i] == 0) {
+      continue;
+    }
+    for (uint32_t j = 0; j < kLupineEventQueryBatch; ++j) {
+      if (slots[j].event == events[i] && slots[j].recorded == recorded[i]) {
+        slots[j].completed = recorded[i];
+        break;
+      }
+    }
+  }
+}
+
+void lupine_note_async_dtoh_copy() {
+  lupine_async_dtoh_issued.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace
+
+extern "C" CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
+  lupine_route route = hStream != nullptr ? lupine_route_for_stream(hStream)
+                                          : lupine_route_for_default();
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuEventRecord", &return_value, hEvent, hStream)) {
+    return return_value;
+  }
+  lupine_note_event_recorded(hEvent);
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
+      rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
+      rpc_write_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return CUDA_SUCCESS;
+}
+
+#ifdef cuEventRecord_ptsz
+#undef cuEventRecord_ptsz
+#endif
+extern "C" CUresult cuEventRecord_ptsz(CUevent hEvent, CUstream hStream) {
+  return cuEventRecord(hEvent, hStream);
+}
+
+extern "C" CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
+                                           unsigned int flags) {
+  lupine_route route = hStream != nullptr ? lupine_route_for_stream(hStream)
+                                          : lupine_route_for_default();
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent, CUstream, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuEventRecordWithFlags", &return_value, hEvent, hStream,
+          flags)) {
+    return return_value;
+  }
+  lupine_note_event_recorded(hEvent);
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
+      rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
+      rpc_write(conn, &flags, sizeof(flags)) < 0 || rpc_write_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return CUDA_SUCCESS;
+}
+
+#ifdef cuEventRecordWithFlags_ptsz
+#undef cuEventRecordWithFlags_ptsz
+#endif
+extern "C" CUresult cuEventRecordWithFlags_ptsz(CUevent hEvent,
+                                                CUstream hStream,
+                                                unsigned int flags) {
+  return cuEventRecordWithFlags(hEvent, hStream, flags);
+}
+
+extern "C" CUresult cuEventQuery(CUevent hEvent) {
+  CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
+  if (flush_result != CUDA_SUCCESS) {
+    return flush_result;
+  }
+  lupine_route route = lupine_route_for_event(hEvent);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventQuery",
+                                                  &return_value, hEvent)) {
+    return return_value == CUDA_SUCCESS ? lupine_sync_mapped_device_to_host()
+                                        : return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  CUevent events[kLupineEventQueryBatch];
+  uint64_t recorded[kLupineEventQueryBatch];
+  uint32_t count =
+      lupine_collect_event_query_batch(hEvent, conn, events, recorded);
+  if (count == 0) {
+    return lupine_sync_mapped_device_to_host();
+  }
+  // Sampled before the request so a copy issued while it is in flight is not
+  // mistaken for one the server already drained.
+  uint64_t drained = lupine_async_dtoh_issued.load(std::memory_order_relaxed);
+  CUresult results[kLupineEventQueryBatch];
+  if (rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
+      rpc_write(conn, &count, sizeof(count)) < 0 ||
+      rpc_write(conn, events, count * sizeof(events[0])) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      lupine_read_deferred_dtoh_copies(conn) < 0 ||
+      rpc_read(conn, results, count * sizeof(results[0])) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  lupine_note_event_query_results(events, recorded, results, count);
+  if (results[0] != CUDA_SUCCESS) {
+    return results[0];
+  }
+  lupine_async_dtoh_drained.store(drained, std::memory_order_relaxed);
+  return lupine_sync_mapped_device_to_host();
+}
+
 extern "C" CUresult cuCtxCreate_v2(CUcontext *pctx, unsigned int flags,
                                    CUdevice dev) {
   if (pctx == nullptr) {
@@ -4876,6 +5089,7 @@ extern "C" CUresult cuMemcpyAtoH(void *dstHost, CUarray srcArray,
 
 extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
+  lupine_note_async_dtoh_copy();
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
@@ -8475,6 +8689,10 @@ lupine_manual_function_map() {
       {"cuStreamWaitValue64", (void *)cuStreamWaitValue64_v2},
       {"cuStreamWaitEvent", (void *)cuStreamWaitEvent},
       {"cuStreamWaitEvent_ptsz", (void *)cuStreamWaitEvent_ptsz},
+      {"cuEventRecord", (void *)cuEventRecord},
+      {"cuEventRecord_ptsz", (void *)cuEventRecord_ptsz},
+      {"cuEventRecordWithFlags", (void *)cuEventRecordWithFlags},
+      {"cuEventRecordWithFlags_ptsz", (void *)cuEventRecordWithFlags_ptsz},
       {"cuStreamWriteValue32", (void *)cuStreamWriteValue32_v2},
       {"cuStreamWriteValue64", (void *)cuStreamWriteValue64_v2},
       {"cuStreamBatchMemOp", (void *)cuStreamBatchMemOp_v2},

--- a/client.cpp
+++ b/client.cpp
@@ -52,6 +52,7 @@
 #include "client_routing.h"
 #include "codegen/gen_api.h"
 #include "codegen/gen_client.h"
+#include "events.h"
 #include "ipc.h"
 #include "lupine_attr_sizes.h"
 #include "lupine_fatbin.h"
@@ -3873,115 +3874,6 @@ extern "C" CUresult cuStreamWaitEvent_ptsz(CUstream hStream, CUevent hEvent,
   return cuStreamWaitEvent(hStream, hEvent, Flags);
 }
 
-// Completion is monotonic between records: once the server reports an event
-// complete for a given record, that stays true until the event is recorded
-// again. A query therefore also asks about every other event the client has
-// outstanding, so a poller walking several events pays one round trip instead
-// of one per event. Deferred device-to-host copies only reach the client on a
-// query that actually reaches the server, so a locally answered query is legal
-// only while no async copy is waiting to be drained.
-namespace {
-
-constexpr uint32_t kLupineEventQueryBatch = LUPINE_EVENT_QUERY_BATCH_MAX;
-
-struct lupine_event_slot {
-  CUevent event;
-  uint64_t recorded;
-  uint64_t completed;
-};
-
-std::mutex &lupine_event_slot_mutex() {
-  static std::mutex mutex;
-  return mutex;
-}
-
-lupine_event_slot *lupine_event_slots() {
-  static lupine_event_slot slots[kLupineEventQueryBatch] = {};
-  return slots;
-}
-
-std::atomic<uint64_t> lupine_event_record_seq{0};
-std::atomic<uint64_t> lupine_async_dtoh_issued{0};
-std::atomic<uint64_t> lupine_async_dtoh_drained{0};
-
-void lupine_note_event_recorded(CUevent event) {
-  uint64_t seq = lupine_event_record_seq.fetch_add(1) + 1;
-  lupine_event_slot *slots = lupine_event_slots();
-  std::lock_guard<std::mutex> lock(lupine_event_slot_mutex());
-  lupine_event_slot *victim = &slots[0];
-  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
-    if (slots[i].event == event) {
-      slots[i].recorded = seq;
-      return;
-    }
-    if (slots[i].recorded < victim->recorded) {
-      victim = &slots[i];
-    }
-  }
-  *victim = {event, seq, 0};
-}
-
-// Fills events/recorded with the batch to ask about, the caller's event first,
-// and returns its length; zero means the answer is already known locally.
-uint32_t lupine_collect_event_query_batch(CUevent primary, conn_t *conn,
-                                          CUevent *events, uint64_t *recorded) {
-  bool copies_pending =
-      lupine_async_dtoh_issued.load(std::memory_order_relaxed) !=
-      lupine_async_dtoh_drained.load(std::memory_order_relaxed);
-  lupine_event_slot *slots = lupine_event_slots();
-  std::lock_guard<std::mutex> lock(lupine_event_slot_mutex());
-  uint32_t count = 1;
-  events[0] = primary;
-  recorded[0] = 0;
-  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
-    if (slots[i].event != primary) {
-      continue;
-    }
-    if (!copies_pending && slots[i].recorded == slots[i].completed) {
-      return 0;
-    }
-    recorded[0] = slots[i].recorded;
-    break;
-  }
-  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
-    if (slots[i].event == nullptr || slots[i].event == primary ||
-        slots[i].recorded == slots[i].completed ||
-        lupine_rpc_conn_for_event(slots[i].event) != conn) {
-      continue;
-    }
-    events[count] = slots[i].event;
-    recorded[count] = slots[i].recorded;
-    if (++count == kLupineEventQueryBatch) {
-      break;
-    }
-  }
-  return count;
-}
-
-void lupine_note_event_query_results(const CUevent *events,
-                                     const uint64_t *recorded,
-                                     const CUresult *results, uint32_t count) {
-  lupine_event_slot *slots = lupine_event_slots();
-  std::lock_guard<std::mutex> lock(lupine_event_slot_mutex());
-  for (uint32_t i = 0; i < count; ++i) {
-    if (results[i] != CUDA_SUCCESS || recorded[i] == 0) {
-      continue;
-    }
-    for (uint32_t j = 0; j < kLupineEventQueryBatch; ++j) {
-      if (slots[j].event == events[i] && slots[j].recorded == recorded[i]) {
-        slots[j].completed = recorded[i];
-        break;
-      }
-    }
-  }
-}
-
-void lupine_note_async_dtoh_copy() {
-  lupine_async_dtoh_issued.fetch_add(1, std::memory_order_relaxed);
-}
-
-} // namespace
-
 extern "C" CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
   lupine_route route = hStream != nullptr ? lupine_route_for_stream(hStream)
                                           : lupine_route_for_default();
@@ -4067,7 +3959,7 @@ extern "C" CUresult cuEventQuery(CUevent hEvent) {
   }
   // Sampled before the request so a copy issued while it is in flight is not
   // mistaken for one the server already drained.
-  uint64_t drained = lupine_async_dtoh_issued.load(std::memory_order_relaxed);
+  uint64_t drained = lupine_async_dtoh_issued_count();
   CUresult results[kLupineEventQueryBatch];
   if (rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
@@ -4082,7 +3974,7 @@ extern "C" CUresult cuEventQuery(CUevent hEvent) {
   if (results[0] != CUDA_SUCCESS) {
     return results[0];
   }
-  lupine_async_dtoh_drained.store(drained, std::memory_order_relaxed);
+  lupine_note_async_dtoh_drained(drained);
   return lupine_sync_mapped_device_to_host();
 }
 

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -3530,6 +3530,7 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
 CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags);
 /**
  * @async
+ * @disabled client - manual client tracks which events have work outstanding
  * @routingkey STREAM hStream
  * @param hEvent SEND_ONLY
  * @param hStream SEND_ONLY
@@ -3537,6 +3538,7 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags);
 CUresult cuEventRecord(CUevent hEvent, CUstream hStream);
 /**
  * @async
+ * @disabled client - manual client tracks which events have work outstanding
  * @routingkey STREAM hStream
  * @param hEvent SEND_ONLY
  * @param hStream SEND_ONLY
@@ -3545,7 +3547,7 @@ CUresult cuEventRecord(CUevent hEvent, CUstream hStream);
 CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
                                 unsigned int flags);
 /**
- * @disabled server
+ * @disabled - manual client batches outstanding events into one query
  * @synchronize DEFERRED_DTOH
  * @routingkey EVENT hEvent
  * @param hEvent SEND_ONLY

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -3158,75 +3158,6 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
   return return_value;
 }
 
-CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
-  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
-                                           : lupine_route_for_default());
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUevent, CUstream);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuEventRecord", &return_value, hEvent, hStream)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
-      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_write_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return CUDA_SUCCESS;
-}
-
-CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
-                                unsigned int flags) {
-  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
-                                           : lupine_route_for_default());
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUevent, CUstream, unsigned int);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuEventRecordWithFlags", &return_value, hEvent, hStream,
-          flags)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
-      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
-      rpc_write_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return CUDA_SUCCESS;
-}
-
-CUresult cuEventQuery(CUevent hEvent) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
-  lupine_route route = lupine_route_for_event(hEvent);
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUevent);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventQuery",
-                                                  &return_value, hEvent)) {
-    if (return_value == CUDA_SUCCESS)
-      return_value = lupine_sync_mapped_device_to_host();
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      lupine_read_deferred_dtoh_copies(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS)
-    return_value = lupine_sync_mapped_device_to_host();
-  return return_value;
-}
-
 CUresult cuEventSynchronize(CUevent hEvent) {
   CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
   if (lupine_sync_result != CUDA_SUCCESS) {
@@ -7052,22 +6983,6 @@ extern "C" CUresult cuStreamSynchronize_ptsz(CUstream hStream) {
   return cuStreamSynchronize(hStream);
 }
 
-#ifdef cuEventRecord_ptsz
-#undef cuEventRecord_ptsz
-#endif
-extern "C" CUresult cuEventRecord_ptsz(CUevent hEvent, CUstream hStream) {
-  return cuEventRecord(hEvent, hStream);
-}
-
-#ifdef cuEventRecordWithFlags_ptsz
-#undef cuEventRecordWithFlags_ptsz
-#endif
-extern "C" CUresult cuEventRecordWithFlags_ptsz(CUevent hEvent,
-                                                CUstream hStream,
-                                                unsigned int flags) {
-  return cuEventRecordWithFlags(hEvent, hStream, flags);
-}
-
 #ifdef cuGraphicsMapResources_ptsz
 #undef cuGraphicsMapResources_ptsz
 #endif
@@ -7355,7 +7270,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuEventCreate", (void *)cuEventCreate},
     {"cuEventRecord", (void *)cuEventRecord},
     {"cuEventRecordWithFlags", (void *)cuEventRecordWithFlags},
-    {"cuEventQuery", (void *)cuEventQuery},
     {"cuEventSynchronize", (void *)cuEventSynchronize},
     {"cuEventDestroy_v2", (void *)cuEventDestroy_v2},
     {"cuEventElapsedTime_v2", (void *)cuEventElapsedTime_v2},
@@ -7556,8 +7470,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuStreamAttachMemAsync_ptsz", (void *)cuStreamAttachMemAsync},
     {"cuStreamQuery_ptsz", (void *)cuStreamQuery},
     {"cuStreamSynchronize_ptsz", (void *)cuStreamSynchronize},
-    {"cuEventRecord_ptsz", (void *)cuEventRecord},
-    {"cuEventRecordWithFlags_ptsz", (void *)cuEventRecordWithFlags},
     {"cuGraphicsMapResources_ptsz", (void *)cuGraphicsMapResources},
     {"cuGraphicsUnmapResources_ptsz", (void *)cuGraphicsUnmapResources},
     {"cuSignalExternalSemaphoresAsync_ptsz",

--- a/events.cpp
+++ b/events.cpp
@@ -1,0 +1,125 @@
+#include "events.h"
+
+#include "client_routing.h"
+
+void lupine_event_note_recorded(lupine_event_table *table, CUevent event) {
+  uint64_t seq = table->record_seq.fetch_add(1) + 1;
+  lupine_event_slot *slots = table->slots;
+  std::lock_guard<std::mutex> lock(table->mutex);
+  lupine_event_slot *victim = &slots[0];
+  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    if (slots[i].event == event) {
+      slots[i].recorded = seq;
+      return;
+    }
+    if (slots[i].recorded < victim->recorded) {
+      victim = &slots[i];
+    }
+  }
+  *victim = {event, seq, 0};
+}
+
+// Fills events/recorded with the batch to ask about, the caller's event first,
+// and returns its length; zero means the answer is already known locally.
+uint32_t lupine_event_collect_query_batch(lupine_event_table *table,
+                                          CUevent primary, conn_t *conn,
+                                          lupine_event_conn_resolver resolver,
+                                          CUevent *events, uint64_t *recorded) {
+  bool copies_pending = table->dtoh_issued.load(std::memory_order_relaxed) !=
+                        table->dtoh_drained.load(std::memory_order_relaxed);
+  lupine_event_slot *slots = table->slots;
+  std::lock_guard<std::mutex> lock(table->mutex);
+  uint32_t count = 1;
+  events[0] = primary;
+  recorded[0] = 0;
+  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    if (slots[i].event != primary) {
+      continue;
+    }
+    if (!copies_pending && slots[i].recorded == slots[i].completed) {
+      return 0;
+    }
+    recorded[0] = slots[i].recorded;
+    break;
+  }
+  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    if (slots[i].event == nullptr || slots[i].event == primary ||
+        slots[i].recorded == slots[i].completed ||
+        resolver(slots[i].event) != conn) {
+      continue;
+    }
+    events[count] = slots[i].event;
+    recorded[count] = slots[i].recorded;
+    if (++count == kLupineEventQueryBatch) {
+      break;
+    }
+  }
+  return count;
+}
+
+void lupine_event_note_query_results(lupine_event_table *table,
+                                     const CUevent *events,
+                                     const uint64_t *recorded,
+                                     const CUresult *results, uint32_t count) {
+  lupine_event_slot *slots = table->slots;
+  std::lock_guard<std::mutex> lock(table->mutex);
+  for (uint32_t i = 0; i < count; ++i) {
+    if (results[i] != CUDA_SUCCESS || recorded[i] == 0) {
+      continue;
+    }
+    for (uint32_t j = 0; j < kLupineEventQueryBatch; ++j) {
+      if (slots[j].event == events[i] && slots[j].recorded == recorded[i]) {
+        slots[j].completed = recorded[i];
+        break;
+      }
+    }
+  }
+}
+
+void lupine_event_note_async_dtoh(lupine_event_table *table) {
+  table->dtoh_issued.fetch_add(1, std::memory_order_relaxed);
+}
+
+uint64_t lupine_event_dtoh_issued(lupine_event_table *table) {
+  return table->dtoh_issued.load(std::memory_order_relaxed);
+}
+
+void lupine_event_note_dtoh_drained(lupine_event_table *table,
+                                    uint64_t drained) {
+  table->dtoh_drained.store(drained, std::memory_order_relaxed);
+}
+
+static lupine_event_table &lupine_event_table_instance() {
+  static lupine_event_table table;
+  return table;
+}
+
+void lupine_note_event_recorded(CUevent event) {
+  lupine_event_note_recorded(&lupine_event_table_instance(), event);
+}
+
+uint32_t lupine_collect_event_query_batch(CUevent primary, conn_t *conn,
+                                          CUevent *events, uint64_t *recorded) {
+  return lupine_event_collect_query_batch(
+      &lupine_event_table_instance(), primary, conn, lupine_rpc_conn_for_event,
+      events, recorded);
+}
+
+void lupine_note_event_query_results(const CUevent *events,
+                                     const uint64_t *recorded,
+                                     const CUresult *results, uint32_t count) {
+  lupine_event_note_query_results(&lupine_event_table_instance(), events,
+                                  recorded, results, count);
+}
+
+void lupine_note_async_dtoh_copy() {
+  lupine_event_note_async_dtoh(&lupine_event_table_instance());
+}
+
+uint64_t lupine_async_dtoh_issued_count() {
+  return lupine_event_dtoh_issued(&lupine_event_table_instance());
+}
+
+void lupine_note_async_dtoh_drained(uint64_t drained) {
+  lupine_event_note_dtoh_drained(&lupine_event_table_instance(), drained);
+}

--- a/events.h
+++ b/events.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// Client-side event completion tracking behind the batched cuEventQuery. The
+// lupine_event_* functions operate on a bare table and take the
+// connection resolver as a parameter, so the batching policy is unit-testable
+// without routing; the lupine_note_*/lupine_collect_* wrappers bind the
+// process-wide table and the real resolver for the client wrappers.
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+
+#define LUPINE_CUDA_COMPAT_TYPES_ONLY
+#include "cuda_compat.h"
+#undef LUPINE_CUDA_COMPAT_TYPES_ONLY
+
+#include "rpc.h"
+
+// Completion is monotonic between records: once the server reports an event
+// complete for a given record, that stays true until the event is recorded
+// again. A query therefore also asks about every other event the client has
+// outstanding, so a poller walking several events pays one round trip instead
+// of one per event. Deferred device-to-host copies only reach the client on a
+// query that actually reaches the server, so a locally answered query is legal
+// only while no async copy is waiting to be drained.
+constexpr uint32_t kLupineEventQueryBatch = LUPINE_EVENT_QUERY_BATCH_MAX;
+
+struct lupine_event_slot {
+  CUevent event;
+  uint64_t recorded;
+  uint64_t completed;
+};
+
+struct lupine_event_table {
+  std::mutex mutex;
+  lupine_event_slot slots[kLupineEventQueryBatch] = {};
+  std::atomic<uint64_t> record_seq{0};
+  std::atomic<uint64_t> dtoh_issued{0};
+  std::atomic<uint64_t> dtoh_drained{0};
+};
+
+typedef conn_t *(*lupine_event_conn_resolver)(CUevent event);
+
+void lupine_event_note_recorded(lupine_event_table *table, CUevent event);
+uint32_t lupine_event_collect_query_batch(lupine_event_table *table,
+                                          CUevent primary, conn_t *conn,
+                                          lupine_event_conn_resolver resolver,
+                                          CUevent *events, uint64_t *recorded);
+void lupine_event_note_query_results(lupine_event_table *table,
+                                     const CUevent *events,
+                                     const uint64_t *recorded,
+                                     const CUresult *results, uint32_t count);
+void lupine_event_note_async_dtoh(lupine_event_table *table);
+uint64_t lupine_event_dtoh_issued(lupine_event_table *table);
+void lupine_event_note_dtoh_drained(lupine_event_table *table,
+                                    uint64_t drained);
+
+void lupine_note_event_recorded(CUevent event);
+uint32_t lupine_collect_event_query_batch(CUevent primary, conn_t *conn,
+                                          CUevent *events, uint64_t *recorded);
+void lupine_note_event_query_results(const CUevent *events,
+                                     const uint64_t *recorded,
+                                     const CUresult *results, uint32_t count);
+void lupine_note_async_dtoh_copy();
+uint64_t lupine_async_dtoh_issued_count();
+void lupine_note_async_dtoh_drained(uint64_t drained);

--- a/events_test.cpp
+++ b/events_test.cpp
@@ -1,0 +1,188 @@
+#include "events.h"
+
+#include <iostream>
+
+// events.cpp's conn-aware wrapper binds the routing resolver; the policy tests
+// below inject their own, so a stub satisfies the link without routing.
+extern "C" conn_t *lupine_rpc_conn_for_event(CUevent) { return nullptr; }
+
+namespace {
+
+conn_t *const kConnA = reinterpret_cast<conn_t *>(0x1000);
+conn_t *const kConnB = reinterpret_cast<conn_t *>(0x2000);
+
+CUevent fake_event(uintptr_t index) {
+  return reinterpret_cast<CUevent>(0x100 + index * 8);
+}
+
+conn_t *resolve_all_to_a(CUevent) { return kConnA; }
+
+// Sends the last recorded event of a 16-event run to a different connection.
+conn_t *resolve_last_to_b(CUevent event) {
+  return event == fake_event(15) ? kConnB : kConnA;
+}
+
+bool batch_contains(const CUevent *events, uint32_t count, CUevent event) {
+  for (uint32_t i = 0; i < count; ++i) {
+    if (events[i] == event) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void complete(lupine_event_table *table, const CUevent *events,
+              const uint64_t *recorded, uint32_t count) {
+  CUresult results[kLupineEventQueryBatch];
+  for (uint32_t i = 0; i < count; ++i) {
+    results[i] = CUDA_SUCCESS;
+  }
+  lupine_event_note_query_results(table, events, recorded, results, count);
+}
+
+bool test_completed_event_answers_locally() {
+  lupine_event_table table;
+  CUevent events[kLupineEventQueryBatch];
+  uint64_t recorded[kLupineEventQueryBatch];
+  lupine_event_note_recorded(&table, fake_event(0));
+  uint32_t count = lupine_event_collect_query_batch(
+      &table, fake_event(0), kConnA, resolve_all_to_a, events, recorded);
+  if (count != 1 || events[0] != fake_event(0) || recorded[0] != 1) {
+    std::cerr << "FAIL: first query did not batch the recorded event\n";
+    return false;
+  }
+  complete(&table, events, recorded, count);
+  if (lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
+                                       resolve_all_to_a, events,
+                                       recorded) != 0) {
+    std::cerr << "FAIL: completed event did not answer locally\n";
+    return false;
+  }
+  return true;
+}
+
+bool test_rerecord_forces_fresh_batch() {
+  lupine_event_table table;
+  CUevent events[kLupineEventQueryBatch];
+  uint64_t recorded[kLupineEventQueryBatch];
+  lupine_event_note_recorded(&table, fake_event(0));
+  uint32_t count = lupine_event_collect_query_batch(
+      &table, fake_event(0), kConnA, resolve_all_to_a, events, recorded);
+  complete(&table, events, recorded, count);
+  lupine_event_note_recorded(&table, fake_event(0));
+  count = lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
+                                           resolve_all_to_a, events, recorded);
+  if (count != 1 || recorded[0] != 2) {
+    std::cerr << "FAIL: re-recorded event did not raise the record sequence\n";
+    return false;
+  }
+  // A result carrying the stale sequence must not mark the new record done.
+  uint64_t stale[kLupineEventQueryBatch] = {1};
+  complete(&table, events, stale, 1);
+  if (lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
+                                       resolve_all_to_a, events,
+                                       recorded) == 0) {
+    std::cerr << "FAIL: stale completion answered a newer record locally\n";
+    return false;
+  }
+  return true;
+}
+
+bool test_eviction_is_oldest_recorded() {
+  lupine_event_table table;
+  CUevent events[kLupineEventQueryBatch];
+  uint64_t recorded[kLupineEventQueryBatch];
+  for (uintptr_t i = 0; i < kLupineEventQueryBatch + 1; ++i) {
+    lupine_event_note_recorded(&table, fake_event(i));
+  }
+  uint32_t count = lupine_event_collect_query_batch(
+      &table, fake_event(kLupineEventQueryBatch), kConnA, resolve_all_to_a,
+      events, recorded);
+  if (recorded[0] != kLupineEventQueryBatch + 1) {
+    std::cerr << "FAIL: newest event lost its slot\n";
+    return false;
+  }
+  if (batch_contains(events, count, fake_event(0))) {
+    std::cerr << "FAIL: oldest recorded event was not evicted\n";
+    return false;
+  }
+  count = lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
+                                           resolve_all_to_a, events, recorded);
+  if (count == 0 || events[0] != fake_event(0) || recorded[0] != 0) {
+    std::cerr << "FAIL: untracked event did not force a remote batch\n";
+    return false;
+  }
+  return true;
+}
+
+bool test_batch_caps_and_filters() {
+  lupine_event_table table;
+  CUevent events[kLupineEventQueryBatch];
+  uint64_t recorded[kLupineEventQueryBatch];
+  for (uintptr_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    lupine_event_note_recorded(&table, fake_event(i));
+  }
+  CUevent untracked = fake_event(99);
+  uint32_t count = lupine_event_collect_query_batch(
+      &table, untracked, kConnA, resolve_all_to_a, events, recorded);
+  if (count != kLupineEventQueryBatch || events[0] != untracked ||
+      recorded[0] != 0) {
+    std::cerr << "FAIL: batch was not capped with the primary first\n";
+    return false;
+  }
+  // One event on another connection and one already completed both drop out,
+  // so a full table now leaves room under the cap.
+  CUevent done[1] = {fake_event(3)};
+  uint64_t done_recorded[1] = {4};
+  complete(&table, done, done_recorded, 1);
+  count = lupine_event_collect_query_batch(&table, untracked, kConnA,
+                                           resolve_last_to_b, events, recorded);
+  if (count != kLupineEventQueryBatch - 1) {
+    std::cerr << "FAIL: completed and foreign-connection events were batched\n";
+    return false;
+  }
+  if (batch_contains(events, count, fake_event(3)) ||
+      batch_contains(events, count, fake_event(15))) {
+    std::cerr << "FAIL: excluded event appeared in the batch\n";
+    return false;
+  }
+  return true;
+}
+
+bool test_pending_dtoh_suppresses_local_answer() {
+  lupine_event_table table;
+  CUevent events[kLupineEventQueryBatch];
+  uint64_t recorded[kLupineEventQueryBatch];
+  lupine_event_note_recorded(&table, fake_event(0));
+  uint32_t count = lupine_event_collect_query_batch(
+      &table, fake_event(0), kConnA, resolve_all_to_a, events, recorded);
+  complete(&table, events, recorded, count);
+  lupine_event_note_async_dtoh(&table);
+  if (lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
+                                       resolve_all_to_a, events,
+                                       recorded) == 0) {
+    std::cerr << "FAIL: pending async copy was answered locally\n";
+    return false;
+  }
+  lupine_event_note_dtoh_drained(&table, lupine_event_dtoh_issued(&table));
+  if (lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
+                                       resolve_all_to_a, events,
+                                       recorded) != 0) {
+    std::cerr << "FAIL: drained copy still forced a round trip\n";
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+int main() {
+  if (!test_completed_event_answers_locally() ||
+      !test_rerecord_forces_fresh_batch() ||
+      !test_eviction_is_oldest_recorded() || !test_batch_caps_and_filters() ||
+      !test_pending_dtoh_suppresses_local_answer()) {
+    return 1;
+  }
+  std::cout << "event completion tracking tests passed\n";
+  return 0;
+}

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3159,9 +3159,17 @@ int handle_manual_cuEventRecord(conn_t *conn, bool with_flags) {
   return 0;
 }
 
+// The client batches every event it still has outstanding into one query so a
+// poller walking several events pays one round trip; events[0] is the one the
+// caller asked about and the only one that governs the deferred copy drain.
 int handle_manual_cuEventQuery(conn_t *conn) {
-  CUevent event = nullptr;
-  if (rpc_read(conn, &event, sizeof(event)) < 0) {
+  uint32_t count = 0;
+  if (rpc_read(conn, &count, sizeof(count)) < 0 || count == 0 ||
+      count > LUPINE_EVENT_QUERY_BATCH_MAX) {
+    return -1;
+  }
+  CUevent events[LUPINE_EVENT_QUERY_BATCH_MAX];
+  if (rpc_read(conn, events, count * sizeof(events[0])) < 0) {
     return -1;
   }
   int request_id = rpc_read_end(conn);
@@ -3169,7 +3177,11 @@ int handle_manual_cuEventQuery(conn_t *conn) {
     return -1;
   }
 
-  CUresult result = cuEventQuery(event);
+  CUresult results[LUPINE_EVENT_QUERY_BATCH_MAX];
+  for (uint32_t i = 0; i < count; ++i) {
+    results[i] = cuEventQuery(events[i]);
+  }
+  CUresult result = results[0];
 
   if (rpc_write_start_response(conn, request_id) < 0) {
     return -1;
@@ -3187,7 +3199,8 @@ int handle_manual_cuEventQuery(conn_t *conn) {
       return -1;
     }
   }
-  if (rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+  if (rpc_write(conn, results, count * sizeof(results[0])) < 0 ||
+      rpc_write_end(conn) < 0) {
     lupine_cleanup_pending_dtoh_copies(&pending);
     return -1;
   }

--- a/rpc.h
+++ b/rpc.h
@@ -35,6 +35,11 @@ struct rpc_http2_read_stats {
 // stay uncredited until the staging buffer they landed in retires.
 #define LUPINE_FF_STAGING_WINDOW_BYTES (64ull * 1024 * 1024)
 
+// Events a single RPC_cuEventQuery may carry. The request is a count followed
+// by that many handles, the caller's own first, and the response is one
+// CUresult per handle in the same order.
+#define LUPINE_EVENT_QUERY_BATCH_MAX 16
+
 // Wire layout for LUPINE_RPC_lupineDeviceSnapshot. The response is all or
 // nothing: a non-success result carries no payload, otherwise every device
 // record holds a fixed-size name buffer, uuid, total memory, and a


### PR DESCRIPTION
Per-thread timeline attribution of the remaining makemore step time at 30ms RTT found torch's pin-memory thread gating the training loop: its CachingHostAllocator records an event per H2D copy and polls them one at a time through process_events, costing two serialized cuEventQuery round trips per step (61.5ms) for events the GPU finished long ago. cuEventQuery now carries a count-prefixed batch of handles returning one CUresult each, and the client keeps a 16-slot (event, recorded_seq, completed_seq) table: a query that returned CUDA_SUCCESS for a snapshot generation answers locally until the event is re-recorded, and local answers are suppressed while any async DtoH is outstanding so the server's deferred-copy drain is never skipped. The pin thread drops to one round trip per step, fully overlapped with the main thread's synchronize. Measured (30ms emulated RTT, losses bit-identical, blocking variant unregressed): non-blocking makemore median step 64.5ms to 42.6ms, wall 17.04s to 15.09s. Write coalescing was investigated and rejected by measurement: rpc_write_end costs 19us/op, 2.3ms/step total, and consecutive ops are ~100us apart, so batching would coalesce nothing; Nagle rejected for the delayed-ACK interaction with blocking synchronizes. Remaining gap to the 31ms floor is ~12ms of application CPU (torch ~10ms, lupine wrappers ~3.4ms) that cannot overlap the trailing synchronize. Unit tests 9/9, custom GPU suite 23/23.