### PR TITLE
Bump Python package to 1.0.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lupine"
-version = "0.5.0"
+version = "1.0.0"
 description = "Small PyTorch adapter helpers for LUPINE-backed CUDA devices"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -252,7 +252,7 @@ wheels = [
 
 [[package]]
 name = "lupine"
-version = "0.5.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Summary

- bump the Python package version from `0.5.0` to `1.0.0`
- keep the uv lockfile package metadata in sync

## Impact

This prepares the first stable Python package release. There are no runtime behavior changes.

## Validation

- `uv lock --check`
- `uv run --all-extras pytest` (82 passed, 1 skipped)
- `uv build`
