### PR TITLE
Keep high-latency HTTP/2 connections warm

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -755,6 +755,7 @@ static int lupine_connect_endpoint(conn_t *conn,
     lupine_socket_close(sockfd);
     return -1;
   }
+  rpc_http2_client_start_heartbeat(conn);
 
   return 0;
 }

--- a/h2.cpp
+++ b/h2.cpp
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <string>
+#include <time.h>
 #include <vector>
 
 namespace {
@@ -30,6 +31,10 @@ constexpr uint32_t kH2ServerWindow =
 constexpr uint64_t kH2MaxHeldBytes = LUPINE_FF_STAGING_WINDOW_BYTES / 2;
 constexpr uint32_t kH2MaxFrame = (16 * 1024 * 1024) - 1;
 constexpr size_t kH2FrameHeaderLen = 9;
+// Linux restarts slow start after an idle period of one retransmission
+// timeout. Keeping response waits below the usual 200 ms minimum RTO avoids
+// collapsing the congestion window between bursts on high-latency links.
+constexpr long kH2HeartbeatIntervalMs = 100;
 
 struct h2_buffer {
   std::vector<unsigned char> data;
@@ -62,6 +67,11 @@ struct h2_transport {
   std::vector<unsigned char> compress_scratch;
   pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_cond_t session_progress = PTHREAD_COND_INITIALIZER;
+  pthread_t heartbeat_thread = {};
+  unsigned int response_waiters = 0;
+  bool heartbeat_started = false;
+  bool heartbeat_stop = false;
+  bool heartbeat_failed = false;
   bool transport_failed = false;
   std::string request_method;
   std::string request_path;
@@ -557,6 +567,58 @@ int h2_flush_session_locked(h2_transport *transport) {
   return result == 0 ? 0 : -1;
 }
 
+timespec h2_heartbeat_deadline() {
+  timespec deadline = {};
+  clock_gettime(CLOCK_REALTIME, &deadline);
+  deadline.tv_nsec += kH2HeartbeatIntervalMs * 1000 * 1000;
+  if (deadline.tv_nsec >= 1000 * 1000 * 1000) {
+    ++deadline.tv_sec;
+    deadline.tv_nsec -= 1000 * 1000 * 1000;
+  }
+  return deadline;
+}
+
+void *h2_heartbeat_main(void *arg) {
+  auto *transport = static_cast<h2_transport *>(arg);
+  pthread_mutex_lock(&transport->session_mutex);
+  while (!transport->heartbeat_stop) {
+    while ((transport->response_waiters == 0 ||
+            transport->heartbeat_failed) &&
+           !transport->heartbeat_stop) {
+      pthread_cond_wait(&transport->session_progress,
+                        &transport->session_mutex);
+    }
+    if (transport->heartbeat_stop) {
+      break;
+    }
+
+    timespec deadline = h2_heartbeat_deadline();
+    int wait_result = 0;
+    while (transport->response_waiters != 0 && !transport->heartbeat_stop &&
+           wait_result != ETIMEDOUT) {
+      wait_result = pthread_cond_timedwait(
+          &transport->session_progress, &transport->session_mutex, &deadline);
+    }
+    if (transport->response_waiters == 0 || transport->heartbeat_stop) {
+      continue;
+    }
+    if (wait_result != ETIMEDOUT) {
+      continue;
+    }
+
+    std::array<uint8_t, 8> opaque = {};
+    if (nghttp2_submit_ping(transport->session, NGHTTP2_FLAG_NONE,
+                            opaque.data()) != 0 ||
+        h2_flush_session_locked(transport) < 0) {
+      // The heartbeat is best-effort. The normal RPC read/write path owns
+      // transport error reporting and the in-flight CUDA call's result.
+      transport->heartbeat_failed = true;
+    }
+  }
+  pthread_mutex_unlock(&transport->session_mutex);
+  return nullptr;
+}
+
 int h2_flush_session(h2_transport *transport) {
   pthread_mutex_lock(&transport->session_mutex);
   int result = h2_flush_session_locked(transport);
@@ -865,6 +927,44 @@ int rpc_http2_get_read_stats(conn_t *conn, rpc_http2_read_stats *stats) {
   return 0;
 }
 
+void rpc_http2_response_wait_begin(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  if (transport->server) {
+    return;
+  }
+  pthread_mutex_lock(&transport->session_mutex);
+  if (!transport->heartbeat_started && !transport->heartbeat_stop &&
+      !transport->heartbeat_failed) {
+    if (pthread_create(&transport->heartbeat_thread, nullptr, h2_heartbeat_main,
+                       transport) == 0) {
+      transport->heartbeat_started = true;
+    } else {
+      transport->heartbeat_failed = true;
+    }
+  }
+  if (transport->heartbeat_started && !transport->heartbeat_stop) {
+    ++transport->response_waiters;
+    pthread_cond_broadcast(&transport->session_progress);
+  }
+  pthread_mutex_unlock(&transport->session_mutex);
+}
+
+void rpc_http2_response_wait_end(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  pthread_mutex_lock(&transport->session_mutex);
+  if (transport->response_waiters != 0) {
+    --transport->response_waiters;
+  }
+  pthread_cond_broadcast(&transport->session_progress);
+  pthread_mutex_unlock(&transport->session_mutex);
+}
+
 void rpc_http2_window_hold_begin(conn_t *conn) {
   if (conn == nullptr || conn->http2 == nullptr) {
     return;
@@ -954,6 +1054,14 @@ void rpc_http2_destroy(conn_t *conn) {
   }
   auto *transport = static_cast<h2_transport *>(conn->http2);
   conn->http2 = nullptr;
+  pthread_mutex_lock(&transport->session_mutex);
+  transport->heartbeat_stop = true;
+  pthread_cond_broadcast(&transport->session_progress);
+  pthread_mutex_unlock(&transport->session_mutex);
+  if (transport->heartbeat_started) {
+    pthread_join(transport->heartbeat_thread, nullptr);
+    transport->heartbeat_started = false;
+  }
   if (transport->session != nullptr) {
     nghttp2_session_del(transport->session);
     transport->session = nullptr;

--- a/h2.cpp
+++ b/h2.cpp
@@ -68,10 +68,7 @@ struct h2_transport {
   pthread_cond_t session_progress = PTHREAD_COND_INITIALIZER;
   pthread_cond_t heartbeat_progress = PTHREAD_COND_INITIALIZER;
   pthread_t heartbeat_thread = {};
-  unsigned int response_waiters = 0;
-  bool heartbeat_started = false;
-  bool heartbeat_stop = false;
-  bool heartbeat_failed = false;
+  int response_waiters = 0;
   bool transport_failed = false;
   std::string request_method;
   std::string request_path;
@@ -570,30 +567,29 @@ int h2_flush_session_locked(h2_transport *transport) {
 void *h2_heartbeat_main(void *arg) {
   auto *transport = static_cast<h2_transport *>(arg);
   pthread_mutex_lock(&transport->session_mutex);
-  while (!transport->heartbeat_stop) {
-    while ((transport->response_waiters == 0 ||
-            transport->heartbeat_failed) &&
-           !transport->heartbeat_stop) {
+  for (;;) {
+    while (transport->response_waiters == 0) {
       pthread_cond_wait(&transport->heartbeat_progress,
                         &transport->session_mutex);
     }
-    if (transport->heartbeat_stop) {
+    if (transport->response_waiters < 0) {
       break;
     }
 
     int wait_result = 0;
-    while (transport->response_waiters != 0 && !transport->heartbeat_stop &&
-           wait_result == 0) {
+    while (transport->response_waiters > 0 && wait_result == 0) {
       wait_result = lupine_cond_wait_for(&transport->heartbeat_progress,
                                          &transport->session_mutex,
                                          kH2HeartbeatIntervalMs);
     }
-    if (transport->response_waiters == 0 || transport->heartbeat_stop) {
+    if (transport->response_waiters < 0) {
+      break;
+    }
+    if (transport->response_waiters == 0) {
       continue;
     }
     if (wait_result < 0) {
-      transport->heartbeat_failed = true;
-      continue;
+      break;
     }
 
     std::array<uint8_t, 8> opaque = {};
@@ -602,7 +598,7 @@ void *h2_heartbeat_main(void *arg) {
         h2_flush_session_locked(transport) < 0) {
       // The heartbeat is best-effort. The normal RPC read/write path owns
       // transport error reporting and the in-flight CUDA call's result.
-      transport->heartbeat_failed = true;
+      break;
     }
   }
   pthread_mutex_unlock(&transport->session_mutex);
@@ -926,7 +922,7 @@ void rpc_http2_response_wait_begin(conn_t *conn) {
     return;
   }
   pthread_mutex_lock(&transport->session_mutex);
-  if (transport->heartbeat_started && !transport->heartbeat_stop) {
+  if (transport->heartbeat_thread != 0 && transport->response_waiters >= 0) {
     ++transport->response_waiters;
     pthread_cond_broadcast(&transport->heartbeat_progress);
   }
@@ -939,7 +935,7 @@ void rpc_http2_response_wait_end(conn_t *conn) {
   }
   auto *transport = static_cast<h2_transport *>(conn->http2);
   pthread_mutex_lock(&transport->session_mutex);
-  if (transport->response_waiters != 0) {
+  if (transport->response_waiters > 0) {
     --transport->response_waiters;
   }
   pthread_cond_broadcast(&transport->heartbeat_progress);
@@ -1000,13 +996,10 @@ void rpc_http2_client_start_heartbeat(conn_t *conn) {
   }
   auto *transport = static_cast<h2_transport *>(conn->http2);
   pthread_mutex_lock(&transport->session_mutex);
-  if (!transport->heartbeat_started && !transport->heartbeat_stop &&
-      !transport->heartbeat_failed) {
-    if (pthread_create(&transport->heartbeat_thread, nullptr, h2_heartbeat_main,
-                       transport) == 0) {
-      transport->heartbeat_started = true;
-    } else {
-      transport->heartbeat_failed = true;
+  if (transport->heartbeat_thread == 0 && transport->response_waiters >= 0) {
+    pthread_t thread = {};
+    if (pthread_create(&thread, nullptr, h2_heartbeat_main, transport) == 0) {
+      transport->heartbeat_thread = thread;
     }
   }
   pthread_mutex_unlock(&transport->session_mutex);
@@ -1054,12 +1047,12 @@ void rpc_http2_destroy(conn_t *conn) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
   conn->http2 = nullptr;
   pthread_mutex_lock(&transport->session_mutex);
-  transport->heartbeat_stop = true;
+  transport->response_waiters = -1;
   pthread_cond_broadcast(&transport->heartbeat_progress);
   pthread_mutex_unlock(&transport->session_mutex);
-  if (transport->heartbeat_started) {
+  if (transport->heartbeat_thread != 0) {
     pthread_join(transport->heartbeat_thread, nullptr);
-    transport->heartbeat_started = false;
+    transport->heartbeat_thread = 0;
   }
   if (transport->session != nullptr) {
     nghttp2_session_del(transport->session);

--- a/h2.cpp
+++ b/h2.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <climits>
 #include <deque>
 #include <errno.h>
@@ -15,6 +16,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -576,21 +578,10 @@ void *h2_heartbeat_main(void *arg) {
       break;
     }
 
-    int wait_result = 0;
-    while (transport->response_waiters > 0 && wait_result == 0) {
-      wait_result = lupine_cond_wait_for(&transport->heartbeat_progress,
-                                         &transport->session_mutex,
-                                         kH2HeartbeatIntervalMs);
-    }
-    if (transport->response_waiters < 0) {
-      break;
-    }
-    if (transport->response_waiters == 0) {
-      continue;
-    }
-    if (wait_result < 0) {
-      break;
-    }
+    pthread_mutex_unlock(&transport->session_mutex);
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(kH2HeartbeatIntervalMs));
+    pthread_mutex_lock(&transport->session_mutex);
 
     std::array<uint8_t, 8> opaque = {};
     if (nghttp2_submit_ping(transport->session, NGHTTP2_FLAG_NONE,
@@ -938,7 +929,6 @@ void rpc_http2_response_wait_end(conn_t *conn) {
   if (transport->response_waiters > 0) {
     --transport->response_waiters;
   }
-  pthread_cond_broadcast(&transport->heartbeat_progress);
   pthread_mutex_unlock(&transport->session_mutex);
 }
 

--- a/h2.cpp
+++ b/h2.cpp
@@ -15,7 +15,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <string>
-#include <time.h>
 #include <vector>
 
 namespace {
@@ -67,6 +66,7 @@ struct h2_transport {
   std::vector<unsigned char> compress_scratch;
   pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_cond_t session_progress = PTHREAD_COND_INITIALIZER;
+  pthread_cond_t heartbeat_progress = PTHREAD_COND_INITIALIZER;
   pthread_t heartbeat_thread = {};
   unsigned int response_waiters = 0;
   bool heartbeat_started = false;
@@ -567,17 +567,6 @@ int h2_flush_session_locked(h2_transport *transport) {
   return result == 0 ? 0 : -1;
 }
 
-timespec h2_heartbeat_deadline() {
-  timespec deadline = {};
-  clock_gettime(CLOCK_REALTIME, &deadline);
-  deadline.tv_nsec += kH2HeartbeatIntervalMs * 1000 * 1000;
-  if (deadline.tv_nsec >= 1000 * 1000 * 1000) {
-    ++deadline.tv_sec;
-    deadline.tv_nsec -= 1000 * 1000 * 1000;
-  }
-  return deadline;
-}
-
 void *h2_heartbeat_main(void *arg) {
   auto *transport = static_cast<h2_transport *>(arg);
   pthread_mutex_lock(&transport->session_mutex);
@@ -585,24 +574,25 @@ void *h2_heartbeat_main(void *arg) {
     while ((transport->response_waiters == 0 ||
             transport->heartbeat_failed) &&
            !transport->heartbeat_stop) {
-      pthread_cond_wait(&transport->session_progress,
+      pthread_cond_wait(&transport->heartbeat_progress,
                         &transport->session_mutex);
     }
     if (transport->heartbeat_stop) {
       break;
     }
 
-    timespec deadline = h2_heartbeat_deadline();
     int wait_result = 0;
     while (transport->response_waiters != 0 && !transport->heartbeat_stop &&
-           wait_result != ETIMEDOUT) {
-      wait_result = pthread_cond_timedwait(
-          &transport->session_progress, &transport->session_mutex, &deadline);
+           wait_result == 0) {
+      wait_result = lupine_cond_wait_for(&transport->heartbeat_progress,
+                                         &transport->session_mutex,
+                                         kH2HeartbeatIntervalMs);
     }
     if (transport->response_waiters == 0 || transport->heartbeat_stop) {
       continue;
     }
-    if (wait_result != ETIMEDOUT) {
+    if (wait_result < 0) {
+      transport->heartbeat_failed = true;
       continue;
     }
 
@@ -936,18 +926,9 @@ void rpc_http2_response_wait_begin(conn_t *conn) {
     return;
   }
   pthread_mutex_lock(&transport->session_mutex);
-  if (!transport->heartbeat_started && !transport->heartbeat_stop &&
-      !transport->heartbeat_failed) {
-    if (pthread_create(&transport->heartbeat_thread, nullptr, h2_heartbeat_main,
-                       transport) == 0) {
-      transport->heartbeat_started = true;
-    } else {
-      transport->heartbeat_failed = true;
-    }
-  }
   if (transport->heartbeat_started && !transport->heartbeat_stop) {
     ++transport->response_waiters;
-    pthread_cond_broadcast(&transport->session_progress);
+    pthread_cond_broadcast(&transport->heartbeat_progress);
   }
   pthread_mutex_unlock(&transport->session_mutex);
 }
@@ -961,7 +942,7 @@ void rpc_http2_response_wait_end(conn_t *conn) {
   if (transport->response_waiters != 0) {
     --transport->response_waiters;
   }
-  pthread_cond_broadcast(&transport->session_progress);
+  pthread_cond_broadcast(&transport->heartbeat_progress);
   pthread_mutex_unlock(&transport->session_mutex);
 }
 
@@ -1013,6 +994,24 @@ int rpc_http2_client_init(conn_t *conn) {
   return h2_init_direct(conn, false, false);
 }
 
+void rpc_http2_client_start_heartbeat(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  pthread_mutex_lock(&transport->session_mutex);
+  if (!transport->heartbeat_started && !transport->heartbeat_stop &&
+      !transport->heartbeat_failed) {
+    if (pthread_create(&transport->heartbeat_thread, nullptr, h2_heartbeat_main,
+                       transport) == 0) {
+      transport->heartbeat_started = true;
+    } else {
+      transport->heartbeat_failed = true;
+    }
+  }
+  pthread_mutex_unlock(&transport->session_mutex);
+}
+
 const char *rpc_http2_client_probe(conn_t *conn) {
   if (h2_init_direct(conn, false, true) < 0) {
     return nullptr;
@@ -1056,7 +1055,7 @@ void rpc_http2_destroy(conn_t *conn) {
   conn->http2 = nullptr;
   pthread_mutex_lock(&transport->session_mutex);
   transport->heartbeat_stop = true;
-  pthread_cond_broadcast(&transport->session_progress);
+  pthread_cond_broadcast(&transport->heartbeat_progress);
   pthread_mutex_unlock(&transport->session_mutex);
   if (transport->heartbeat_started) {
     pthread_join(transport->heartbeat_thread, nullptr);
@@ -1066,6 +1065,7 @@ void rpc_http2_destroy(conn_t *conn) {
     nghttp2_session_del(transport->session);
     transport->session = nullptr;
   }
+  pthread_cond_destroy(&transport->heartbeat_progress);
   pthread_cond_destroy(&transport->session_progress);
   pthread_mutex_destroy(&transport->session_mutex);
   delete transport;

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <nghttp2/nghttp2.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <string>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -158,6 +159,31 @@ bool raw_read_exact(lupine_socket_t socket, unsigned char *data, size_t size) {
     size -= static_cast<size_t>(received);
   }
   return true;
+}
+
+void test_response_wait_sends_transport_heartbeat() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+
+  rpc_http2_response_wait_begin(&pair.client);
+  bool received_ping = false;
+  for (int frame_count = 0; frame_count < 8 && !received_ping; ++frame_count) {
+    pollfd descriptor = {pair.server.connfd, POLLIN, 0};
+    require(poll(&descriptor, 1, 1000) > 0,
+            "response wait did not emit an HTTP/2 frame");
+    std::array<unsigned char, 9> header = {};
+    require(raw_read_exact(pair.server.connfd, header.data(), header.size()),
+            "heartbeat frame header read failed");
+    size_t payload_size = (static_cast<size_t>(header[0]) << 16) |
+                          (static_cast<size_t>(header[1]) << 8) | header[2];
+    std::vector<unsigned char> payload(payload_size);
+    require(raw_read_exact(pair.server.connfd, payload.data(), payload.size()),
+            "heartbeat frame payload read failed");
+    received_ping =
+        header[3] == NGHTTP2_PING && (header[4] & NGHTTP2_FLAG_ACK) == 0;
+  }
+  rpc_http2_response_wait_end(&pair.client);
+  require(received_ping, "response wait did not emit an HTTP/2 PING heartbeat");
 }
 
 void test_client_to_server() {
@@ -924,6 +950,7 @@ int main() {
   test_rpc_write_queue_grows();
   test_rpc_write_copy_owns_buffer();
   test_rpc_lz4_payload_round_trip();
+  test_response_wait_sends_transport_heartbeat();
   test_client_to_server();
   test_server_receives_session_id();
   test_server_to_client_after_request_headers();

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -10,8 +10,8 @@
 #include <cstring>
 #include <fcntl.h>
 #include <iostream>
-#include <nghttp2/nghttp2.h>
 #include <netinet/in.h>
+#include <nghttp2/nghttp2.h>
 #include <poll.h>
 #include <string>
 #include <sys/mman.h>

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -61,6 +61,7 @@ h2_pair make_pair() {
   h2_pair pair;
   init_pair_sockets(&pair);
   require(rpc_http2_client_init(&pair.client) == 0, "client h2 init failed");
+  rpc_http2_client_start_heartbeat(&pair.client);
   require(rpc_http2_server_init(&pair.server) == 0, "server h2 init failed");
   return pair;
 }

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -17,13 +17,13 @@
 #include <cstdio>
 #include <cstdlib>
 #include <io.h>
+#include <mstcpip.h>
+#include <mswsock.h>
 #include <mutex>
 #include <thread>
 #include <vector>
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <mswsock.h>
-#include <mstcpip.h>
 
 using ssize_t = SSIZE_T;
 using socklen_t = int;

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -16,13 +16,15 @@
 #include <cstdio>
 #include <cstdlib>
 #include <io.h>
-#include <mstcpip.h>
-#include <mswsock.h>
 #include <mutex>
 #include <thread>
 #include <vector>
+// clang-format off: Windows extension headers require winsock2.h first.
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <mswsock.h>
+#include <mstcpip.h>
+// clang-format on
 
 using ssize_t = SSIZE_T;
 using socklen_t = int;

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -11,7 +11,6 @@
 
 #include <BaseTsd.h>
 #include <algorithm>
-#include <chrono>
 #include <climits>
 #include <condition_variable>
 #include <cstdio>
@@ -77,15 +76,6 @@ inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
 inline int pthread_cond_broadcast(pthread_cond_t *cond) {
   cond->cond.notify_all();
   return 0;
-}
-
-inline int lupine_cond_wait_for(pthread_cond_t *cond, pthread_mutex_t *mutex,
-                                int milliseconds) {
-  std::unique_lock<std::mutex> lock(mutex->mutex, std::adopt_lock);
-  std::cv_status status =
-      cond->cond.wait_for(lock, std::chrono::milliseconds(milliseconds));
-  lock.release();
-  return status == std::cv_status::timeout ? 1 : 0;
 }
 
 inline int pthread_create(pthread_t *thread, void *, void *(*start)(void *),
@@ -180,7 +170,6 @@ inline int lupine_fd_truncate(int fd, long length) {
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
-#include <time.h>
 #include <unistd.h>
 
 using lupine_socket_t = int;
@@ -191,16 +180,6 @@ using lupine_socket_t = int;
 inline int lupine_socket_init() { return 0; }
 inline bool lupine_socket_error_is_intr() { return errno == EINTR; }
 
-inline int lupine_cond_wait_for(pthread_cond_t *cond, pthread_mutex_t *mutex,
-                                int milliseconds) {
-  timespec deadline = {};
-  clock_gettime(CLOCK_REALTIME, &deadline);
-  deadline.tv_nsec += static_cast<long>(milliseconds) * 1000 * 1000;
-  deadline.tv_sec += deadline.tv_nsec / (1000 * 1000 * 1000);
-  deadline.tv_nsec %= 1000 * 1000 * 1000;
-  int result = pthread_cond_timedwait(cond, mutex, &deadline);
-  return result == 0 ? 0 : result == ETIMEDOUT ? 1 : -1;
-}
 inline int lupine_socket_close(lupine_socket_t socket) { return close(socket); }
 inline int lupine_socket_set_reuseaddr(lupine_socket_t socket) {
   const int enable = 1;

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -11,6 +11,7 @@
 
 #include <BaseTsd.h>
 #include <algorithm>
+#include <chrono>
 #include <climits>
 #include <condition_variable>
 #include <cstdio>
@@ -76,6 +77,15 @@ inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
 inline int pthread_cond_broadcast(pthread_cond_t *cond) {
   cond->cond.notify_all();
   return 0;
+}
+
+inline int lupine_cond_wait_for(pthread_cond_t *cond, pthread_mutex_t *mutex,
+                                int milliseconds) {
+  std::unique_lock<std::mutex> lock(mutex->mutex, std::adopt_lock);
+  std::cv_status status =
+      cond->cond.wait_for(lock, std::chrono::milliseconds(milliseconds));
+  lock.release();
+  return status == std::cv_status::timeout ? 1 : 0;
 }
 
 inline int pthread_create(pthread_t *thread, void *, void *(*start)(void *),
@@ -170,6 +180,7 @@ inline int lupine_fd_truncate(int fd, long length) {
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
+#include <time.h>
 #include <unistd.h>
 
 using lupine_socket_t = int;
@@ -179,6 +190,17 @@ using lupine_socket_t = int;
 
 inline int lupine_socket_init() { return 0; }
 inline bool lupine_socket_error_is_intr() { return errno == EINTR; }
+
+inline int lupine_cond_wait_for(pthread_cond_t *cond, pthread_mutex_t *mutex,
+                                int milliseconds) {
+  timespec deadline = {};
+  clock_gettime(CLOCK_REALTIME, &deadline);
+  deadline.tv_nsec += static_cast<long>(milliseconds) * 1000 * 1000;
+  deadline.tv_sec += deadline.tv_nsec / (1000 * 1000 * 1000);
+  deadline.tv_nsec %= 1000 * 1000 * 1000;
+  int result = pthread_cond_timedwait(cond, mutex, &deadline);
+  return result == 0 ? 0 : result == ETIMEDOUT ? 1 : -1;
+}
 inline int lupine_socket_close(lupine_socket_t socket) { return close(socket); }
 inline int lupine_socket_set_reuseaddr(lupine_socket_t socket) {
   const int enable = 1;

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -225,6 +225,7 @@ int open_connection() {
           freeaddrinfo(res);
           continue;
         }
+        rpc_http2_client_start_heartbeat(c);
         conn_labels.push_back(server_label);
         ++nconns;
         freeaddrinfo(res);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -461,19 +461,21 @@ static uint64_t lupine_rpc_stats_now_ns() {
 // request and then waits for the corresponding response. this pattern is
 // so common that having this function keeps the codegen much cleaner.
 int rpc_wait_for_response(conn_t *conn) {
-  if (lupine_rpc_stats_path() != nullptr) {
-    int op = conn->write_op;
-    uint64_t start = lupine_rpc_stats_now_ns();
-    int write_id = rpc_write_end(conn);
-    if (write_id < 0 || rpc_read_start(conn, write_id) < 0) {
-      return -1;
-    }
-    lupine_rpc_stats_record(op, 0, lupine_rpc_stats_now_ns() - start);
-    return 0;
-  }
+  int op = conn->write_op;
+  uint64_t start =
+      lupine_rpc_stats_path() != nullptr ? lupine_rpc_stats_now_ns() : 0;
   int write_id = rpc_write_end(conn);
-  if (write_id < 0 || rpc_read_start(conn, write_id) < 0) {
+  if (write_id < 0) {
     return -1;
+  }
+  rpc_http2_response_wait_begin(conn);
+  int result = rpc_read_start(conn, write_id);
+  rpc_http2_response_wait_end(conn);
+  if (result < 0) {
+    return -1;
+  }
+  if (lupine_rpc_stats_path() != nullptr) {
+    lupine_rpc_stats_record(op, 0, lupine_rpc_stats_now_ns() - start);
   }
   return 0;
 }

--- a/rpc.h
+++ b/rpc.h
@@ -200,6 +200,12 @@ extern int rpc_http2_compress_lz4(conn_t *conn);
 extern const char *rpc_http2_session_id(conn_t *conn);
 extern int rpc_http2_get_read_stats(conn_t *conn, rpc_http2_read_stats *stats);
 
+// Keeps the client-to-server TCP path active while a synchronous RPC waits for
+// its response. The heartbeat is transport-only: it emits HTTP/2 PING frames
+// and does not add, combine, or otherwise change CUDA RPCs.
+extern void rpc_http2_response_wait_begin(conn_t *conn);
+extern void rpc_http2_response_wait_end(conn_t *conn);
+
 // Server-side flow control for payloads that outlive the read that received
 // them. Between hold_begin and hold_end the transport stops crediting received
 // DATA bytes back to the peer; hold_end returns the byte count the caller now

--- a/rpc.h
+++ b/rpc.h
@@ -186,6 +186,7 @@ extern int rpc_http2_read(conn_t *conn, void *data, size_t size);
 extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
                             int entry_count);
 extern int rpc_http2_client_init(conn_t *conn);
+extern void rpc_http2_client_start_heartbeat(conn_t *conn);
 // Sends HEAD / and returns the x-lupine-cuda-version response header, or
 // nullptr when the request fails or the server does not advertise a version.
 // The returned pointer remains valid until rpc_http2_destroy() or


### PR DESCRIPTION
## What changed

- bracket synchronous response waits with a client-side HTTP/2 heartbeat
- lazily start one heartbeat thread per HTTP/2 transport
- emit a transport-only PING after 100 ms and every 100 ms while at least one response remains outstanding
- serialize PING submission through the existing nghttp2 session mutex and join the thread during transport teardown
- add a focused wire-level test that verifies a response wait emits an HTTP/2 PING

The heartbeat does not add, combine, delay, or change CUDA RPCs. Fire-and-forget calls still flush immediately. A PING failure is best-effort and cannot replace the result of the in-flight CUDA call.

## Why

The GPT benchmark sends a large burst of asynchronous launch traffic, waits for GPU completion, and then sends the next burst. On Linux, `tcp_slow_start_after_idle=1` can collapse the client congestion window after one retransmission timeout of inactivity. That makes the next launch burst ramp from a small congestion window on a high-RTT link.

A small transport frame during the synchronous GPU wait keeps the client-to-server TCP path active without changing CUDA semantics.

## Performance

RTX 4090, GPT 709M (12 layers, 2048 embedding, 32 heads, context 1024), batch 5, 10 warmup iterations and 5 timed iterations. The 300 ms delay was applied only to the client container's egress qdisc; the host qdisc was untouched. Three untimed synchronizations followed the qdisc change so the TCP RTT/RTO estimate could converge. Netem reported zero drops in every sample.

| Added RTT | Current main | Heartbeat | Change |
| --- | ---: | ---: | ---: |
| 0 ms | 3.992 it/s | 3.991 it/s | -0.03% |
| 300 ms, median of 3 | 1.551 it/s | 2.969 it/s | +91.4% |

Raw 300 ms samples:

- current main: 1.551, 0.921, 1.574 it/s
- heartbeat: 2.756, 3.002, 2.969 it/s

The baseline variance is consistent with the congestion-window sensitivity observed during the abrupt in-container qdisc transition; the heartbeat samples remain tightly grouped.

## Validation

- CUDA 13.1 Release build
- CTest: 10/10 passed, with the two environment-dependent signal tests skipped
- `h2_test`: 12 additional runs across four parallel workers
- paired zero-RTT and container-only 300 ms GPU benchmarks
