### PR TITLE
Use cached parameter layout bounds

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -2350,6 +2350,13 @@ static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
     return CUDA_SUCCESS;
   }
 
+  size_t param_count = 0;
+  if (lupine_param_layout_count_cache().find(
+          lupine_param_layout_key{handle, kernel}, param_count) &&
+      param_index >= param_count) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
   size_t offset = 0;
   size_t size = 0;


### PR DESCRIPTION
## What changed

- consult the cached parameter-layout count after a parameter-info cache miss
- return the known out-of-range result locally instead of issuing another RPC

## Why

The success-only parameter-info cache stores valid parameter records and the successfully discovered layout length separately. The getter used the records but ignored the length, so every kernel launch repeated the terminal out-of-range `cuFuncGetParamInfo` or `cuKernelGetParamInfo` RPC. On a 300 ms link this leaves one blocking round trip per launch and collapses GPT benchmark throughput.

This keeps error results out of the cache: the fast path derives the out-of-range result from the cached successful layout boundary.

## Validation

- full CUDA 13.1 build
- CTest: 10/10 passed (2 expected environment skips)
- `git diff --check`
