### PR TITLE
Parallelize device snapshot collection

### DIFF
--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3687,6 +3687,44 @@ struct lupine_device_snapshot_record {
   std::vector<int32_t> pairs;
 };
 
+static CUresult
+lupine_build_device_snapshot_record(size_t ordinal,
+                                    lupine_device_snapshot_record *record) {
+  CUdevice device = 0;
+  size_t bytes = 0;
+  CUresult result = cuDeviceGet(&device, static_cast<int>(ordinal));
+  if (result == CUDA_SUCCESS) {
+    result = cuDeviceGetName(record->name, sizeof(record->name), device);
+    record->name[sizeof(record->name) - 1] = '\0';
+  }
+  if (result == CUDA_SUCCESS) {
+    result = cuDeviceGetUuid_v2(&record->uuid, device);
+  }
+  if (result == CUDA_SUCCESS) {
+    result = cuDeviceTotalMem_v2(&bytes, device);
+    record->total_mem = bytes;
+  }
+  if (result != CUDA_SUCCESS) {
+    return result;
+  }
+
+  try {
+    record->pairs.reserve(static_cast<size_t>(CU_DEVICE_ATTRIBUTE_MAX - 1) * 2);
+  } catch (...) {
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  for (int attrib = 1; attrib < CU_DEVICE_ATTRIBUTE_MAX; ++attrib) {
+    int value = 0;
+    if (cuDeviceGetAttribute(&value, static_cast<CUdevice_attribute>(attrib),
+                             device) == CUDA_SUCCESS) {
+      record->pairs.push_back(static_cast<int32_t>(attrib));
+      record->pairs.push_back(static_cast<int32_t>(value));
+    }
+  }
+  record->pair_count = static_cast<uint32_t>(record->pairs.size() / 2);
+  return CUDA_SUCCESS;
+}
+
 int handle_manual_lupineDeviceSnapshot(conn_t *conn) {
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
@@ -3702,40 +3740,44 @@ int handle_manual_lupineDeviceSnapshot(conn_t *conn) {
   // rpc_write queues iovecs that are only sent at rpc_write_end, so all
   // records are built first in storage that stays stable until then.
   std::vector<lupine_device_snapshot_record> records;
+  std::vector<CUresult> record_results;
   if (result == CUDA_SUCCESS) {
     try {
       records.resize(static_cast<size_t>(device_count));
+      record_results.resize(records.size(), CUDA_ERROR_UNKNOWN);
     } catch (...) {
       result = CUDA_ERROR_OUT_OF_MEMORY;
     }
   }
-  for (size_t ordinal = 0; result == CUDA_SUCCESS && ordinal < records.size();
-       ++ordinal) {
-    auto &record = records[ordinal];
-    CUdevice device = 0;
-    size_t bytes = 0;
-    result = cuDeviceGet(&device, static_cast<int>(ordinal));
-    if (result == CUDA_SUCCESS) {
-      result = cuDeviceGetName(record.name, sizeof(record.name), device);
-      record.name[sizeof(record.name) - 1] = '\0';
+  if (result == CUDA_SUCCESS && !records.empty()) {
+    std::vector<std::thread> workers;
+    auto build_record = [&records, &record_results](size_t ordinal) {
+      record_results[ordinal] =
+          lupine_build_device_snapshot_record(ordinal, &records[ordinal]);
+    };
+    size_t next_ordinal = 1;
+    try {
+      workers.reserve(records.size() - 1);
+      for (; next_ordinal < records.size(); ++next_ordinal) {
+        workers.emplace_back(build_record, next_ordinal);
+      }
+    } catch (...) {
+      // Any unlaunched devices fall back to this RPC thread below.
     }
-    if (result == CUDA_SUCCESS) {
-      result = cuDeviceGetUuid_v2(&record.uuid, device);
+
+    build_record(0);
+    for (size_t ordinal = next_ordinal; ordinal < records.size(); ++ordinal) {
+      build_record(ordinal);
     }
-    if (result == CUDA_SUCCESS) {
-      result = cuDeviceTotalMem_v2(&bytes, device);
-      record.total_mem = bytes;
+    for (auto &worker : workers) {
+      worker.join();
     }
-    for (int attrib = 1; result == CUDA_SUCCESS && attrib < CU_DEVICE_ATTRIBUTE_MAX;
-         ++attrib) {
-      int value = 0;
-      if (cuDeviceGetAttribute(&value, static_cast<CUdevice_attribute>(attrib),
-                               device) == CUDA_SUCCESS) {
-        record.pairs.push_back(static_cast<int32_t>(attrib));
-        record.pairs.push_back(static_cast<int32_t>(value));
+    for (CUresult record_result : record_results) {
+      if (record_result != CUDA_SUCCESS) {
+        result = record_result;
+        break;
       }
     }
-    record.pair_count = static_cast<uint32_t>(record.pairs.size() / 2);
   }
 
   uint32_t devices = static_cast<uint32_t>(records.size());


### PR DESCRIPTION
## What changed

- build each GPU's immutable device snapshot concurrently on the server
- use the existing RPC worker for GPU 0 and one child worker for each additional GPU
- preserve the single-GPU path without creating a child thread
- fall back to collecting unlaunched workers sequentially if thread creation is unavailable
- preserve ordinal-ordered error selection and the existing wire format

## Why

The snapshot RPC currently queries name, UUID, memory, and every device attribute for each GPU serially. Those device records are independent, so multi-GPU servers pay the sum of each GPU's metadata-query time before sending the response.

## Impact

On `inferable-node-008` (RTX 2070 SUPER + RTX 4090), 1,000 warm server-side snapshot samples showed:

- sequential median: 2.048 ms
- parallel median: 1.176 ms
- reduction: 42.6% (1.74x speedup)
- one visible GPU: 0.872 ms for both paths

Across 30 fresh end-to-end clients over the current ~50 ms network path, median first-snapshot latency improved from 52.855 ms to 51.244 ms (3.0%). Lower-latency deployments and servers with more GPUs should expose more of the server-side gain.

## Validation

- complete Release build
- CTest: 10/10 passed (2 environment-dependent SIGTERM cases skipped)
- `test_invalid_device_ordinal` against the branch server on node 008
- baseline and parallel servers returned identical serialized metadata for both GPUs
- clang-format and `git diff --check`
