### PR TITLE
Add request-owned RPC writes

### DIFF
--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -714,6 +714,48 @@ void test_rpc_write_queue_grows() {
   require(received == values, "large queue payload mismatch");
 }
 
+void test_rpc_write_copy_owns_buffer() {
+  h2_pair pair = make_pair();
+
+  constexpr int kResponseId = 19;
+  const std::vector<int> expected = {2, 3, 5, 7, 11};
+  std::vector<int> received(expected.size(), 0);
+  std::thread reader([&] {
+    read_rpc_prefix(&pair.server);
+    require(pair.server.read_id == kResponseId,
+            "copied write response id mismatch");
+    require(rpc_read_start(&pair.server, kResponseId) == 0,
+            "copied write read start failed");
+    require(rpc_read(&pair.server, received.data(),
+                     received.size() * sizeof(received[0])) ==
+                static_cast<int>(received.size() * sizeof(received[0])),
+            "copied write payload read failed");
+    require(rpc_read_end(&pair.server) == kResponseId,
+            "copied write read_end failed");
+  });
+
+  require(rpc_write_start_response(&pair.client, kResponseId) == 0,
+          "copied write response start failed");
+  std::vector<int> source = expected;
+  require(rpc_write_copy(&pair.client, source.data(),
+                         source.size() * sizeof(source[0])) == 0,
+          "rpc_write_copy failed");
+  require(pair.client.write_queue_count == 4,
+          "copied write queue count mismatch");
+  require(pair.client.write_queue[3].owned != 0,
+          "copied write queue did not own its buffer");
+  require(pair.client.write_queue[3].iov.iov_base != source.data(),
+          "copied write retained the source buffer");
+  std::fill(source.begin(), source.end(), -1);
+
+  require(rpc_write_end(&pair.client) == kResponseId,
+          "copied write write_end failed");
+  require(pair.client.write_queue[3].owned == 0,
+          "copied write ownership survived write_end");
+  reader.join();
+  require(received == expected, "copied write payload mismatch");
+}
+
 void test_rpc_lz4_payload_round_trip() {
   h2_pair pair = make_pair();
   init_rpc_write(&pair.client);
@@ -775,6 +817,7 @@ int main() {
   test_head_probe_cuda_version_metadata();
 #else
   test_rpc_write_queue_grows();
+  test_rpc_write_copy_owns_buffer();
   test_rpc_lz4_payload_round_trip();
   test_client_to_server();
   test_server_receives_session_id();

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -109,7 +109,24 @@ static int rpc_write_queue_reserve(conn_t *conn, int capacity) {
   return 0;
 }
 
+static void rpc_write_queue_release_owned(conn_t *conn) {
+  if (conn == nullptr) {
+    return;
+  }
+  for (int i = 0; i < conn->write_queue_count; ++i) {
+    rpc_write_entry *entry = &conn->write_queue[i];
+    if (entry->owned) {
+      free(entry->iov.iov_base);
+      *entry = {};
+    }
+  }
+}
+
 static int rpc_write_queue_reset(conn_t *conn, int count) {
+  rpc_write_queue_release_owned(conn);
+  if (conn != nullptr) {
+    conn->write_queue_count = 0;
+  }
   if (rpc_write_queue_reserve(conn, count) < 0) {
     return -1;
   }
@@ -121,12 +138,13 @@ static int rpc_write_queue_reset(conn_t *conn, int count) {
 }
 
 static int rpc_write_queue_push(conn_t *conn, const void *data, size_t size,
-                                unsigned char framed) {
+                                unsigned char framed, unsigned char owned) {
   if (conn == nullptr || conn->write_queue_count == INT_MAX ||
       rpc_write_queue_reserve(conn, conn->write_queue_count + 1) < 0) {
     return -1;
   }
-  conn->write_queue[conn->write_queue_count++] = {{(void *)data, size}, framed};
+  conn->write_queue[conn->write_queue_count++] = {
+      {(void *)data, size}, framed, owned};
   return 0;
 }
 
@@ -134,6 +152,7 @@ void rpc_write_queue_free(conn_t *conn) {
   if (conn == nullptr) {
     return;
   }
+  rpc_write_queue_release_owned(conn);
   free(conn->write_queue);
   conn->write_queue = nullptr;
   conn->write_queue_count = 0;
@@ -489,7 +508,26 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
 }
 
 int rpc_write(conn_t *conn, const void *data, const size_t size) {
-  return rpc_write_queue_push(conn, data, size, 0);
+  return rpc_write_queue_push(conn, data, size, 0, 0);
+}
+
+int rpc_write_copy(conn_t *conn, const void *data, const size_t size) {
+  if (size == 0) {
+    return rpc_write_queue_push(conn, data, size, 0, 0);
+  }
+  if (data == nullptr) {
+    return -1;
+  }
+  void *copy = malloc(size);
+  if (copy == nullptr) {
+    return -1;
+  }
+  memcpy(copy, data, size);
+  if (rpc_write_queue_push(conn, copy, size, 0, 1) < 0) {
+    free(copy);
+    return -1;
+  }
+  return 0;
 }
 
 int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs, size_t count) {
@@ -997,7 +1035,7 @@ int rpc_read_jit_outputs(conn_t *conn,
 // buffer must stay valid until rpc_write_end() returns, exactly like
 // rpc_write(). See compress.cpp for the framing format.
 int rpc_write_framed(conn_t *conn, const void *data, const size_t size) {
-  return rpc_write_queue_push(conn, data, size, 1);
+  return rpc_write_queue_push(conn, data, size, 1, 0);
 }
 
 // rpc_write_end finalizes the current request builder on the given connection
@@ -1008,6 +1046,7 @@ int rpc_write_framed(conn_t *conn, const void *data, const size_t size) {
 int rpc_write_end(conn_t *conn) {
   bool request = conn->write_op != -1;
   if (conn->closed) {
+    rpc_write_queue_release_owned(conn);
     pthread_mutex_unlock(&conn->write_mutex);
     if (request) {
       pthread_mutex_unlock(&conn->call_mutex);
@@ -1023,6 +1062,7 @@ int rpc_write_end(conn_t *conn) {
     conn->write_queue[2] = {{&conn->write_op, sizeof(conn->write_op)}, 0};
     result = rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
   }
+  rpc_write_queue_release_owned(conn);
   pthread_mutex_unlock(&conn->write_mutex);
   if (request) {
     pthread_mutex_unlock(&conn->call_mutex);

--- a/rpc.h
+++ b/rpc.h
@@ -18,6 +18,8 @@ struct rpc_write_entry {
   // every block is stored raw (the source is already compressed, so the LZ4
   // attempt would only waste CPU; the wire format is unchanged).
   unsigned char framed;
+  // The queue owns iov_base and releases it after rpc_write_end or reset.
+  unsigned char owned;
 };
 
 struct rpc_http2_read_stats {
@@ -91,6 +93,9 @@ extern int rpc_wait_for_response(conn_t *conn);
 extern int rpc_write_start_request(conn_t *conn, const int op);
 extern int rpc_write_start_response(conn_t *conn, const int read_id);
 extern int rpc_write(conn_t *conn, const void *data, const size_t size);
+// Copies data into request-owned storage. Unlike rpc_write, the caller may
+// modify or release its source buffer before rpc_write_end returns.
+extern int rpc_write_copy(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs,
                             size_t count);
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);


### PR DESCRIPTION
## Summary

- add `rpc_write_copy` for request payloads whose source lifetime does not extend to `rpc_write_end`
- track copied buffers on individual write-queue entries
- release owned buffers after a successful or failed flush, when a queue is reset, and when a connection is destroyed
- retain the existing borrowed, zero-copy `rpc_write` behavior
- test that the source may be mutated before flush and that ownership is cleared at `rpc_write_end`

## Why

`rpc_write` deliberately queues borrowed iovecs. Small metadata serializers currently need caller-owned scratch buffers solely to keep bytes alive until the queue flushes. `rpc_write_copy` makes that lifecycle explicit in the transport and lets those serializers construct local wire buffers safely.

Follow-up #502 audits the existing hand-written and generated callers, migrates transient metadata, and deliberately keeps large or otherwise stable payloads on borrowed writes.

## Validation

- `cmake --build build --parallel 8`
- `ctest --test-dir build --output-on-failure` — 10/10 passed, two expected skips
- ASan + UBSan `h2_test` — passed