### PR TITLE
Prefill library kernel function handles

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -499,6 +499,21 @@ lupine_param_info_cache() {
   return *cache;
 }
 
+static void lupine_cache_param_layout(uintptr_t handle, bool kernel,
+                                      uint32_t count,
+                                      const std::vector<uint64_t> &params) {
+  for (uint32_t index = 0; index < count; ++index) {
+    lupine_param_info_cache().insert_or_assign(
+        lupine_param_info_key{handle, index, kernel},
+        lupine_param_info_value{CUDA_SUCCESS,
+                                static_cast<size_t>(params[index * 2]),
+                                static_cast<size_t>(params[index * 2 + 1])});
+  }
+  lupine_param_info_cache().insert_or_assign(
+      lupine_param_info_key{handle, count, kernel},
+      lupine_param_info_value{CUDA_ERROR_INVALID_VALUE, 0, 0});
+}
+
 // Filled from the library snapshot side-channel RPC; serves
 // cuLibraryGetKernel without a round trip.
 struct lupine_library_kernel_name_key {
@@ -4392,6 +4407,7 @@ extern "C" CUresult cuModuleLoadDataEx(CUmodule *module, const void *image,
 struct lupine_wire_library_kernel_record {
   std::string name;
   CUkernel kernel = nullptr;
+  CUfunction function = nullptr;
   uint32_t param_count = 0;
   std::vector<uint64_t> params;
 };
@@ -4427,6 +4443,7 @@ static void lupine_prefill_library_snapshot(CUlibrary library, conn_t *conn) {
     record.name.resize(name_len);
     if (rpc_read(conn, record.name.data(), name_len) < 0 ||
         rpc_read(conn, &record.kernel, sizeof(record.kernel)) < 0 ||
+        rpc_read(conn, &record.function, sizeof(record.function)) < 0 ||
         rpc_read(conn, &record.param_count, sizeof(record.param_count)) < 0) {
       return;
     }
@@ -4443,26 +4460,27 @@ static void lupine_prefill_library_snapshot(CUlibrary library, conn_t *conn) {
     return;
   }
 
-  lupine_route route = lupine_remote_route_for_conn(conn);
+  lupine_route remote_route = lupine_remote_route_for_conn(conn);
+  CUcontext current_context = nullptr;
+  (void)cuCtxGetCurrent(&current_context);
   for (const auto &record : table) {
     if (record.kernel == nullptr) {
       continue;
     }
-    for (uint32_t index = 0; index < record.param_count; ++index) {
-      lupine_param_info_cache().insert_or_assign(
-          lupine_param_info_key{reinterpret_cast<uintptr_t>(record.kernel),
-                                index, true},
-          lupine_param_info_value{
-              CUDA_SUCCESS, static_cast<size_t>(record.params[index * 2]),
-              static_cast<size_t>(record.params[index * 2 + 1])});
+    lupine_cache_param_layout(reinterpret_cast<uintptr_t>(record.kernel), true,
+                              record.param_count, record.params);
+    if (record.function != nullptr) {
+      lupine_note_function_owner_route(record.function, remote_route);
+      lupine_cache_param_layout(reinterpret_cast<uintptr_t>(record.function),
+                                false, record.param_count, record.params);
+      lupine_kernel_function_cache().insert_or_assign(
+          lupine_kernel_function_key{lupine_route_identity(remote_route),
+                                     current_context, record.kernel},
+          record.function);
     }
-    lupine_param_info_cache().insert_or_assign(
-        lupine_param_info_key{reinterpret_cast<uintptr_t>(record.kernel),
-                              record.param_count, true},
-        lupine_param_info_value{CUDA_ERROR_INVALID_VALUE, 0, 0});
     if (lupine_record_library_kernel(record.kernel, library,
                                      record.name.c_str(),
-                                     route) == CUDA_SUCCESS) {
+                                     remote_route) == CUDA_SUCCESS) {
       lupine_library_kernel_names().insert_or_assign(
           lupine_library_kernel_name_key{library, record.name}, record.kernel);
     }

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1052,6 +1052,7 @@ int handle_manual_lupineLibrarySnapshot(conn_t *conn) {
   struct kernel_record {
     std::string name;
     CUkernel kernel = nullptr;
+    CUfunction function = nullptr;
     uint32_t name_len = 0;
     uint32_t param_count = 0;
     std::vector<uint64_t> params;
@@ -1080,6 +1081,9 @@ int handle_manual_lupineLibrarySnapshot(conn_t *conn) {
       record.name = name;
       record.name_len = static_cast<uint32_t>(record.name.size() + 1);
       record.kernel = kernel;
+      if (cuKernelGetFunction(&record.function, kernel) != CUDA_SUCCESS) {
+        record.function = nullptr;
+      }
       for (size_t index = 0;; ++index) {
         size_t offset = 0;
         size_t size = 0;
@@ -1106,6 +1110,7 @@ int handle_manual_lupineLibrarySnapshot(conn_t *conn) {
     if (rpc_write(conn, &record.name_len, sizeof(record.name_len)) < 0 ||
         rpc_write(conn, record.name.c_str(), record.name_len) < 0 ||
         rpc_write(conn, &record.kernel, sizeof(record.kernel)) < 0 ||
+        rpc_write(conn, &record.function, sizeof(record.function)) < 0 ||
         rpc_write(conn, &record.param_count, sizeof(record.param_count)) < 0 ||
         (record.param_count != 0 &&
          rpc_write(conn, record.params.data(),

--- a/test/test_library_kernel_function_prefill.cu
+++ b/test/test_library_kernel_function_prefill.cu
@@ -1,0 +1,96 @@
+// Verifies that the library snapshot carries the corresponding CUfunction
+// handle and that both handles expose the same parameter layout.
+#include <cuda.h>
+
+#include <cstdio>
+
+#if !defined(CUDA_VERSION) || CUDA_VERSION < 12040
+int main() {
+  std::printf("SKIP: library kernel enumeration requires CUDA 12.4 or newer\n");
+  return 0;
+}
+#else
+
+static const char kParameterizedPtx[] = ".version 6.4\n"
+                                        ".target sm_52\n"
+                                        ".address_size 64\n"
+                                        ".visible .entry parameterized(\n"
+                                        "  .param .u64 parameterized_param_0,\n"
+                                        "  .param .u32 parameterized_param_1\n"
+                                        ")\n"
+                                        "{\n"
+                                        "  ret;\n"
+                                        "}\n";
+
+static const char *error_name(CUresult result) {
+  const char *name = nullptr;
+  cuGetErrorName(result, &name);
+  return name == nullptr ? "unknown" : name;
+}
+
+static bool check(CUresult result, const char *operation) {
+  if (result == CUDA_SUCCESS) {
+    return true;
+  }
+  std::fprintf(stderr, "%s failed: %s (%d)\n", operation, error_name(result),
+               static_cast<int>(result));
+  return false;
+}
+
+int main() {
+  CUdevice device = 0;
+  CUcontext context = nullptr;
+  CUlibrary library = nullptr;
+  CUkernel kernel = nullptr;
+  CUfunction function = nullptr;
+  if (!check(cuInit(0), "cuInit") ||
+      !check(cuDeviceGet(&device, 0), "cuDeviceGet") ||
+      !check(cuDevicePrimaryCtxRetain(&context, device),
+             "cuDevicePrimaryCtxRetain") ||
+      !check(cuCtxSetCurrent(context), "cuCtxSetCurrent") ||
+      !check(cuLibraryLoadData(&library, kParameterizedPtx, nullptr, nullptr, 0,
+                               nullptr, nullptr, 0),
+             "cuLibraryLoadData") ||
+      !check(cuLibraryGetKernel(&kernel, library, "parameterized"),
+             "cuLibraryGetKernel") ||
+      !check(cuKernelGetFunction(&function, kernel), "cuKernelGetFunction")) {
+    return 1;
+  }
+
+  for (size_t index = 0; index < 2; ++index) {
+    size_t kernel_offset = 0;
+    size_t kernel_size = 0;
+    size_t function_offset = 0;
+    size_t function_size = 0;
+    if (!check(
+            cuKernelGetParamInfo(kernel, index, &kernel_offset, &kernel_size),
+            "cuKernelGetParamInfo") ||
+        !check(cuFuncGetParamInfo(function, index, &function_offset,
+                                  &function_size),
+               "cuFuncGetParamInfo") ||
+        kernel_offset != function_offset || kernel_size != function_size) {
+      std::fprintf(stderr,
+                   "parameter %zu differs: kernel=(%zu, %zu), function=(%zu, "
+                   "%zu)\n",
+                   index, kernel_offset, kernel_size, function_offset,
+                   function_size);
+      return 1;
+    }
+  }
+
+  size_t ignored_offset = 0;
+  size_t ignored_size = 0;
+  if (cuFuncGetParamInfo(function, 2, &ignored_offset, &ignored_size) !=
+      CUDA_ERROR_INVALID_VALUE) {
+    std::fprintf(stderr, "expected parameter 2 to be out of range\n");
+    return 1;
+  }
+
+  if (!check(cuLibraryUnload(library), "cuLibraryUnload") ||
+      !check(cuDevicePrimaryCtxRelease(device), "cuDevicePrimaryCtxRelease")) {
+    return 1;
+  }
+  std::printf("library kernel function and parameter layout prefilled\n");
+  return 0;
+}
+#endif


### PR DESCRIPTION
## Summary

- include each library kernel's corresponding `CUfunction` in the explicit `lupineLibrarySnapshot` response
- seed the `(route, context, CUkernel) -> CUfunction` cache when that snapshot arrives
- reuse the snapshot's kernel parameter layout to seed `cuFuncGetParamInfo` as well as `cuKernelGetParamInfo`
- add a CUDA integration test that checks the prefetched function handle and both parameter-layout views

## Why

The GPT latency trace shows 353 blocking `cuKernelGetFunction` calls followed by 705 blocking `cuFuncGetParamInfo` calls during cold discovery. Both APIs already cache results, but they currently pay one RTT per unique kernel and then one RTT per function parameter before the cache is warm.

#491 moves the existing kernel inventory and parameter layouts out of the CUDA `cuLibraryLoadData` response and into a separately named Lupine snapshot RPC. Extending that explicit snapshot with the corresponding function handle lets the client fill the two remaining caches without changing any CUDA RPC's wire contract.

This is stacked on #491 so protocol cleanup and function-handle prefill remain independently reviewable.

## Validation

- `cmake --build build --parallel 8`
- `ctest --test-dir build --output-on-failure` (10/10 passed; 2 expected skips)
- CUDA integration test compiles locally against CUDA 13.1
- paired CUDA 13.1 remote integration passed on an RTX 2070 SUPER using the full stack through #490
