### PR TITLE
Cache function attributes and make kernel attribute sets async

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -480,20 +480,6 @@ lupine_kernel_attribute_cache() {
   return *cache;
 }
 
-static libcuckoo::cuckoohash_map<lupine_kernel_attribute_key, int,
-                                 lupine_kernel_attribute_key_hash> &
-lupine_kernel_attribute_set_cache() {
-  static auto *cache =
-      new libcuckoo::cuckoohash_map<lupine_kernel_attribute_key, int,
-                                    lupine_kernel_attribute_key_hash>();
-  return *cache;
-}
-
-static std::mutex &lupine_kernel_attribute_set_mutex() {
-  static auto *mutex = new std::mutex();
-  return *mutex;
-}
-
 static libcuckoo::cuckoohash_map<lupine_function_attribute_key, int,
                                  lupine_function_attribute_key_hash> &
 lupine_function_attribute_cache() {
@@ -2377,54 +2363,6 @@ extern "C" CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
   return return_value;
 }
 
-extern "C" CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
-                                         CUkernel kernel, CUdevice dev) {
-  lupine_route route = lupine_route_for_device(&dev);
-  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE) {
-    return CUDA_ERROR_INVALID_DEVICE;
-  }
-
-  lupine_kernel_attribute_key key{lupine_route_identity(route), kernel,
-                                  static_cast<int>(attrib),
-                                  static_cast<int>(dev)};
-  std::lock_guard<std::mutex> lock(lupine_kernel_attribute_set_mutex());
-  int cached_value = 0;
-  if (lupine_kernel_attribute_set_cache().find(key, cached_value) &&
-      cached_value == val) {
-    return CUDA_SUCCESS;
-  }
-
-  using real_fn_t = CUresult (*)(CUfunction_attribute, int, CUkernel, CUdevice);
-  CUresult return_value;
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuKernelSetAttribute",
-                                                  &return_value, attrib, val,
-                                                  kernel, dev)) {
-    if (return_value == CUDA_SUCCESS) {
-      lupine_kernel_attribute_set_cache().insert_or_assign(key, val);
-      lupine_kernel_attribute_cache().erase(key);
-    }
-    return return_value;
-  }
-
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
-      rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
-      rpc_write(conn, &val, sizeof(val)) < 0 ||
-      rpc_write(conn, &kernel, sizeof(kernel)) < 0 ||
-      rpc_write(conn, &dev, sizeof(dev)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (return_value == CUDA_SUCCESS) {
-    lupine_kernel_attribute_set_cache().insert_or_assign(key, val);
-    lupine_kernel_attribute_cache().erase(key);
-  }
-  return return_value;
-}
-
 extern "C" CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
                                        CUfunction hfunc) {
   if (pi == nullptr) {
@@ -2471,6 +2409,13 @@ extern "C" CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
 
 extern "C" void lupine_invalidate_kernel_attribute_cache() {
   lupine_kernel_attribute_cache().clear();
+}
+
+extern "C" void lupine_kernel_attribute_cache_erase(int route_id,
+                                                    CUkernel kernel, int attrib,
+                                                    int dev) {
+  lupine_kernel_attribute_cache().erase(
+      lupine_kernel_attribute_key{route_id, kernel, attrib, dev});
 }
 
 extern "C" void lupine_invalidate_function_attribute_cache() {
@@ -4660,7 +4605,6 @@ extern "C" void lupine_invalidate_function_caches() {
   lupine_kernel_function_cache().clear();
   lupine_occupancy_cache().clear();
   lupine_kernel_attribute_cache().clear();
-  lupine_kernel_attribute_set_cache().clear();
   lupine_function_attribute_cache().clear();
 }
 

--- a/client.cpp
+++ b/client.cpp
@@ -289,6 +289,28 @@ struct lupine_kernel_attribute_key_hash {
   }
 };
 
+struct lupine_function_attribute_key {
+  int route_id = -2;
+  CUfunction function = nullptr;
+  int attribute = 0;
+
+  bool operator==(const lupine_function_attribute_key &other) const {
+    return route_id == other.route_id && function == other.function &&
+           attribute == other.attribute;
+  }
+};
+
+struct lupine_function_attribute_key_hash {
+  size_t operator()(const lupine_function_attribute_key &key) const {
+    size_t hash = std::hash<int>{}(key.route_id);
+    hash ^= std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(key.function)) +
+            0x9e3779b9 + (hash << 6) + (hash >> 2);
+    hash ^= std::hash<int>{}(key.attribute) + 0x9e3779b9 + (hash << 6) +
+            (hash >> 2);
+    return hash;
+  }
+};
+
 struct lupine_param_info_key {
   uintptr_t handle = 0;
   size_t index = 0;
@@ -455,6 +477,29 @@ lupine_kernel_attribute_cache() {
   static auto *cache =
       new libcuckoo::cuckoohash_map<lupine_kernel_attribute_key, int,
                                     lupine_kernel_attribute_key_hash>();
+  return *cache;
+}
+
+static libcuckoo::cuckoohash_map<lupine_kernel_attribute_key, int,
+                                 lupine_kernel_attribute_key_hash> &
+lupine_kernel_attribute_set_cache() {
+  static auto *cache =
+      new libcuckoo::cuckoohash_map<lupine_kernel_attribute_key, int,
+                                    lupine_kernel_attribute_key_hash>();
+  return *cache;
+}
+
+static std::mutex &lupine_kernel_attribute_set_mutex() {
+  static auto *mutex = new std::mutex();
+  return *mutex;
+}
+
+static libcuckoo::cuckoohash_map<lupine_function_attribute_key, int,
+                                 lupine_function_attribute_key_hash> &
+lupine_function_attribute_cache() {
+  static auto *cache =
+      new libcuckoo::cuckoohash_map<lupine_function_attribute_key, int,
+                                    lupine_function_attribute_key_hash>();
   return *cache;
 }
 
@@ -2332,15 +2377,104 @@ extern "C" CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
   return return_value;
 }
 
+extern "C" CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
+                                         CUkernel kernel, CUdevice dev) {
+  lupine_route route = lupine_route_for_device(&dev);
+  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE) {
+    return CUDA_ERROR_INVALID_DEVICE;
+  }
+
+  lupine_kernel_attribute_key key{lupine_route_identity(route), kernel,
+                                  static_cast<int>(attrib),
+                                  static_cast<int>(dev)};
+  std::lock_guard<std::mutex> lock(lupine_kernel_attribute_set_mutex());
+  int cached_value = 0;
+  if (lupine_kernel_attribute_set_cache().find(key, cached_value) &&
+      cached_value == val) {
+    return CUDA_SUCCESS;
+  }
+
+  using real_fn_t = CUresult (*)(CUfunction_attribute, int, CUkernel, CUdevice);
+  CUresult return_value;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuKernelSetAttribute",
+                                                  &return_value, attrib, val,
+                                                  kernel, dev)) {
+    if (return_value == CUDA_SUCCESS) {
+      lupine_kernel_attribute_set_cache().insert_or_assign(key, val);
+      lupine_kernel_attribute_cache().erase(key);
+    }
+    return return_value;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
+      rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
+      rpc_write(conn, &val, sizeof(val)) < 0 ||
+      rpc_write(conn, &kernel, sizeof(kernel)) < 0 ||
+      rpc_write(conn, &dev, sizeof(dev)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_kernel_attribute_set_cache().insert_or_assign(key, val);
+    lupine_kernel_attribute_cache().erase(key);
+  }
+  return return_value;
+}
+
+extern "C" CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
+                                       CUfunction hfunc) {
+  if (pi == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  CUfunction translated = lupine_translate_private_function(hfunc);
+  lupine_route route = lupine_route_for_function(translated);
+  lupine_function_attribute_key key{lupine_route_identity(route), translated,
+                                    static_cast<int>(attrib)};
+  if (lupine_function_attribute_cache().find(key, *pi)) {
+    return CUDA_SUCCESS;
+  }
+
+  using real_fn_t = CUresult (*)(int *, CUfunction_attribute, CUfunction);
+  CUresult return_value;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuFuncGetAttribute", &return_value, pi, attrib, translated)) {
+    if (return_value == CUDA_SUCCESS) {
+      lupine_function_attribute_cache().insert_or_assign(key, *pi);
+    }
+    return return_value;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  int value = 0;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuFuncGetAttribute) < 0 ||
+      rpc_write(conn, &value, sizeof(value)) < 0 ||
+      rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
+      rpc_write(conn, &translated, sizeof(translated)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &value, sizeof(value)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_function_attribute_cache().insert_or_assign(key, value);
+    *pi = value;
+  }
+  return return_value;
+}
+
 extern "C" void lupine_invalidate_kernel_attribute_cache() {
   lupine_kernel_attribute_cache().clear();
 }
 
-extern "C" void lupine_kernel_attribute_cache_erase(int route_id,
-                                                    CUkernel kernel, int attrib,
-                                                    int dev) {
-  lupine_kernel_attribute_cache().erase(
-      lupine_kernel_attribute_key{route_id, kernel, attrib, dev});
+extern "C" void lupine_invalidate_function_attribute_cache() {
+  lupine_function_attribute_cache().clear();
 }
 
 static CUresult lupine_cuOccupancy_cached(int *numBlocks, CUfunction func,
@@ -4526,6 +4660,8 @@ extern "C" void lupine_invalidate_function_caches() {
   lupine_kernel_function_cache().clear();
   lupine_occupancy_cache().clear();
   lupine_kernel_attribute_cache().clear();
+  lupine_kernel_attribute_set_cache().clear();
+  lupine_function_attribute_cache().clear();
 }
 
 static CUresult lupine_resolve_launch_function_for_route(

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2551,6 +2551,7 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
 CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
                               CUkernel kernel, CUdevice dev);
 /**
+ * @disabled client - manual client deduplicates successful attribute sets
  * @param attrib SEND_ONLY
  * @param val SEND_ONLY
  * @param kernel SEND_ONLY
@@ -3672,6 +3673,7 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count,
                                CUstreamBatchMemOpParams *paramArray,
                                unsigned int flags);
 /**
+ * @disabled client - manual client caches successful attribute queries
  * @routingkey FUNCTION hfunc
  * @param pi SEND_RECV
  * @param attrib SEND_ONLY

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2551,7 +2551,7 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
 CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
                               CUkernel kernel, CUdevice dev);
 /**
- * @disabled client - manual client deduplicates successful attribute sets
+ * @async
  * @param attrib SEND_ONLY
  * @param val SEND_ONLY
  * @param kernel SEND_ONLY

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -840,6 +840,8 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
         f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_current_context_cache();\n")
     if function.name.format() in KERNEL_PARAM_LAYOUT_INVALIDATORS:
         f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_function_caches();\n")
+    if function.name.format() == "cuKernelSetAttribute":
+        f.write("    if (return_value == CUDA_SUCCESS) lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel, (int)attrib, (int)dev);\n")
     if function.name.format() == "cuFuncSetAttribute":
         f.write("    if (return_value == CUDA_SUCCESS) {\n")
         f.write("        lupine_invalidate_kernel_attribute_cache();\n")
@@ -1336,6 +1338,7 @@ def main():
             'extern "C" void lupine_forget_destroyed_context(CUcontext ctx);\n'
             'extern "C" void lupine_invalidate_function_caches();\n'
             'extern "C" void lupine_invalidate_kernel_attribute_cache();\n'
+            'extern "C" void lupine_kernel_attribute_cache_erase(int route_id, CUkernel kernel, int attrib, int dev);\n'
             'extern "C" void lupine_invalidate_function_attribute_cache();\n'
             'extern "C" CUresult lupine_flush_dirty_host_pages_to_server();\n\n'
             'extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);\n'

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -840,10 +840,11 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
         f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_current_context_cache();\n")
     if function.name.format() in KERNEL_PARAM_LAYOUT_INVALIDATORS:
         f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_function_caches();\n")
-    if function.name.format() == "cuKernelSetAttribute":
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel, (int)attrib, (int)dev);\n")
     if function.name.format() == "cuFuncSetAttribute":
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_kernel_attribute_cache();\n")
+        f.write("    if (return_value == CUDA_SUCCESS) {\n")
+        f.write("        lupine_invalidate_kernel_attribute_cache();\n")
+        f.write("        lupine_invalidate_function_attribute_cache();\n")
+        f.write("    }\n")
     if function.name.format() == "cuModuleGetFunction":
         f.write("    if (return_value == CUDA_SUCCESS && hfunc != nullptr) return_value = lupine_record_module_function(*hfunc, hmod, name, route);\n")
     if function.name.format() == "cuLibraryGetKernel":
@@ -1335,7 +1336,7 @@ def main():
             'extern "C" void lupine_forget_destroyed_context(CUcontext ctx);\n'
             'extern "C" void lupine_invalidate_function_caches();\n'
             'extern "C" void lupine_invalidate_kernel_attribute_cache();\n'
-            'extern "C" void lupine_kernel_attribute_cache_erase(int route_id, CUkernel kernel, int attrib, int dev);\n'
+            'extern "C" void lupine_invalidate_function_attribute_cache();\n'
             'extern "C" CUresult lupine_flush_dirty_host_pages_to_server();\n\n'
             'extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);\n'
             'extern "C" int lupine_forward_remote_stdout(conn_t *conn);\n'

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -76,9 +76,7 @@ extern "C" void lupine_invalidate_current_context_cache();
 extern "C" void lupine_forget_destroyed_context(CUcontext ctx);
 extern "C" void lupine_invalidate_function_caches();
 extern "C" void lupine_invalidate_kernel_attribute_cache();
-extern "C" void lupine_kernel_attribute_cache_erase(int route_id,
-                                                    CUkernel kernel, int attrib,
-                                                    int dev);
+extern "C" void lupine_invalidate_function_attribute_cache();
 extern "C" CUresult lupine_flush_dirty_host_pages_to_server();
 
 extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);
@@ -996,38 +994,6 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
-CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
-                              CUkernel kernel, CUdevice dev) {
-  lupine_route route = lupine_route_for_device(&dev);
-  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)
-    return CUDA_ERROR_INVALID_DEVICE;
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUfunction_attribute, int, CUkernel, CUdevice);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuKernelSetAttribute",
-                                                  &return_value, attrib, val,
-                                                  kernel, dev)) {
-    if (return_value == CUDA_SUCCESS)
-      lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel,
-                                          (int)attrib, (int)dev);
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
-      rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
-      rpc_write(conn, &val, sizeof(int)) < 0 ||
-      rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
-      rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS)
-    lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel,
-                                        (int)attrib, (int)dev);
   return return_value;
 }
 
@@ -3556,29 +3522,6 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count,
   return return_value;
 }
 
-CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
-                            CUfunction hfunc) {
-  lupine_route route = lupine_route_for_function(hfunc);
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(int *, CUfunction_attribute, CUfunction);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuFuncGetAttribute", &return_value, pi, attrib, hfunc)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuFuncGetAttribute) < 0 ||
-      rpc_write(conn, pi, sizeof(int)) < 0 ||
-      rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
-      rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
-      rpc_wait_for_response(conn) < 0 || rpc_read(conn, pi, sizeof(int)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
                             int value) {
   lupine_route route = lupine_route_for_function(hfunc);
@@ -3586,8 +3529,10 @@ CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
   using real_fn_t = CUresult (*)(CUfunction, CUfunction_attribute, int);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuFuncSetAttribute", &return_value, hfunc, attrib, value)) {
-    if (return_value == CUDA_SUCCESS)
+    if (return_value == CUDA_SUCCESS) {
       lupine_invalidate_kernel_attribute_cache();
+      lupine_invalidate_function_attribute_cache();
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -3601,8 +3546,10 @@ CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS)
+  if (return_value == CUDA_SUCCESS) {
     lupine_invalidate_kernel_attribute_cache();
+    lupine_invalidate_function_attribute_cache();
+  }
   return return_value;
 }
 

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -76,6 +76,9 @@ extern "C" void lupine_invalidate_current_context_cache();
 extern "C" void lupine_forget_destroyed_context(CUcontext ctx);
 extern "C" void lupine_invalidate_function_caches();
 extern "C" void lupine_invalidate_kernel_attribute_cache();
+extern "C" void lupine_kernel_attribute_cache_erase(int route_id,
+                                                    CUkernel kernel, int attrib,
+                                                    int dev);
 extern "C" void lupine_invalidate_function_attribute_cache();
 extern "C" CUresult lupine_flush_dirty_host_pages_to_server();
 
@@ -994,6 +997,37 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
+                              CUkernel kernel, CUdevice dev) {
+  lupine_route route = lupine_route_for_device(&dev);
+  if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)
+    return CUDA_ERROR_INVALID_DEVICE;
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction_attribute, int, CUkernel, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuKernelSetAttribute",
+                                                  &return_value, attrib, val,
+                                                  kernel, dev)) {
+    if (return_value == CUDA_SUCCESS)
+      lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel,
+                                          (int)attrib, (int)dev);
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
+      rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
+      rpc_write(conn, &val, sizeof(int)) < 0 ||
+      rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
+      rpc_write(conn, &dev, sizeof(CUdevice)) < 0 || rpc_write_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return_value = CUDA_SUCCESS;
+  if (return_value == CUDA_SUCCESS)
+    lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel,
+                                        (int)attrib, (int)dev);
   return return_value;
 }
 

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -1642,7 +1642,6 @@ int handle_cuKernelSetAttribute(conn_t *conn) {
   CUkernel kernel;
   CUdevice dev;
   int request_id;
-  CUresult lupine_intercept_result;
   if (rpc_read(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_read(conn, &val, sizeof(int)) < 0 ||
       rpc_read(conn, &kernel, sizeof(CUkernel)) < 0 ||
@@ -1652,12 +1651,7 @@ int handle_cuKernelSetAttribute(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
-  lupine_intercept_result = cuKernelSetAttribute(attrib, val, kernel, dev);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
+  cuKernelSetAttribute(attrib, val, kernel, dev);
 
   return 0;
 ERROR_0:

--- a/test/test_function_attribute_cache.cu
+++ b/test/test_function_attribute_cache.cu
@@ -1,5 +1,5 @@
-// Exercises the client-side function attribute query cache and successful
-// kernel attribute set deduplication. Auto-discovered by run_custom_tests.sh.
+// Exercises the client-side function attribute query cache and asynchronous
+// kernel attribute sets. Auto-discovered by run_custom_tests.sh.
 #include <cuda.h>
 
 #include <cstdio>
@@ -121,27 +121,21 @@ int main() {
   if (!check(
           cuKernelSetAttribute(CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                                0, kernel, device),
-          "cuKernelSetAttribute(first)") ||
-      !check(
-          cuKernelSetAttribute(CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-                               0, kernel, device),
-          "cuKernelSetAttribute(deduplicated)")) {
+          "cuKernelSetAttribute(async)")) {
     return 1;
   }
 
-  int max_threads = 0;
-  if (!check(cuKernelGetAttribute(&max_threads,
-                                  CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
-                                  kernel, device),
-             "cuKernelGetAttribute(MAX_THREADS_PER_BLOCK)") ||
-      !expect(cuKernelSetAttribute(CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
-                                   max_threads, kernel, device),
-              CUDA_ERROR_INVALID_VALUE,
-              "cuKernelSetAttribute(read-only first)") ||
-      !expect(cuKernelSetAttribute(CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
-                                   max_threads, kernel, device),
-              CUDA_ERROR_INVALID_VALUE,
-              "cuKernelSetAttribute(read-only repeated)")) {
+  // The blocking getter orders after the fire-and-forget setter and verifies
+  // both that the request arrived and that the local getter cache was erased.
+  int dynamic_shared_size = -1;
+  if (!check(
+          cuKernelGetAttribute(&dynamic_shared_size,
+                               CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                               kernel, device),
+          "cuKernelGetAttribute(MAX_DYNAMIC_SHARED_SIZE_BYTES)") ||
+      dynamic_shared_size != 0) {
+    std::fprintf(stderr, "stale kernel attribute value: %d, expected 0\n",
+                 dynamic_shared_size);
     return 1;
   }
 
@@ -149,8 +143,8 @@ int main() {
       !check(cuDevicePrimaryCtxRelease(device), "cuDevicePrimaryCtxRelease")) {
     return 1;
   }
-  std::printf("function attribute cache preserves values, invalidation, and "
-              "setter errors\n");
+  std::printf("function attribute cache preserves values and invalidation; "
+              "kernel attribute sets preserve ordering\n");
   return 0;
 }
 #endif

--- a/test/test_function_attribute_cache.cu
+++ b/test/test_function_attribute_cache.cu
@@ -1,0 +1,156 @@
+// Exercises the client-side function attribute query cache and successful
+// kernel attribute set deduplication. Auto-discovered by run_custom_tests.sh.
+#include <cuda.h>
+
+#include <cstdio>
+
+#if !defined(CUDA_VERSION) || CUDA_VERSION < 12000
+int main() {
+  std::printf("SKIP: CUkernel attributes require CUDA 12.0 or newer\n");
+  return 0;
+}
+#else
+
+static const char kNoopPtx[] = ".version 6.4\n"
+                               ".target sm_52\n"
+                               ".address_size 64\n"
+                               ".visible .entry noop()\n"
+                               "{\n"
+                               "  ret;\n"
+                               "}\n";
+
+static const char *error_name(CUresult result) {
+  const char *name = nullptr;
+  cuGetErrorName(result, &name);
+  return name == nullptr ? "unknown" : name;
+}
+
+static bool check(CUresult result, const char *operation) {
+  if (result == CUDA_SUCCESS) {
+    return true;
+  }
+  std::fprintf(stderr, "%s failed: %s (%d)\n", operation, error_name(result),
+               static_cast<int>(result));
+  return false;
+}
+
+static bool expect(CUresult result, CUresult expected, const char *operation) {
+  if (result == expected) {
+    return true;
+  }
+  std::fprintf(stderr, "%s returned %s (%d), expected %s (%d)\n", operation,
+               error_name(result), static_cast<int>(result),
+               error_name(expected), static_cast<int>(expected));
+  return false;
+}
+
+int main() {
+  CUdevice device = 0;
+  CUcontext context = nullptr;
+  CUlibrary library = nullptr;
+  CUkernel kernel = nullptr;
+  CUfunction function = nullptr;
+  if (!check(cuInit(0), "cuInit") ||
+      !check(cuDeviceGet(&device, 0), "cuDeviceGet") ||
+      !check(cuDevicePrimaryCtxRetain(&context, device),
+             "cuDevicePrimaryCtxRetain") ||
+      !check(cuCtxSetCurrent(context), "cuCtxSetCurrent") ||
+      !check(cuLibraryLoadData(&library, kNoopPtx, nullptr, nullptr, 0, nullptr,
+                               nullptr, 0),
+             "cuLibraryLoadData") ||
+      !check(cuLibraryGetKernel(&kernel, library, "noop"),
+             "cuLibraryGetKernel") ||
+      !check(cuKernelGetFunction(&function, kernel), "cuKernelGetFunction")) {
+    return 1;
+  }
+
+  int first_threads = 0;
+  int second_threads = 0;
+  if (!check(cuFuncGetAttribute(&first_threads,
+                                CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+                                function),
+             "cuFuncGetAttribute(first)") ||
+      !check(cuFuncGetAttribute(&second_threads,
+                                CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+                                function),
+             "cuFuncGetAttribute(cached)") ||
+      first_threads <= 0 || first_threads != second_threads) {
+    std::fprintf(stderr, "function attribute values differ: %d then %d\n",
+                 first_threads, second_threads);
+    return 1;
+  }
+
+  auto invalid_attribute = static_cast<CUfunction_attribute>(9999);
+  int ignored = 0;
+  if (!expect(cuFuncGetAttribute(&ignored, invalid_attribute, function),
+              CUDA_ERROR_INVALID_VALUE, "cuFuncGetAttribute(invalid first)") ||
+      !expect(cuFuncGetAttribute(&ignored, invalid_attribute, function),
+              CUDA_ERROR_INVALID_VALUE,
+              "cuFuncGetAttribute(invalid repeated)")) {
+    return 1;
+  }
+
+  if (!check(
+          cuFuncSetAttribute(
+              function, CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT, 25),
+          "cuFuncSetAttribute(25)")) {
+    return 1;
+  }
+  int carveout = -1;
+  if (!check(cuFuncGetAttribute(
+                 &carveout, CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT,
+                 function),
+             "cuFuncGetAttribute(carveout 25)") ||
+      carveout != 25 ||
+      !check(
+          cuFuncSetAttribute(
+              function, CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT, 50),
+          "cuFuncSetAttribute(50)")) {
+    return 1;
+  }
+  if (!check(cuFuncGetAttribute(
+                 &carveout, CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT,
+                 function),
+             "cuFuncGetAttribute(carveout 50)") ||
+      carveout != 50) {
+    std::fprintf(stderr, "stale function attribute value: %d, expected 50\n",
+                 carveout);
+    return 1;
+  }
+
+  if (!check(
+          cuKernelSetAttribute(CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                               0, kernel, device),
+          "cuKernelSetAttribute(first)") ||
+      !check(
+          cuKernelSetAttribute(CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                               0, kernel, device),
+          "cuKernelSetAttribute(deduplicated)")) {
+    return 1;
+  }
+
+  int max_threads = 0;
+  if (!check(cuKernelGetAttribute(&max_threads,
+                                  CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+                                  kernel, device),
+             "cuKernelGetAttribute(MAX_THREADS_PER_BLOCK)") ||
+      !expect(cuKernelSetAttribute(CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+                                   max_threads, kernel, device),
+              CUDA_ERROR_INVALID_VALUE,
+              "cuKernelSetAttribute(read-only first)") ||
+      !expect(cuKernelSetAttribute(CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+                                   max_threads, kernel, device),
+              CUDA_ERROR_INVALID_VALUE,
+              "cuKernelSetAttribute(read-only repeated)")) {
+    return 1;
+  }
+
+  if (!check(cuLibraryUnload(library), "cuLibraryUnload") ||
+      !check(cuDevicePrimaryCtxRelease(device), "cuDevicePrimaryCtxRelease")) {
+    return 1;
+  }
+  std::printf("function attribute cache preserves values, invalidation, and "
+              "setter errors\n");
+  return 0;
+}
+#endif


### PR DESCRIPTION
## Summary

- cache successful `cuFuncGetAttribute` queries by route, translated function, and attribute
- send remote `cuKernelSetAttribute` calls fire-and-forget while preserving normal synchronous CUDA behavior for locally routed devices
- invalidate cached function attributes after `cuFuncSetAttribute` and cached kernel attributes when an async setter is queued
- add a GPU integration test for function cache hits, mutation invalidation, error passthrough, and same-lane async setter ordering

## Why

The unchanged GPT benchmark issues 74 blocking `cuFuncGetAttribute` calls and 24 blocking `cuKernelSetAttribute` calls per measured iteration. Those 98 serial metadata round trips explain the nearly linear RTT sensitivity. The earlier cache covered `cuKernelGetAttribute`; it is working and sees no steady-state calls in this workload, but it does not cover these two APIs.

`cuKernelSetAttribute` now follows Lupine's existing generated `@async` path. Remote calls report successful enqueue rather than the eventual CUDA driver result, so remote-only invalid-value, invalid-handle, read-only-attribute, and resource errors are not returned synchronously. Transport/routing failures detected before enqueue still propagate.

Requests remain ordered on the calling host thread's server lane. They are not globally ordered across lanes: a launch made by another host thread after an application-level handoff can execute before the queued setter. Native CUDA's synchronous setter return would prevent that race. This is an intentional latency/observability/ordering tradeoff; a future launch-preflight design can carry pending setter state across lanes if that fidelity is required.

The remaining cold `cuKernelGetFunction` and `cuFuncGetParamInfo` misses are handled separately by #489, rather than expanding this PR's scope. Bulk function/kernel attribute prefill is isolated in #490.

## Benchmark

Exact unmodified `https://console.lupine.sh/gpt_bench.py`, RTX 4090 server, client-side Docker `tc netem` only:

| RTT | `main` | this branch |
| ---: | ---: | ---: |
| 100 ms | 0.10 it/s | 6.98 it/s |
| 200 ms | 0.05 it/s | 5.69 it/s |
| 300 ms | 0.03 it/s | 4.63 it/s |

## Validation

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` (10/10 passed; 2 expected skips)
- generated sources regenerated and formatted
- remote CUDA 13.1 / RTX 4090 GPU integration passed
- CUDA 11 client builds that failed with the earlier manual-wrapper implementation are now passing in CI
