### PR TITLE
Isolate event query cache warming

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -4057,6 +4057,30 @@ extern "C" CUresult cuEventRecordWithFlags_ptsz(CUevent hEvent,
   return cuEventRecordWithFlags(hEvent, hStream, flags);
 }
 
+// Best-effort cache warming for events other than the one the caller queried.
+// This is intentionally a separate RPC: failures must not affect the result
+// already produced by RPC_cuEventQuery.
+static void lupine_prefetch_event_queries(CUevent exclude, conn_t *conn) {
+  CUevent events[kLupineEventQueryBatch];
+  uint64_t recorded[kLupineEventQueryBatch];
+  uint32_t count =
+      lupine_collect_event_query_prefetch(exclude, conn, events, recorded);
+  if (count == 0) {
+    return;
+  }
+
+  CUresult results[kLupineEventQueryBatch];
+  if (rpc_write_start_request(conn, LUPINE_RPC_lupineEventQueryBatch) < 0 ||
+      rpc_write(conn, &count, sizeof(count)) < 0 ||
+      rpc_write(conn, events, count * sizeof(events[0])) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, results, count * sizeof(results[0])) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return;
+  }
+  lupine_note_event_query_results(events, recorded, results, count);
+}
+
 extern "C" CUresult cuEventQuery(CUevent hEvent) {
   CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
   if (flush_result != CUDA_SUCCESS) {
@@ -4074,32 +4098,30 @@ extern "C" CUresult cuEventQuery(CUevent hEvent) {
   if (conn == nullptr) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  CUevent events[kLupineEventQueryBatch];
-  uint64_t recorded[kLupineEventQueryBatch];
-  uint32_t count =
-      lupine_collect_event_query_batch(hEvent, conn, events, recorded);
-  if (count == 0) {
+  uint64_t recorded = 0;
+  if (!lupine_event_query_needed(hEvent, &recorded)) {
     return lupine_sync_mapped_device_to_host();
   }
   // Sampled before the request so a copy issued while it is in flight is not
   // mistaken for one the server already drained.
   uint64_t drained = lupine_async_dtoh_issued_count();
-  CUresult results[kLupineEventQueryBatch];
+  CUresult result = CUDA_ERROR_UNKNOWN;
   if (rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
-      rpc_write(conn, &count, sizeof(count)) < 0 ||
-      rpc_write(conn, events, count * sizeof(events[0])) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
-      rpc_read(conn, results, count * sizeof(results[0])) < 0 ||
-      rpc_read_end(conn) < 0) {
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  lupine_note_event_query_results(events, recorded, results, count);
-  if (results[0] != CUDA_SUCCESS) {
-    return results[0];
+  lupine_note_event_query_results(&hEvent, &recorded, &result, 1);
+
+  return_value = result;
+  if (return_value == CUDA_SUCCESS) {
+    lupine_note_async_dtoh_drained(drained);
+    return_value = lupine_sync_mapped_device_to_host();
   }
-  lupine_note_async_dtoh_drained(drained);
-  return lupine_sync_mapped_device_to_host();
+  lupine_prefetch_event_queries(hEvent, conn);
+  return return_value;
 }
 
 extern "C" CUresult cuCtxCreate_v2(CUcontext *pctx, unsigned int flags,

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -3549,7 +3549,7 @@ CUresult cuEventRecord(CUevent hEvent, CUstream hStream);
 CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
                                 unsigned int flags);
 /**
- * @disabled - manual client batches outstanding events into one query
+ * @disabled - manual client caches completions and separately prefetches events
  * @synchronize DEFERRED_DTOH
  * @routingkey EVENT hEvent
  * @param hEvent SEND_ONLY

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -189,6 +189,7 @@ PRIVATE_RPC_FUNCTIONS = [
     "cuStreamBeginCaptureToGraph",
     "cuStreamGetCaptureInfo_v3",
     "lupineDeviceSnapshot",
+    "lupineEventQueryBatch",
     "lupineLibrarySnapshot",
     "lupineManagedHostFlush",
     "lupineModuleGetFunctionWithLayout",

--- a/codegen/gen_api.h
+++ b/codegen/gen_api.h
@@ -454,6 +454,7 @@
 #define LUPINE_RPC_cuStreamBeginCaptureToGraph 1423223781
 #define LUPINE_RPC_cuStreamGetCaptureInfo_v3 1793131524
 #define LUPINE_RPC_lupineDeviceSnapshot 838398900
+#define LUPINE_RPC_lupineEventQueryBatch 1291828496
 #define LUPINE_RPC_lupineLibrarySnapshot 1662367389
 #define LUPINE_RPC_lupineManagedHostFlush 1450411892
 #define LUPINE_RPC_lupineModuleGetFunctionWithLayout 368273666

--- a/events.cpp
+++ b/events.cpp
@@ -19,31 +19,31 @@ void lupine_event_note_recorded(lupine_event_table *table, CUevent event) {
   *victim = {event, seq, 0};
 }
 
-// Fills events/recorded with the batch to ask about, the caller's event first,
-// and returns its length; zero means the answer is already known locally.
-uint32_t lupine_event_collect_query_batch(lupine_event_table *table,
-                                          CUevent primary, conn_t *conn,
-                                          lupine_event_conn_resolver resolver,
-                                          CUevent *events, uint64_t *recorded) {
+bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
+                               uint64_t *recorded) {
   bool copies_pending = table->dtoh_issued.load(std::memory_order_relaxed) !=
                         table->dtoh_drained.load(std::memory_order_relaxed);
   lupine_event_slot *slots = table->slots;
   std::lock_guard<std::mutex> lock(table->mutex);
-  uint32_t count = 1;
-  events[0] = primary;
-  recorded[0] = 0;
+  *recorded = 0;
   for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
-    if (slots[i].event != primary) {
+    if (slots[i].event != event) {
       continue;
     }
-    if (!copies_pending && slots[i].recorded == slots[i].completed) {
-      return 0;
-    }
-    recorded[0] = slots[i].recorded;
-    break;
+    *recorded = slots[i].recorded;
+    return copies_pending || slots[i].recorded != slots[i].completed;
   }
+  return true;
+}
+
+uint32_t lupine_event_collect_query_prefetch(
+    lupine_event_table *table, CUevent exclude, conn_t *conn,
+    lupine_event_conn_resolver resolver, CUevent *events, uint64_t *recorded) {
+  lupine_event_slot *slots = table->slots;
+  std::lock_guard<std::mutex> lock(table->mutex);
+  uint32_t count = 0;
   for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
-    if (slots[i].event == nullptr || slots[i].event == primary ||
+    if (slots[i].event == nullptr || slots[i].event == exclude ||
         slots[i].recorded == slots[i].completed ||
         resolver(slots[i].event) != conn) {
       continue;
@@ -98,10 +98,16 @@ void lupine_note_event_recorded(CUevent event) {
   lupine_event_note_recorded(&lupine_event_table_instance(), event);
 }
 
-uint32_t lupine_collect_event_query_batch(CUevent primary, conn_t *conn,
-                                          CUevent *events, uint64_t *recorded) {
-  return lupine_event_collect_query_batch(
-      &lupine_event_table_instance(), primary, conn, lupine_rpc_conn_for_event,
+bool lupine_event_query_needed(CUevent event, uint64_t *recorded) {
+  return lupine_event_query_needed(&lupine_event_table_instance(), event,
+                                   recorded);
+}
+
+uint32_t lupine_collect_event_query_prefetch(CUevent exclude, conn_t *conn,
+                                             CUevent *events,
+                                             uint64_t *recorded) {
+  return lupine_event_collect_query_prefetch(
+      &lupine_event_table_instance(), exclude, conn, lupine_rpc_conn_for_event,
       events, recorded);
 }
 

--- a/events.h
+++ b/events.h
@@ -1,10 +1,10 @@
 #pragma once
 
-// Client-side event completion tracking behind the batched cuEventQuery. The
-// lupine_event_* functions operate on a bare table and take the
-// connection resolver as a parameter, so the batching policy is unit-testable
-// without routing; the lupine_note_*/lupine_collect_* wrappers bind the
-// process-wide table and the real resolver for the client wrappers.
+// Client-side event completion tracking and explicit query prefetch policy.
+// The lupine_event_* functions operate on a bare table and take the connection
+// resolver as a parameter, so the policy is unit-testable without routing; the
+// lupine_note_*/lupine_collect_* wrappers bind the process-wide table and the
+// real resolver for the client wrappers.
 
 #include <atomic>
 #include <cstdint>
@@ -18,11 +18,10 @@
 
 // Completion is monotonic between records: once the server reports an event
 // complete for a given record, that stays true until the event is recorded
-// again. A query therefore also asks about every other event the client has
-// outstanding, so a poller walking several events pays one round trip instead
-// of one per event. Deferred device-to-host copies only reach the client on a
-// query that actually reaches the server, so a locally answered query is legal
-// only while no async copy is waiting to be drained.
+// again. Deferred device-to-host copies only reach the client on a query that
+// actually reaches the server, so a locally answered query is legal only while
+// no async copy is waiting to be drained. Other outstanding events may be
+// queried by a separate Lupine RPC to warm this cache.
 constexpr uint32_t kLupineEventQueryBatch = LUPINE_EVENT_QUERY_BATCH_MAX;
 
 struct lupine_event_slot {
@@ -42,10 +41,11 @@ struct lupine_event_table {
 typedef conn_t *(*lupine_event_conn_resolver)(CUevent event);
 
 void lupine_event_note_recorded(lupine_event_table *table, CUevent event);
-uint32_t lupine_event_collect_query_batch(lupine_event_table *table,
-                                          CUevent primary, conn_t *conn,
-                                          lupine_event_conn_resolver resolver,
-                                          CUevent *events, uint64_t *recorded);
+bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
+                               uint64_t *recorded);
+uint32_t lupine_event_collect_query_prefetch(
+    lupine_event_table *table, CUevent exclude, conn_t *conn,
+    lupine_event_conn_resolver resolver, CUevent *events, uint64_t *recorded);
 void lupine_event_note_query_results(lupine_event_table *table,
                                      const CUevent *events,
                                      const uint64_t *recorded,
@@ -56,8 +56,10 @@ void lupine_event_note_dtoh_drained(lupine_event_table *table,
                                     uint64_t drained);
 
 void lupine_note_event_recorded(CUevent event);
-uint32_t lupine_collect_event_query_batch(CUevent primary, conn_t *conn,
-                                          CUevent *events, uint64_t *recorded);
+bool lupine_event_query_needed(CUevent event, uint64_t *recorded);
+uint32_t lupine_collect_event_query_prefetch(CUevent exclude, conn_t *conn,
+                                             CUevent *events,
+                                             uint64_t *recorded);
 void lupine_note_event_query_results(const CUevent *events,
                                      const uint64_t *recorded,
                                      const CUresult *results, uint32_t count);

--- a/events_test.cpp
+++ b/events_test.cpp
@@ -42,46 +42,42 @@ void complete(lupine_event_table *table, const CUevent *events,
 
 bool test_completed_event_answers_locally() {
   lupine_event_table table;
-  CUevent events[kLupineEventQueryBatch];
-  uint64_t recorded[kLupineEventQueryBatch];
+  CUevent event = fake_event(0);
+  uint64_t recorded = 0;
   lupine_event_note_recorded(&table, fake_event(0));
-  uint32_t count = lupine_event_collect_query_batch(
-      &table, fake_event(0), kConnA, resolve_all_to_a, events, recorded);
-  if (count != 1 || events[0] != fake_event(0) || recorded[0] != 1) {
-    std::cerr << "FAIL: first query did not batch the recorded event\n";
+  if (!lupine_event_query_needed(&table, event, &recorded) || recorded != 1) {
+    std::cerr << "FAIL: first query did not require the recorded event\n";
     return false;
   }
-  complete(&table, events, recorded, count);
-  if (lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
-                                       resolve_all_to_a, events,
-                                       recorded) != 0) {
+  CUresult result = CUDA_SUCCESS;
+  lupine_event_note_query_results(&table, &event, &recorded, &result, 1);
+  if (lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: completed event did not answer locally\n";
     return false;
   }
   return true;
 }
 
-bool test_rerecord_forces_fresh_batch() {
+bool test_rerecord_forces_fresh_query() {
   lupine_event_table table;
-  CUevent events[kLupineEventQueryBatch];
-  uint64_t recorded[kLupineEventQueryBatch];
-  lupine_event_note_recorded(&table, fake_event(0));
-  uint32_t count = lupine_event_collect_query_batch(
-      &table, fake_event(0), kConnA, resolve_all_to_a, events, recorded);
-  complete(&table, events, recorded, count);
-  lupine_event_note_recorded(&table, fake_event(0));
-  count = lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
-                                           resolve_all_to_a, events, recorded);
-  if (count != 1 || recorded[0] != 2) {
+  CUevent event = fake_event(0);
+  uint64_t recorded = 0;
+  lupine_event_note_recorded(&table, event);
+  if (!lupine_event_query_needed(&table, event, &recorded)) {
+    std::cerr << "FAIL: first record did not require a query\n";
+    return false;
+  }
+  CUresult result = CUDA_SUCCESS;
+  lupine_event_note_query_results(&table, &event, &recorded, &result, 1);
+  lupine_event_note_recorded(&table, event);
+  if (!lupine_event_query_needed(&table, event, &recorded) || recorded != 2) {
     std::cerr << "FAIL: re-recorded event did not raise the record sequence\n";
     return false;
   }
   // A result carrying the stale sequence must not mark the new record done.
-  uint64_t stale[kLupineEventQueryBatch] = {1};
-  complete(&table, events, stale, 1);
-  if (lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
-                                       resolve_all_to_a, events,
-                                       recorded) == 0) {
+  uint64_t stale = 1;
+  lupine_event_note_query_results(&table, &event, &stale, &result, 1);
+  if (!lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: stale completion answered a newer record locally\n";
     return false;
   }
@@ -95,27 +91,30 @@ bool test_eviction_is_oldest_recorded() {
   for (uintptr_t i = 0; i < kLupineEventQueryBatch + 1; ++i) {
     lupine_event_note_recorded(&table, fake_event(i));
   }
-  uint32_t count = lupine_event_collect_query_batch(
-      &table, fake_event(kLupineEventQueryBatch), kConnA, resolve_all_to_a,
-      events, recorded);
-  if (recorded[0] != kLupineEventQueryBatch + 1) {
+  uint64_t newest_recorded = 0;
+  if (!lupine_event_query_needed(&table, fake_event(kLupineEventQueryBatch),
+                                 &newest_recorded) ||
+      newest_recorded != kLupineEventQueryBatch + 1) {
     std::cerr << "FAIL: newest event lost its slot\n";
     return false;
   }
+  uint32_t count = lupine_event_collect_query_prefetch(
+      &table, fake_event(kLupineEventQueryBatch), kConnA, resolve_all_to_a,
+      events, recorded);
   if (batch_contains(events, count, fake_event(0))) {
     std::cerr << "FAIL: oldest recorded event was not evicted\n";
     return false;
   }
-  count = lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
-                                           resolve_all_to_a, events, recorded);
-  if (count == 0 || events[0] != fake_event(0) || recorded[0] != 0) {
-    std::cerr << "FAIL: untracked event did not force a remote batch\n";
+  uint64_t untracked_recorded = 1;
+  if (!lupine_event_query_needed(&table, fake_event(0), &untracked_recorded) ||
+      untracked_recorded != 0) {
+    std::cerr << "FAIL: untracked event did not force a remote query\n";
     return false;
   }
   return true;
 }
 
-bool test_batch_caps_and_filters() {
+bool test_prefetch_batch_excludes_and_filters() {
   lupine_event_table table;
   CUevent events[kLupineEventQueryBatch];
   uint64_t recorded[kLupineEventQueryBatch];
@@ -123,22 +122,21 @@ bool test_batch_caps_and_filters() {
     lupine_event_note_recorded(&table, fake_event(i));
   }
   CUevent untracked = fake_event(99);
-  uint32_t count = lupine_event_collect_query_batch(
-      &table, untracked, kConnA, resolve_all_to_a, events, recorded);
-  if (count != kLupineEventQueryBatch || events[0] != untracked ||
-      recorded[0] != 0) {
-    std::cerr << "FAIL: batch was not capped with the primary first\n";
+  uint32_t count = lupine_event_collect_query_prefetch(
+      &table, fake_event(0), kConnA, resolve_all_to_a, events, recorded);
+  if (count != kLupineEventQueryBatch - 1 ||
+      batch_contains(events, count, fake_event(0))) {
+    std::cerr << "FAIL: requested event appeared in the prefetch batch\n";
     return false;
   }
-  // One event on another connection and one already completed both drop out,
-  // so a full table now leaves room under the cap.
+  // One event on another connection and one already completed both drop out.
   CUevent done[1] = {fake_event(3)};
   uint64_t done_recorded[1] = {4};
   complete(&table, done, done_recorded, 1);
-  count = lupine_event_collect_query_batch(&table, untracked, kConnA,
-                                           resolve_last_to_b, events, recorded);
-  if (count != kLupineEventQueryBatch - 1) {
-    std::cerr << "FAIL: completed and foreign-connection events were batched\n";
+  count = lupine_event_collect_query_prefetch(
+      &table, untracked, kConnA, resolve_last_to_b, events, recorded);
+  if (count != kLupineEventQueryBatch - 2) {
+    std::cerr << "FAIL: prefetch did not filter completed and foreign events\n";
     return false;
   }
   if (batch_contains(events, count, fake_event(3)) ||
@@ -149,25 +147,45 @@ bool test_batch_caps_and_filters() {
   return true;
 }
 
+bool test_query_results_cache_only_successes() {
+  lupine_event_table table;
+  CUevent events[2] = {fake_event(0), fake_event(1)};
+  uint64_t recorded[2] = {1, 2};
+  CUresult results[2] = {CUDA_SUCCESS, CUDA_ERROR_NOT_READY};
+  lupine_event_note_recorded(&table, events[0]);
+  lupine_event_note_recorded(&table, events[1]);
+  lupine_event_note_query_results(&table, events, recorded, results, 2);
+
+  uint64_t query_recorded = 0;
+  if (lupine_event_query_needed(&table, events[0], &query_recorded)) {
+    std::cerr << "FAIL: successful prefetch result was not cached\n";
+    return false;
+  }
+  if (!lupine_event_query_needed(&table, events[1], &query_recorded)) {
+    std::cerr << "FAIL: incomplete prefetch result was cached\n";
+    return false;
+  }
+  return true;
+}
+
 bool test_pending_dtoh_suppresses_local_answer() {
   lupine_event_table table;
-  CUevent events[kLupineEventQueryBatch];
-  uint64_t recorded[kLupineEventQueryBatch];
-  lupine_event_note_recorded(&table, fake_event(0));
-  uint32_t count = lupine_event_collect_query_batch(
-      &table, fake_event(0), kConnA, resolve_all_to_a, events, recorded);
-  complete(&table, events, recorded, count);
+  CUevent event = fake_event(0);
+  uint64_t recorded = 0;
+  lupine_event_note_recorded(&table, event);
+  if (!lupine_event_query_needed(&table, event, &recorded)) {
+    std::cerr << "FAIL: first record did not require a query\n";
+    return false;
+  }
+  CUresult result = CUDA_SUCCESS;
+  lupine_event_note_query_results(&table, &event, &recorded, &result, 1);
   lupine_event_note_async_dtoh(&table);
-  if (lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
-                                       resolve_all_to_a, events,
-                                       recorded) == 0) {
+  if (!lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: pending async copy was answered locally\n";
     return false;
   }
   lupine_event_note_dtoh_drained(&table, lupine_event_dtoh_issued(&table));
-  if (lupine_event_collect_query_batch(&table, fake_event(0), kConnA,
-                                       resolve_all_to_a, events,
-                                       recorded) != 0) {
+  if (lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: drained copy still forced a round trip\n";
     return false;
   }
@@ -178,8 +196,10 @@ bool test_pending_dtoh_suppresses_local_answer() {
 
 int main() {
   if (!test_completed_event_answers_locally() ||
-      !test_rerecord_forces_fresh_batch() ||
-      !test_eviction_is_oldest_recorded() || !test_batch_caps_and_filters() ||
+      !test_rerecord_forces_fresh_query() ||
+      !test_eviction_is_oldest_recorded() ||
+      !test_prefetch_batch_excludes_and_filters() ||
+      !test_query_results_cache_only_successes() ||
       !test_pending_dtoh_suppresses_local_answer()) {
     return 1;
   }

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3200,10 +3200,43 @@ int handle_manual_cuEventRecord(conn_t *conn, bool with_flags) {
   return 0;
 }
 
-// The client batches every event it still has outstanding into one query so a
-// poller walking several events pays one round trip; events[0] is the one the
-// caller asked about and the only one that governs the deferred copy drain.
 int handle_manual_cuEventQuery(conn_t *conn) {
+  CUevent event = nullptr;
+  if (rpc_read(conn, &event, sizeof(event)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  CUresult result = cuEventQuery(event);
+
+  if (rpc_write_start_response(conn, request_id) < 0) {
+    return -1;
+  }
+  uint32_t copy_count = 0;
+  std::vector<lupine_pending_dtoh_copy> pending;
+  if (result == CUDA_SUCCESS) {
+    pending = lupine_detach_pending_dtoh_copies(conn, nullptr, true);
+    if (lupine_write_pending_dtoh_copies(&copy_count, conn, pending) < 0) {
+      lupine_cleanup_pending_dtoh_copies(&pending);
+      return -1;
+    }
+  } else {
+    if (rpc_write(conn, &copy_count, sizeof(copy_count)) < 0) {
+      return -1;
+    }
+  }
+  if (rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    lupine_cleanup_pending_dtoh_copies(&pending);
+    return -1;
+  }
+  lupine_cleanup_pending_dtoh_copies(&pending);
+  return 0;
+}
+
+int handle_manual_lupineEventQueryBatch(conn_t *conn) {
   uint32_t count = 0;
   if (rpc_read(conn, &count, sizeof(count)) < 0 || count == 0 ||
       count > LUPINE_EVENT_QUERY_BATCH_MAX) {
@@ -3222,30 +3255,12 @@ int handle_manual_cuEventQuery(conn_t *conn) {
   for (uint32_t i = 0; i < count; ++i) {
     results[i] = cuEventQuery(events[i]);
   }
-  CUresult result = results[0];
 
-  if (rpc_write_start_response(conn, request_id) < 0) {
-    return -1;
-  }
-  uint32_t copy_count = 0;
-  std::vector<lupine_pending_dtoh_copy> pending;
-  if (result == CUDA_SUCCESS) {
-    pending = lupine_detach_pending_dtoh_copies(conn, nullptr, true);
-    if (lupine_write_pending_dtoh_copies(&copy_count, conn, pending) < 0) {
-      lupine_cleanup_pending_dtoh_copies(&pending);
-      return -1;
-    }
-  } else {
-    if (rpc_write(conn, &copy_count, sizeof(copy_count)) < 0) {
-      return -1;
-    }
-  }
-  if (rpc_write(conn, results, count * sizeof(results[0])) < 0 ||
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, results, count * sizeof(results[0])) < 0 ||
       rpc_write_end(conn) < 0) {
-    lupine_cleanup_pending_dtoh_copies(&pending);
     return -1;
   }
-  lupine_cleanup_pending_dtoh_copies(&pending);
   return 0;
 }
 

--- a/manual_server.h
+++ b/manual_server.h
@@ -68,6 +68,7 @@ int handle_manual_cuLaunchHostFunc(conn_t *conn);
 int handle_manual_cuStreamAddCallback(conn_t *conn);
 int handle_manual_cuEventRecord(conn_t *conn, bool with_flags);
 int handle_manual_cuEventQuery(conn_t *conn);
+int handle_manual_lupineEventQueryBatch(conn_t *conn);
 int handle_manual_cuStreamWaitEvent(conn_t *conn);
 int handle_manual_cuStreamBeginCaptureToGraph(conn_t *conn);
 int handle_manual_cuStreamUpdateCaptureDependencies(conn_t *conn);

--- a/rpc.h
+++ b/rpc.h
@@ -35,8 +35,8 @@ struct rpc_http2_read_stats {
 // stay uncredited until the staging buffer they landed in retires.
 #define LUPINE_FF_STAGING_WINDOW_BYTES (64ull * 1024 * 1024)
 
-// Events a single RPC_cuEventQuery may carry. The request is a count followed
-// by that many handles, the caller's own first, and the response is one
+// Events the explicit lupineEventQueryBatch cache-warming RPC may carry. Its
+// request is a count followed by that many handles, and its response is one
 // CUresult per handle in the same order.
 #define LUPINE_EVENT_QUERY_BATCH_MAX 16
 

--- a/server.cpp
+++ b/server.cpp
@@ -246,6 +246,8 @@ lupine_manual_handlers() {
        {[](conn_t *conn) { return handle_manual_cuEventRecord(conn, true); },
         "cuEventRecordWithFlags"}},
       {RPC_cuEventQuery, {handle_manual_cuEventQuery, "cuEventQuery"}},
+      {LUPINE_RPC_lupineEventQueryBatch,
+       {handle_manual_lupineEventQueryBatch, "lupineEventQueryBatch"}},
       {RPC_cuStreamWaitEvent,
        {handle_manual_cuStreamWaitEvent, "cuStreamWaitEvent"}},
       {LUPINE_RPC_cuStreamBeginCaptureToGraph,


### PR DESCRIPTION
## Summary

- restore `RPC_cuEventQuery` to querying only the caller-requested event
- keep the requested event's completion-gated deferred DtoH payload in the original response
- add an explicit `LUPINE_RPC_lupineEventQueryBatch` request for best-effort cache warming of other outstanding events
- separate the primary-query decision from prefetch candidate collection and extend the event-cache tests

## Semantics

The client fully consumes the original `RPC_cuEventQuery` response, updates the requested event's cache entry, and fixes the CUDA/mapped-memory return value before attempting the supplemental batch. The batch excludes the requested event, stays on the same routed connection and lane, and caches only successful results whose record sequence is still current.

A batch transport or per-event query failure is ignored and cannot change the original call's return value. A transport failure can still make that connection unavailable to later CUDA calls, as with any failed RPC, but it does not rewrite the completed `cuEventQuery` result.

When other outstanding events exist, preserving batch warming now costs one explicit additional blocking RTT. When there are no candidates, no sidechannel request is sent. Same-connection ordering ensures the server observes preceding event records before either query.

## Validation

- `cmake --build build --parallel 8`
- `ctest --test-dir build --output-on-failure` (10/10 passed; two environment-dependent tests skipped)
- regenerated checked-in RPC sources with `codegen.py`; only the new deterministic private RPC ID was added
- `git diff --check`

Fixes #493
