### PR TITLE
Cache kernel parameter layouts and host-function misses on the launch path

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -144,8 +144,10 @@ lupine_read_func_param_layout(CUfunction function,
 static CUresult
 lupine_read_kernel_param_layout(CUkernel kernel,
                                 lupine_kernel_param_layout *layout);
-static CUresult lupine_warm_func_param_info(CUfunction function);
-static CUresult lupine_warm_kernel_param_info(CUkernel kernel);
+static CUresult lupine_kernel_param_layout_for(
+    CUfunction function, bool kernel,
+    std::shared_ptr<const lupine_kernel_param_layout> *layout);
+static CUresult lupine_warm_param_layout(CUfunction function, bool kernel);
 
 struct lupine_graph_kernel_node_params_storage {
   CUDA_KERNEL_NODE_PARAMS params = {};
@@ -235,6 +237,12 @@ static std::vector<CUmodule> &lupine_loaded_modules() {
 // otherwise repeat it. Loading a module can turn a miss into a hit, so
 // lupine_remember_loaded_module() drops these. Guarded by
 // lupine_host_function_mutex().
+//
+// A negative entry is only sound because the positive map cannot be filled by
+// anything but lupine_resolve_host_function() itself: we replace libcuda only,
+// so the stub-address-to-kernel-name binding __cudaRegisterFunction() makes
+// inside the real libcudart is never seen by a hook, and dladdr() is the sole
+// way back to the name.
 static std::unordered_set<CUfunction> &lupine_host_function_misses() {
   static auto *misses = new std::unordered_set<CUfunction>();
   return *misses;
@@ -301,23 +309,6 @@ struct lupine_kernel_attribute_key_hash {
   }
 };
 
-struct lupine_param_info_key {
-  uintptr_t handle = 0;
-  size_t index = 0;
-  bool kernel = false;
-
-  bool operator==(const lupine_param_info_key &other) const {
-    return handle == other.handle && index == other.index &&
-           kernel == other.kernel;
-  }
-};
-
-struct lupine_param_info_value {
-  CUresult result = CUDA_ERROR_INVALID_VALUE;
-  size_t offset = 0;
-  size_t size = 0;
-};
-
 struct lupine_param_layout_key {
   uintptr_t handle = 0;
   bool kernel = false;
@@ -365,17 +356,6 @@ struct lupine_occupancy_key_hash {
 struct lupine_param_layout_key_hash {
   size_t operator()(const lupine_param_layout_key &key) const {
     size_t hash = std::hash<uintptr_t>{}(key.handle);
-    hash ^=
-        std::hash<bool>{}(key.kernel) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-    return hash;
-  }
-};
-
-struct lupine_param_info_key_hash {
-  size_t operator()(const lupine_param_info_key &key) const {
-    size_t hash = std::hash<uintptr_t>{}(key.handle);
-    hash ^=
-        std::hash<size_t>{}(key.index) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     hash ^=
         std::hash<bool>{}(key.kernel) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     return hash;
@@ -488,20 +468,13 @@ lupine_kernel_attribute_cache() {
   return *cache;
 }
 
-static libcuckoo::cuckoohash_map<lupine_param_info_key, lupine_param_info_value,
-                                 lupine_param_info_key_hash> &
-lupine_param_info_cache() {
-  static auto *cache =
-      new libcuckoo::cuckoohash_map<lupine_param_info_key,
-                                    lupine_param_info_value,
-                                    lupine_param_info_key_hash>();
-  return *cache;
-}
-
-// Whole-layout cache for the launch path. The per-index lupine_param_info_cache
-// still backs cold reads, but a launch must not walk it once per parameter.
-// Entries are shared_ptr so a concurrent lupine_invalidate_function_caches()
-// cannot free a layout a launch is still reading.
+// The only parameter-info cache. An entry is always a handle's complete
+// layout, never a prefix of one, so index >= count is exactly the
+// CUDA_ERROR_INVALID_VALUE terminator cuFuncGetParamInfo reports and a handle
+// whose layout could not be read end to end stays absent and costs a round
+// trip. Entries are shared_ptr so a concurrent
+// lupine_invalidate_function_caches() cannot free a layout a launch is still
+// reading.
 static libcuckoo::cuckoohash_map<
     lupine_param_layout_key, std::shared_ptr<const lupine_kernel_param_layout>,
     lupine_param_layout_key_hash> &
@@ -1030,7 +1003,8 @@ extern "C" CUresult lupine_record_library_kernel(CUkernel kernel,
     return CUDA_ERROR_INVALID_VALUE;
   }
   lupine_note_function_owner_route(reinterpret_cast<CUfunction>(kernel), route);
-  CUresult result = lupine_warm_kernel_param_info(kernel);
+  CUresult result =
+      lupine_warm_param_layout(reinterpret_cast<CUfunction>(kernel), true);
   if (result != CUDA_SUCCESS) {
     return result;
   }
@@ -1054,7 +1028,7 @@ extern "C" CUresult lupine_record_module_function(CUfunction function,
     return CUDA_ERROR_INVALID_VALUE;
   }
   lupine_note_function_owner_route(function, route);
-  CUresult result = lupine_warm_func_param_info(function);
+  CUresult result = lupine_warm_param_layout(function, false);
   if (result != CUDA_SUCCESS) {
     return result;
   }
@@ -1367,7 +1341,7 @@ static CUresult lupine_resolve_library_kernel_for_route(CUfunction function,
     new_record.kernels_by_route[route_id] = kernel;
   }
   lupine_note_function_owner_route(reinterpret_cast<CUfunction>(kernel), route);
-  result = lupine_warm_kernel_param_info(kernel);
+  result = lupine_warm_param_layout(reinterpret_cast<CUfunction>(kernel), true);
   if (result != CUDA_SUCCESS) {
     return result;
   }
@@ -1445,7 +1419,7 @@ static CUresult lupine_resolve_module_function_for_route(CUfunction function,
     new_record.functions_by_route[route_id] = route_function;
   }
   lupine_note_function_owner_route(route_function, route);
-  result = lupine_warm_func_param_info(route_function);
+  result = lupine_warm_param_layout(route_function, false);
   if (result != CUDA_SUCCESS) {
     return result;
   }
@@ -2153,22 +2127,13 @@ extern "C" CUresult cuDevicePrimaryCtxReset(CUdevice dev) {
   return cuDevicePrimaryCtxReset_v2(dev);
 }
 
-static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
-                                             size_t param_index,
-                                             size_t *param_offset,
-                                             size_t *param_size, bool kernel) {
+static CUresult lupine_cuGetParamInfo_uncached(uintptr_t handle,
+                                               size_t param_index,
+                                               size_t *param_offset,
+                                               size_t *param_size,
+                                               bool kernel) {
   if (param_offset == nullptr || param_size == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  lupine_param_info_key key{handle, param_index, kernel};
-  lupine_param_info_value cached;
-  if (lupine_param_info_cache().find(key, cached)) {
-    if (cached.result == CUDA_SUCCESS) {
-      *param_offset = cached.offset;
-      *param_size = cached.size;
-    }
-    return cached.result;
   }
 
   CUfunction function = reinterpret_cast<CUfunction>(handle);
@@ -2203,15 +2168,32 @@ static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
     }
   }
 
-  if (result == CUDA_SUCCESS || result == CUDA_ERROR_INVALID_VALUE) {
-    lupine_param_info_cache().insert_or_assign(
-        key, lupine_param_info_value{result, offset, size});
-  }
   if (result == CUDA_SUCCESS) {
     *param_offset = offset;
     *param_size = size;
   }
   return result;
+}
+
+static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
+                                             size_t param_index,
+                                             size_t *param_offset,
+                                             size_t *param_size, bool kernel) {
+  if (param_offset == nullptr || param_size == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  std::shared_ptr<const lupine_kernel_param_layout> layout;
+  if (lupine_kernel_param_layout_for(reinterpret_cast<CUfunction>(handle),
+                                     kernel, &layout) != CUDA_SUCCESS) {
+    return lupine_cuGetParamInfo_uncached(handle, param_index, param_offset,
+                                          param_size, kernel);
+  }
+  if (param_index >= layout->count) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  *param_offset = layout->offsets[param_index];
+  *param_size = layout->sizes[param_index];
+  return CUDA_SUCCESS;
 }
 
 extern "C" CUresult cuKernelGetParamInfo(CUkernel kernel, size_t paramIndex,
@@ -2263,7 +2245,7 @@ extern "C" CUresult cuKernelGetFunction(CUfunction *pFunc, CUkernel kernel) {
     CUresult result = real(pFunc, route_kernel);
     if (result == CUDA_SUCCESS) {
       lupine_note_function_owner_route(*pFunc, route);
-      result = lupine_warm_func_param_info(*pFunc);
+      result = lupine_warm_param_layout(*pFunc, false);
     }
     if (result == CUDA_SUCCESS) {
       lupine_kernel_function_cache().insert_or_assign(key, *pFunc);
@@ -2284,7 +2266,7 @@ extern "C" CUresult cuKernelGetFunction(CUfunction *pFunc, CUkernel kernel) {
   }
   if (return_value == CUDA_SUCCESS) {
     lupine_note_function_owner(function, conn);
-    return_value = lupine_warm_func_param_info(function);
+    return_value = lupine_warm_param_layout(function, false);
   }
   if (return_value == CUDA_SUCCESS) {
     lupine_kernel_function_cache().insert_or_assign(key, function);
@@ -2481,7 +2463,7 @@ static CUresult lupine_get_remote_private_module_node(CUcontext context,
   }
   if (result == CUDA_SUCCESS && *server_node != nullptr) {
     lupine_note_function_owner_route(*server_node, route);
-    result = lupine_warm_func_param_info(*server_node);
+    result = lupine_warm_param_layout(*server_node, false);
   }
   return result;
 }
@@ -4430,20 +4412,18 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
       if (record.kernel == nullptr) {
         continue;
       }
+      auto layout = std::make_shared<lupine_kernel_param_layout>();
+      layout->count = record.param_count;
       for (uint32_t index = 0; index < record.param_count; ++index) {
-        lupine_param_info_cache().insert_or_assign(
-            lupine_param_info_key{reinterpret_cast<uintptr_t>(record.kernel),
-                                  index, true},
-            lupine_param_info_value{CUDA_SUCCESS,
-                                    static_cast<size_t>(
-                                        record.params[index * 2]),
-                                    static_cast<size_t>(
-                                        record.params[index * 2 + 1])});
+        layout->offsets.push_back(
+            static_cast<size_t>(record.params[index * 2]));
+        layout->sizes.push_back(
+            static_cast<size_t>(record.params[index * 2 + 1]));
       }
-      lupine_param_info_cache().insert_or_assign(
-          lupine_param_info_key{reinterpret_cast<uintptr_t>(record.kernel),
-                                record.param_count, true},
-          lupine_param_info_value{CUDA_ERROR_INVALID_VALUE, 0, 0});
+      lupine_param_layout_cache().insert_or_assign(
+          lupine_param_layout_key{reinterpret_cast<uintptr_t>(record.kernel),
+                                  true},
+          layout);
       if (lupine_record_library_kernel(record.kernel, *library,
                                        record.name.c_str(), route) ==
           CUDA_SUCCESS) {
@@ -4456,80 +4436,6 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
   return return_value;
 }
 
-static CUresult
-lupine_read_func_param_layout(CUfunction function,
-                              lupine_kernel_param_layout *layout) {
-  if (layout == nullptr) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-  *layout = {};
-  for (uint32_t i = 0;; ++i) {
-    size_t offset = 0;
-    size_t size = 0;
-    CUresult result = cuFuncGetParamInfo(function, i, &offset, &size);
-    if (result == CUDA_ERROR_INVALID_VALUE) {
-      return CUDA_SUCCESS;
-    }
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-    layout->offsets.push_back(offset);
-    layout->sizes.push_back(size);
-    layout->count = i + 1;
-  }
-}
-
-static CUresult
-lupine_read_kernel_param_layout(CUkernel kernel,
-                                lupine_kernel_param_layout *layout) {
-  if (layout == nullptr) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-  *layout = {};
-  for (uint32_t i = 0;; ++i) {
-    size_t offset = 0;
-    size_t size = 0;
-    CUresult result = cuKernelGetParamInfo(kernel, i, &offset, &size);
-    if (result == CUDA_ERROR_INVALID_VALUE) {
-      return CUDA_SUCCESS;
-    }
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-    layout->offsets.push_back(offset);
-    layout->sizes.push_back(size);
-    layout->count = i + 1;
-  }
-}
-
-static CUresult lupine_warm_func_param_info(CUfunction function) {
-  for (size_t i = 0;; ++i) {
-    size_t offset = 0;
-    size_t size = 0;
-    CUresult result = cuFuncGetParamInfo(function, i, &offset, &size);
-    if (result == CUDA_ERROR_INVALID_VALUE) {
-      return CUDA_SUCCESS;
-    }
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-  }
-}
-
-static CUresult lupine_warm_kernel_param_info(CUkernel kernel) {
-  for (size_t i = 0;; ++i) {
-    size_t offset = 0;
-    size_t size = 0;
-    CUresult result = cuKernelGetParamInfo(kernel, i, &offset, &size);
-    if (result == CUDA_ERROR_INVALID_VALUE) {
-      return CUDA_SUCCESS;
-    }
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-  }
-}
-
 // A handle's parameter layout is fixed for the life of the handle, so resolve
 // it once instead of once per launch.
 static CUresult lupine_kernel_param_layout_for(
@@ -4540,21 +4446,59 @@ static CUresult lupine_kernel_param_layout_for(
     return CUDA_SUCCESS;
   }
   auto resolved = std::make_shared<lupine_kernel_param_layout>();
-  CUresult status =
-      kernel ? lupine_read_kernel_param_layout(
-                   reinterpret_cast<CUkernel>(function), resolved.get())
-             : lupine_read_func_param_layout(function, resolved.get());
-  if (status != CUDA_SUCCESS) {
-    return status;
+  for (uint32_t i = 0;; ++i) {
+    size_t offset = 0;
+    size_t size = 0;
+    CUresult result = lupine_cuGetParamInfo_uncached(
+        reinterpret_cast<uintptr_t>(function), i, &offset, &size, kernel);
+    if (result == CUDA_ERROR_INVALID_VALUE) {
+      break;
+    }
+    if (result != CUDA_SUCCESS) {
+      return result;
+    }
+    resolved->offsets.push_back(offset);
+    resolved->sizes.push_back(size);
+    resolved->count = i + 1;
   }
   *layout = resolved;
   lupine_param_layout_cache().insert_or_assign(key, resolved);
   return CUDA_SUCCESS;
 }
 
+static CUresult lupine_copy_param_layout(CUfunction function, bool kernel,
+                                         lupine_kernel_param_layout *out) {
+  if (out == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  std::shared_ptr<const lupine_kernel_param_layout> layout;
+  CUresult result = lupine_kernel_param_layout_for(function, kernel, &layout);
+  if (result == CUDA_SUCCESS) {
+    *out = *layout;
+  }
+  return result;
+}
+
+static CUresult
+lupine_read_func_param_layout(CUfunction function,
+                              lupine_kernel_param_layout *layout) {
+  return lupine_copy_param_layout(function, false, layout);
+}
+
+static CUresult
+lupine_read_kernel_param_layout(CUkernel kernel,
+                                lupine_kernel_param_layout *layout) {
+  return lupine_copy_param_layout(reinterpret_cast<CUfunction>(kernel), true,
+                                  layout);
+}
+
+static CUresult lupine_warm_param_layout(CUfunction function, bool kernel) {
+  std::shared_ptr<const lupine_kernel_param_layout> layout;
+  return lupine_kernel_param_layout_for(function, kernel, &layout);
+}
+
 extern "C" void lupine_invalidate_function_caches() {
   lupine_param_layout_cache().clear();
-  lupine_param_info_cache().clear();
   lupine_kernel_function_cache().clear();
   lupine_occupancy_cache().clear();
   lupine_kernel_attribute_cache().clear();

--- a/client.cpp
+++ b/client.cpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <netdb.h>
 #include <netinet/tcp.h>
@@ -33,6 +34,7 @@
 #include <thread>
 #include <unistd.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -228,6 +230,16 @@ static std::vector<CUmodule> &lupine_loaded_modules() {
   return modules;
 }
 
+// Handles that are not host kernel stubs. Resolving one costs a dladdr() plus a
+// scan of every loaded module, and every launch of a server-side handle would
+// otherwise repeat it. Loading a module can turn a miss into a hit, so
+// lupine_remember_loaded_module() drops these. Guarded by
+// lupine_host_function_mutex().
+static std::unordered_set<CUfunction> &lupine_host_function_misses() {
+  static auto *misses = new std::unordered_set<CUfunction>();
+  return *misses;
+}
+
 struct lupine_device_attribute_key {
   int device = 0;
   int attribute = 0;
@@ -306,6 +318,15 @@ struct lupine_param_info_value {
   size_t size = 0;
 };
 
+struct lupine_param_layout_key {
+  uintptr_t handle = 0;
+  bool kernel = false;
+
+  bool operator==(const lupine_param_layout_key &other) const {
+    return handle == other.handle && kernel == other.kernel;
+  }
+};
+
 struct lupine_device_attribute_key_hash {
   size_t operator()(const lupine_device_attribute_key &key) const {
     return (static_cast<size_t>(static_cast<unsigned int>(key.device)) << 32) ^
@@ -337,6 +358,15 @@ struct lupine_occupancy_key_hash {
             (hash >> 2);
     hash ^= std::hash<bool>{}(key.with_flags) + 0x9e3779b9 + (hash << 6) +
             (hash >> 2);
+    return hash;
+  }
+};
+
+struct lupine_param_layout_key_hash {
+  size_t operator()(const lupine_param_layout_key &key) const {
+    size_t hash = std::hash<uintptr_t>{}(key.handle);
+    hash ^=
+        std::hash<bool>{}(key.kernel) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     return hash;
   }
 };
@@ -468,6 +498,21 @@ lupine_param_info_cache() {
   return *cache;
 }
 
+// Whole-layout cache for the launch path. The per-index lupine_param_info_cache
+// still backs cold reads, but a launch must not walk it once per parameter.
+// Entries are shared_ptr so a concurrent lupine_invalidate_function_caches()
+// cannot free a layout a launch is still reading.
+static libcuckoo::cuckoohash_map<
+    lupine_param_layout_key, std::shared_ptr<const lupine_kernel_param_layout>,
+    lupine_param_layout_key_hash> &
+lupine_param_layout_cache() {
+  static auto *cache = new libcuckoo::cuckoohash_map<
+      lupine_param_layout_key,
+      std::shared_ptr<const lupine_kernel_param_layout>,
+      lupine_param_layout_key_hash>();
+  return *cache;
+}
+
 // Filled from the kernel table piggybacked on the cuLibraryLoadData response;
 // serves cuLibraryGetKernel without a round trip.
 struct lupine_library_kernel_name_key {
@@ -542,6 +587,7 @@ static void lupine_remember_loaded_module(CUmodule module) {
   auto &modules = lupine_loaded_modules();
   if (std::find(modules.begin(), modules.end(), module) == modules.end()) {
     modules.push_back(module);
+    lupine_host_function_misses().clear();
   }
 }
 
@@ -1527,11 +1573,20 @@ static CUfunction lupine_resolve_host_function(CUfunction function) {
     if (mapped != lupine_host_function_map().end()) {
       return mapped->second;
     }
+    if (lupine_host_function_misses().count(function) != 0) {
+      return function;
+    }
   }
+
+  auto remember_miss = [&]() {
+    std::lock_guard<std::mutex> lock(lupine_host_function_mutex());
+    lupine_host_function_misses().insert(function);
+    return function;
+  };
 
   Dl_info info = {};
   if (dladdr(reinterpret_cast<void *>(function), &info) == 0) {
-    return function;
+    return remember_miss();
   }
   std::string symbol_name;
   const char *kernel_name = info.dli_sname;
@@ -1547,7 +1602,7 @@ static CUfunction lupine_resolve_host_function(CUfunction function) {
   if (kernel_name == nullptr) {
     LUPINE_TRACE_LOG("LUPINE could not resolve host kernel symbol for "
                      << reinterpret_cast<void *>(function));
-    return function;
+    return remember_miss();
   }
 
   std::vector<CUmodule> modules;
@@ -1572,7 +1627,7 @@ static CUfunction lupine_resolve_host_function(CUfunction function) {
                                          << modules.size()
                                          << " loaded modules");
 
-  return function;
+  return remember_miss();
 }
 
 static CUfunction lupine_translate_private_function(CUfunction function) {
@@ -4475,7 +4530,30 @@ static CUresult lupine_warm_kernel_param_info(CUkernel kernel) {
   }
 }
 
+// A handle's parameter layout is fixed for the life of the handle, so resolve
+// it once instead of once per launch.
+static CUresult lupine_kernel_param_layout_for(
+    CUfunction function, bool kernel,
+    std::shared_ptr<const lupine_kernel_param_layout> *layout) {
+  lupine_param_layout_key key{reinterpret_cast<uintptr_t>(function), kernel};
+  if (lupine_param_layout_cache().find(key, *layout)) {
+    return CUDA_SUCCESS;
+  }
+  auto resolved = std::make_shared<lupine_kernel_param_layout>();
+  CUresult status =
+      kernel ? lupine_read_kernel_param_layout(
+                   reinterpret_cast<CUkernel>(function), resolved.get())
+             : lupine_read_func_param_layout(function, resolved.get());
+  if (status != CUDA_SUCCESS) {
+    return status;
+  }
+  *layout = resolved;
+  lupine_param_layout_cache().insert_or_assign(key, resolved);
+  return CUDA_SUCCESS;
+}
+
 extern "C" void lupine_invalidate_function_caches() {
+  lupine_param_layout_cache().clear();
   lupine_param_info_cache().clear();
   lupine_kernel_function_cache().clear();
   lupine_occupancy_cache().clear();
@@ -4543,27 +4621,25 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
                       blockDimZ, sharedMemBytes, hStream, kernelParams, extra);
   }
 
-  lupine_kernel_param_layout layout;
-  status = kernel_handle ? lupine_read_kernel_param_layout(
-                               reinterpret_cast<CUkernel>(f), &layout)
-                         : lupine_read_func_param_layout(f, &layout);
+  std::shared_ptr<const lupine_kernel_param_layout> layout_ref;
+  status = lupine_kernel_param_layout_for(f, kernel_handle, &layout_ref);
   if (status != CUDA_SUCCESS) {
     return status;
   }
 
   size_t payload_size = 0;
-  for (uint32_t i = 0; i < layout.count; ++i) {
+  for (uint32_t i = 0; i < layout_ref->count; ++i) {
     if (kernelParams == nullptr) {
       return CUDA_ERROR_INVALID_VALUE;
     }
     if (kernelParams[i] == nullptr) {
       return CUDA_ERROR_INVALID_VALUE;
     }
-    payload_size += layout.sizes[i];
+    payload_size += layout_ref->sizes[i];
   }
 
   lupine_route arg_route = lupine_route_from_known_kernel_deviceptr_args(
-      kernelParams, layout, launch_route);
+      kernelParams, *layout_ref, launch_route);
   if (lupine_route_identity(arg_route) != lupine_route_identity(launch_route)) {
     launch_route = arg_route;
     status = lupine_resolve_launch_function_for_route(
@@ -4573,23 +4649,22 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
     }
     route = lupine_route_for_function(f);
 
-    status = kernel_handle ? lupine_read_kernel_param_layout(
-                                 reinterpret_cast<CUkernel>(f), &layout)
-                           : lupine_read_func_param_layout(f, &layout);
+    status = lupine_kernel_param_layout_for(f, kernel_handle, &layout_ref);
     if (status != CUDA_SUCCESS) {
       return status;
     }
     payload_size = 0;
-    for (uint32_t i = 0; i < layout.count; ++i) {
+    for (uint32_t i = 0; i < layout_ref->count; ++i) {
       if (kernelParams == nullptr || kernelParams[i] == nullptr) {
         return CUDA_ERROR_INVALID_VALUE;
       }
-      payload_size += layout.sizes[i];
+      payload_size += layout_ref->sizes[i];
     }
     LUPINE_TRACE_LOG("LUPINE cuLaunchKernel rerouted by args f="
                      << f << " route=" << lupine_route_identity(route));
   }
 
+  const lupine_kernel_param_layout &layout = *layout_ref;
   bool used_managed_mapping = false;
   std::vector<CUdeviceptr> translated_params(layout.count);
   std::vector<void *> rpc_params(layout.count);
@@ -4669,27 +4744,25 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
                            : real(config, f, kernelParams, extra);
   }
 
-  lupine_kernel_param_layout layout;
-  status = kernel_handle ? lupine_read_kernel_param_layout(
-                               reinterpret_cast<CUkernel>(f), &layout)
-                         : lupine_read_func_param_layout(f, &layout);
+  std::shared_ptr<const lupine_kernel_param_layout> layout_ref;
+  status = lupine_kernel_param_layout_for(f, kernel_handle, &layout_ref);
   if (status != CUDA_SUCCESS) {
     return status;
   }
 
   size_t payload_size = 0;
-  for (uint32_t i = 0; i < layout.count; ++i) {
+  for (uint32_t i = 0; i < layout_ref->count; ++i) {
     if (kernelParams == nullptr) {
       return CUDA_ERROR_INVALID_VALUE;
     }
     if (kernelParams[i] == nullptr) {
       return CUDA_ERROR_INVALID_VALUE;
     }
-    payload_size += layout.sizes[i];
+    payload_size += layout_ref->sizes[i];
   }
 
   lupine_route arg_route = lupine_route_from_known_kernel_deviceptr_args(
-      kernelParams, layout, launch_route);
+      kernelParams, *layout_ref, launch_route);
   if (lupine_route_identity(arg_route) != lupine_route_identity(launch_route)) {
     launch_route = arg_route;
     status = lupine_resolve_launch_function_for_route(
@@ -4699,21 +4772,20 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
     }
     route = lupine_route_for_function(f);
 
-    status = kernel_handle ? lupine_read_kernel_param_layout(
-                                 reinterpret_cast<CUkernel>(f), &layout)
-                           : lupine_read_func_param_layout(f, &layout);
+    status = lupine_kernel_param_layout_for(f, kernel_handle, &layout_ref);
     if (status != CUDA_SUCCESS) {
       return status;
     }
     payload_size = 0;
-    for (uint32_t i = 0; i < layout.count; ++i) {
+    for (uint32_t i = 0; i < layout_ref->count; ++i) {
       if (kernelParams == nullptr || kernelParams[i] == nullptr) {
         return CUDA_ERROR_INVALID_VALUE;
       }
-      payload_size += layout.sizes[i];
+      payload_size += layout_ref->sizes[i];
     }
   }
 
+  const lupine_kernel_param_layout &layout = *layout_ref;
   bool used_managed_mapping = false;
   std::vector<CUdeviceptr> translated_params(layout.count);
   std::vector<void *> rpc_params(layout.count);

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1997,11 +1997,31 @@ int handle_manual_cuModuleGetGlobal_v2(conn_t *conn) {
   return 0;
 }
 
-CUresult lupine_get_kernel_param_layout(CUfunction f,
-                                        lupine_kernel_param_layout *layout) {
-  if (layout == nullptr) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
+// The driver rebuilds a kernel's parameter layout from its metadata on every
+// cuFuncGetParamInfo/cuKernelGetParamInfo call, which every launch would
+// otherwise repeat once per parameter. A handle's layout is fixed for the life
+// of the handle, so memoize it and drop the table when a module or library
+// unloads, before any handle can be reused.
+static std::mutex &lupine_kernel_param_layout_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+static std::unordered_map<CUfunction, lupine_kernel_param_layout> &
+lupine_kernel_param_layout_cache() {
+  static auto *cache =
+      new std::unordered_map<CUfunction, lupine_kernel_param_layout>();
+  return *cache;
+}
+
+void lupine_forget_kernel_param_layouts() {
+  std::lock_guard<std::mutex> lock(lupine_kernel_param_layout_mutex());
+  lupine_kernel_param_layout_cache().clear();
+}
+
+static CUresult
+lupine_read_kernel_param_layout(CUfunction f,
+                                lupine_kernel_param_layout *layout) {
   *layout = {};
   bool use_kernel_info = false;
   for (uint32_t i = 0;; ++i) {
@@ -2030,6 +2050,28 @@ CUresult lupine_get_kernel_param_layout(CUfunction f,
     layout->count = i + 1;
   }
   return CUDA_SUCCESS;
+}
+
+CUresult lupine_get_kernel_param_layout(CUfunction f,
+                                        lupine_kernel_param_layout *layout) {
+  if (layout == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  {
+    std::lock_guard<std::mutex> lock(lupine_kernel_param_layout_mutex());
+    auto &cache = lupine_kernel_param_layout_cache();
+    auto cached = cache.find(f);
+    if (cached != cache.end()) {
+      *layout = cached->second;
+      return CUDA_SUCCESS;
+    }
+  }
+  CUresult result = lupine_read_kernel_param_layout(f, layout);
+  if (result == CUDA_SUCCESS) {
+    std::lock_guard<std::mutex> lock(lupine_kernel_param_layout_mutex());
+    lupine_kernel_param_layout_cache()[f] = *layout;
+  }
+  return result;
 }
 
 int handle_manual_cuLaunchKernel(conn_t *conn) {

--- a/manual_server.h
+++ b/manual_server.h
@@ -9,6 +9,7 @@ struct lupine_kernel_param_layout;
 
 CUresult lupine_get_kernel_param_layout(CUfunction f,
                                         lupine_kernel_param_layout *layout);
+void lupine_forget_kernel_param_layouts();
 
 int handle_manual_cuGetErrorName(conn_t *conn);
 int handle_manual_cuGetErrorString(conn_t *conn);

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -476,17 +476,19 @@ static void lupine_disable_dirty_tracking(void *host,
   allocation.fresh_chunk_count = 0;
 }
 
-static std::vector<lupine_mapped_host_snapshot> lupine_mapped_host_snapshots() {
-  std::vector<lupine_mapped_host_snapshot> snapshots;
+// Callers copy the table out because acting on an entry needs
+// lupine_host_allocation_mutex() again; they pass in storage so the launch path
+// does not allocate one per launch.
+static void
+lupine_mapped_host_snapshots(std::vector<lupine_mapped_host_snapshot> *out) {
+  out->clear();
   std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
   for (const auto &entry : lupine_mutable_host_allocations_locked()) {
     if (entry.second.device_ptr != 0 && !entry.second.local_cuda) {
-      snapshots.push_back({entry.first, entry.second.size,
-                           entry.second.device_ptr, entry.second.device_dirty,
-                           entry.second.managed});
+      out->push_back({entry.first, entry.second.size, entry.second.device_ptr,
+                      entry.second.device_dirty, entry.second.managed});
     }
   }
-  return snapshots;
 }
 
 extern "C" void lupine_mark_host_range_clean(void *host, size_t size) {
@@ -849,8 +851,10 @@ CUresult lupine_sync_mapped_host_to_device_for_launch(
   if (used_managed_mapping != nullptr) {
     *used_managed_mapping = false;
   }
-  std::vector<lupine_mapped_host_snapshot> snapshots =
-      lupine_mapped_host_snapshots();
+  // Reused across launches on this thread; the loop below only reads it and
+  // never re-enters the launch path.
+  static thread_local std::vector<lupine_mapped_host_snapshot> snapshots;
+  lupine_mapped_host_snapshots(&snapshots);
   bool used_managed = false;
   for (const auto &mapping : snapshots) {
     for (uint32_t i = 0; i < count; ++i) {
@@ -1157,7 +1161,9 @@ extern "C" void lupine_ensure_mapped_host_readable(const void *host,
 }
 
 extern "C" CUresult lupine_sync_mapped_device_to_host() {
-  for (const auto &mapping : lupine_mapped_host_snapshots()) {
+  std::vector<lupine_mapped_host_snapshot> mappings;
+  lupine_mapped_host_snapshots(&mappings);
+  for (const auto &mapping : mappings) {
     if (!mapping.device_dirty || mapping.size == 0) {
       continue;
     }

--- a/server.cpp
+++ b/server.cpp
@@ -287,6 +287,12 @@ lupine_manual_handlers() {
 static int lupine_handle_rpc_request(conn_t *conn, int op) {
   LUPINE_TRACE_LOG("LUPINE server handling op " << op);
 
+  // Unloading frees the function handles the layout cache is keyed by, and the
+  // driver may hand the same address back to a later load.
+  if (op == RPC_cuModuleUnload || op == RPC_cuLibraryUnload) {
+    lupine_forget_kernel_param_layouts();
+  }
+
   const auto &manual_handlers = lupine_manual_handlers();
   auto manual = manual_handlers.find(op);
   if (manual != manual_handlers.end()) {


### PR DESCRIPTION
CPU profiling (perf, client and server, against a native baseline of 1.28ms/step on the same GPU) attributed the ~12ms zero-RTT step cost: not RTT-bound at LAN — 139 cuLaunchKernel wrappers per step at ~41us of client CPU each, dominated by per-parameter cuckoo-map lookups in the layout path, a dladdr() call per launch that takes the loader lock and serializes the main and autograd threads (positive-only cache; misses were never cached), per-launch vector allocations, and on the server the driver rebuilding param layouts via snprintf on every cuFuncGetParamInfo. Changes, each isolated by alternating binary swaps: whole-layout cache keyed by handle behind a shared_ptr so concurrent invalidation cannot free a layout mid-launch (-1.0ms), negative dladdr cache dropped on module load (-0.4ms including the lock-contention relief), caller-provided scratch for the mapped-host snapshot, and server-side layout memoization dropped on module/library unload (-0.4ms). A stack-array h2 write buffer showed no measurable benefit and was reverted rather than shipped. Measured: LAN median step 13.11 to 11.55ms; at 30ms netem 42.49 to 41.71ms (non-blocking) and 104.89 to 102.33ms (blocking); losses bit-identical; unit 9/9, custom GPU 23/23. Remaining vs the native floor, quantified for follow-up: ~2.2ms of global routing-mutex traffic on the launch path (~10-20 acquisitions per launch, the likely source of the main thread's 44% futex share, plus the known O(N) deviceptr scan), ~1.8ms of per-op sendmsg syscalls (WSL2-expensive; fixing means batching, deliberately out of scope), ~0.9ms of cached-lookup overhead that the cache.cpp epoch scheme would remove, remainder torch's own dispatcher.