### PR TITLE
Release resources after failed client disconnects

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -8241,11 +8241,7 @@ void rpc_close(conn_t *conn) {
   // lane threads with no CUDA context. Invalidate all per-lane context hints.
   lupine_invalidate_current_context_cache();
 
-  if (!conn->closed) {
-    conn->closed = 1;
-    shutdown(conn->connfd, SHUT_RDWR);
-    close(conn->connfd);
-  }
+  rpc_close_transport_socket(conn);
 
   pthread_mutex_lock(&conn->read_mutex);
   pthread_cond_broadcast(&conn->read_cond);

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -4,11 +4,14 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cerrno>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <iostream>
 #include <nghttp2/nghttp2.h>
+#include <netinet/in.h>
 #include <string>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -313,6 +316,108 @@ void test_truncated_read_clears_direct_destination() {
     }
     require(guarded[i] == 0xa5, "truncated read wrote outside prefix");
   }
+}
+
+void test_close_already_failed_transport_socket() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+
+  // Transport readers mark the logical connection closed before the owner
+  // performs descriptor cleanup. That state must not suppress shutdown: a
+  // peer can otherwise retain its per-connection resources indefinitely.
+  pair.client.closed = 1;
+  rpc_close_transport_socket(&pair.client);
+  require(pair.client.connfd == LUPINE_INVALID_SOCKET,
+          "failed transport socket was not claimed");
+
+  char buffer[4096];
+  ssize_t received = 0;
+  do {
+    received = recv(pair.server.connfd, buffer, sizeof(buffer), 0);
+  } while (received > 0);
+  require(received == 0 || (received < 0 && errno == ECONNRESET),
+          "failed transport socket did not notify peer");
+
+  // Cleanup can race the dispatch thread and the library destructor.
+  rpc_close_transport_socket(&pair.client);
+  require(pair.client.connfd == LUPINE_INVALID_SOCKET,
+          "transport socket close was not idempotent");
+}
+
+void test_abort_failed_transport_with_queued_data() {
+  int listener = socket(AF_INET, SOCK_STREAM, 0);
+  require(listener >= 0, "queued close listener socket failed");
+
+  sockaddr_in address = {};
+  address.sin_family = AF_INET;
+  address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  address.sin_port = 0;
+  require(bind(listener, reinterpret_cast<sockaddr *>(&address),
+               sizeof(address)) == 0,
+          "queued close bind failed");
+  socklen_t address_size = sizeof(address);
+  require(getsockname(listener, reinterpret_cast<sockaddr *>(&address),
+                      &address_size) == 0,
+          "queued close getsockname failed");
+  require(listen(listener, 1) == 0, "queued close listen failed");
+
+  conn_t connection = {};
+  connection.connfd = socket(AF_INET, SOCK_STREAM, 0);
+  require(connection.connfd >= 0, "queued close client socket failed");
+  require(lupine_socket_apply_transport_options(connection.connfd) == 0,
+          "queued close transport setup failed");
+#ifdef TCP_USER_TIMEOUT
+  int user_timeout = 0;
+  socklen_t user_timeout_size = sizeof(user_timeout);
+  require(getsockopt(connection.connfd, IPPROTO_TCP, TCP_USER_TIMEOUT,
+                     &user_timeout, &user_timeout_size) == 0 &&
+              user_timeout == 105000,
+          "unacknowledged transport data has no dead-peer timeout");
+#endif
+  int buffer_size = 4096;
+  require(setsockopt(connection.connfd, SOL_SOCKET, SO_SNDBUF, &buffer_size,
+                     sizeof(buffer_size)) == 0,
+          "queued close send buffer setup failed");
+  require(connect(connection.connfd, reinterpret_cast<sockaddr *>(&address),
+                  sizeof(address)) == 0,
+          "queued close connect failed");
+  int peer = accept(listener, nullptr, nullptr);
+  require(peer >= 0, "queued close accept failed");
+  require(setsockopt(peer, SOL_SOCKET, SO_RCVBUF, &buffer_size,
+                     sizeof(buffer_size)) == 0,
+          "queued close receive buffer setup failed");
+
+  int flags = fcntl(connection.connfd, F_GETFL, 0);
+  require(flags >= 0 &&
+              fcntl(connection.connfd, F_SETFL, flags | O_NONBLOCK) == 0,
+          "queued close nonblocking setup failed");
+  std::array<char, 64 * 1024> payload = {};
+  size_t queued = 0;
+  for (;;) {
+    ssize_t sent = send(connection.connfd, payload.data(), payload.size(),
+                        MSG_NOSIGNAL);
+    if (sent > 0) {
+      queued += static_cast<size_t>(sent);
+      continue;
+    }
+    require(sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK),
+            "queued close fill failed");
+    break;
+  }
+  require(queued != 0, "queued close did not queue data");
+
+  connection.closed = 1;
+  rpc_close_transport_socket(&connection);
+
+  ssize_t received = 0;
+  do {
+    received = recv(peer, payload.data(), payload.size(), 0);
+  } while (received > 0);
+  require(received < 0 && errno == ECONNRESET,
+          "queued transport close was not abortive");
+
+  close(peer);
+  close(listener);
 }
 
 void test_concurrent_response_lanes() {
@@ -827,6 +932,8 @@ int main() {
   test_fragmented_frames_direct();
   test_partial_read_stages_only_overflow();
   test_truncated_read_clears_direct_destination();
+  test_close_already_failed_transport_socket();
+  test_abort_failed_transport_with_queued_data();
   test_concurrent_response_lanes();
   test_large_payload();
   test_framed_payload_round_trip();

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -231,6 +231,10 @@ inline int lupine_fd_truncate(int fd, off_t length) {
 //     With the defaults a dead peer is detected in ~105s instead of hanging on
 //     the retransmit timer. Socket buffer sizing is left to the OS, which
 //     auto-tunes on modern kernels.
+//   * TCP_USER_TIMEOUT, where available, applies the same dead-peer bound
+//     while application data is unacknowledged. TCP keepalive does not run
+//     while data is in flight, which otherwise leaves a disconnected client
+//     on the much longer system retransmission timeout.
 //
 // Returns 0 on success, -1 on an invalid descriptor.
 inline int lupine_socket_apply_transport_options(lupine_socket_t fd) {
@@ -270,12 +274,19 @@ inline int lupine_socket_apply_transport_options(lupine_socket_t fd) {
              sizeof(keepcnt));
 #endif
 #else
+  constexpr int kDeadPeerTimeoutMs =
+      (kKeepidleSec + kKeepintvlSec * kKeepcnt) * 1000;
   setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,
              reinterpret_cast<const char *>(&keepidle), sizeof(keepidle));
   setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL,
              reinterpret_cast<const char *>(&keepintvl), sizeof(keepintvl));
   setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,
              reinterpret_cast<const char *>(&keepcnt), sizeof(keepcnt));
+#ifdef TCP_USER_TIMEOUT
+  int user_timeout = kDeadPeerTimeoutMs;
+  setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &user_timeout,
+             sizeof(user_timeout));
+#endif
 #endif
   return 0;
 }

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -263,11 +263,7 @@ void close_connections() {
   int count = nconns;
   for (int i = 0; i < count; ++i) {
     conn_t *c = &conns[i];
-    if (!c->closed) {
-      c->closed = 1;
-      shutdown(c->connfd, SHUT_RDWR);
-      close(c->connfd);
-    }
+    rpc_close_transport_socket(c);
     pthread_mutex_lock(&c->read_mutex);
     pthread_cond_broadcast(&c->read_cond);
     pthread_mutex_unlock(&c->read_mutex);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -81,6 +81,44 @@ lupine_socket_t lupine_tcp_connect(const char *host, const char *port) {
 
 extern void rpc_http2_destroy(conn_t *conn);
 
+void rpc_close_transport_socket(conn_t *conn) {
+  if (conn == nullptr) {
+    return;
+  }
+
+#ifdef _WIN32
+  conn->closed = 1;
+  lupine_socket_t socket = conn->connfd;
+  conn->connfd = LUPINE_INVALID_SOCKET;
+#else
+  __atomic_store_n(&conn->closed, 1, __ATOMIC_RELEASE);
+  lupine_socket_t socket = __atomic_exchange_n(
+      &conn->connfd, LUPINE_INVALID_SOCKET, __ATOMIC_ACQ_REL);
+#endif
+  if (socket == LUPINE_INVALID_SOCKET) {
+    return;
+  }
+  struct linger abortive = {};
+  abortive.l_onoff = 1;
+  abortive.l_linger = 0;
+#ifdef _WIN32
+  (void)setsockopt(socket, SOL_SOCKET, SO_LINGER,
+                   reinterpret_cast<const char *>(&abortive),
+                   sizeof(abortive));
+#else
+  (void)setsockopt(socket, SOL_SOCKET, SO_LINGER, &abortive,
+                   sizeof(abortive));
+#endif
+  // Wake a reader blocked in recv without sending a FIN. SHUT_RDWR would
+  // gracefully close the write side before SO_LINGER can reset the peer.
+#ifdef _WIN32
+  (void)shutdown(socket, SD_RECEIVE);
+#else
+  (void)shutdown(socket, SHUT_RD);
+#endif
+  (void)lupine_socket_close(socket);
+}
+
 static int rpc_write_queue_reserve(conn_t *conn, int capacity) {
   if (conn == nullptr || capacity < 0) {
     return -1;
@@ -163,6 +201,7 @@ void rpc_conn_destroy(conn_t *conn) {
   if (conn == nullptr) {
     return;
   }
+  rpc_close_transport_socket(conn);
   rpc_http2_destroy(conn);
   rpc_write_queue_free(conn);
   pthread_mutex_destroy(&conn->read_mutex);

--- a/rpc.h
+++ b/rpc.h
@@ -100,6 +100,10 @@ extern int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs,
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
+// Marks a connection closed and atomically takes ownership of its transport
+// socket before aborting it. Safe after a transport error has already set
+// conn->closed, and safe for concurrent/idempotent cleanup.
+extern void rpc_close_transport_socket(conn_t *conn);
 extern void rpc_write_queue_free(conn_t *conn);
 extern void rpc_conn_destroy(conn_t *conn);
 

--- a/server.cpp
+++ b/server.cpp
@@ -367,18 +367,15 @@ int client_handler(lupine_socket_t connfd) {
   int http2_init_result = rpc_http2_server_init(&conn);
   if (http2_init_result < 0) {
     LUPINE_LOG_ERROR("Error initializing HTTP/2 connection.");
-    lupine_socket_close(connfd);
     rpc_conn_destroy(&conn);
     return lupine_server_checkpoint_child_finish();
   }
   if (http2_init_result != 0) {
-    lupine_socket_close(connfd);
     rpc_conn_destroy(&conn);
     return lupine_server_checkpoint_child_finish();
   }
   if (!lupine_server_initialize_connection(&conn)) {
     LUPINE_LOG_ERROR("Error initializing per-connection staging state.");
-    lupine_socket_close(connfd);
     rpc_conn_destroy(&conn);
     return lupine_server_checkpoint_child_finish();
   }
@@ -522,9 +519,8 @@ int client_handler(lupine_socket_t connfd) {
     }
   }
 
-  conn.closed = 1;
+  rpc_close_transport_socket(&conn);
   pthread_cond_broadcast(&conn.read_cond);
-  lupine_socket_close(connfd);
   if (conn.rpc_thread != 0) {
     pthread_join(conn.rpc_thread, nullptr);
     conn.rpc_thread = 0;


### PR DESCRIPTION
## Summary

- close transport descriptors even when an RPC failure has already marked the logical connection closed
- make transport cleanup idempotent and abortive, and use it consistently for CUDA, NVML, server, and final connection destruction
- bound unacknowledged TCP data with `TCP_USER_TIMEOUT` using the existing 105-second keepalive failure budget
- cover already-failed, repeated, and queued-data teardown paths

## Root cause

Transport read/write failures set `conn->closed` before owner cleanup. CUDA and NVML cleanup then skipped `shutdown`/`close` whenever that flag was set, allowing the server child and its CUDA context to remain alive. With client-only netem, even a successful reset can be dropped when Docker destroys the delayed network namespace. In that case the server had an unacknowledged response, so keepalive did not run and Linux fell back to its much longer retransmission timeout.

## Validation

- full local build
- `ctest --test-dir build --output-on-failure`: 10/10 passed (2 expected skips)
- focused RTX 4090 repro on `inferable-node-008`: allocate/touch 20 GiB, add 300 ms client-container netem, then trigger a 6 GiB OOM and let Python exit
  - main: server retained 20,930 MiB and both connection children beyond 45 seconds
  - this branch: CUDA child exited by 110 seconds and GPU usage was fully released by 115 seconds, matching the configured 105-second dead-peer budget

## Tradeoff

When the peer disappears without delivering FIN/RST, a connection with unacknowledged data now fails after the same ~105-second budget already used for idle keepalive detection, rather than the host kernel's longer retransmission policy.