### PR TITLE
Support vLLM 0.25.1 with CUDA 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ else()
     )
     add_test(
         NAME nvml_ecc_exports
-        COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter"
+        COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetCudaComputeCapability"
     )
     set_source_files_properties(
         ${SERVER_SOURCES}

--- a/client.cpp
+++ b/client.cpp
@@ -3184,7 +3184,33 @@ extern "C" CUresult cuProfilerStop(void) {
 }
 
 CUresult cuStreamDestroy_v2(CUstream hStream);
-CUresult cuEventDestroy_v2(CUevent hEvent);
+extern "C" CUresult cuEventDestroy_v2(CUevent hEvent) {
+  std::unique_lock<std::shared_mutex> event_lifecycle_lock(
+      lupine_event_lifecycle_mutex());
+  lupine_route route = lupine_route_for_event(hEvent);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  using real_fn_t = CUresult (*)(CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuEventDestroy_v2", &result, hEvent)) {
+    if (result == CUDA_SUCCESS) {
+      lupine_forget_event_owner(hEvent);
+    }
+    return result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (result == CUDA_SUCCESS) {
+    lupine_forget_event_owner(hEvent);
+  }
+  return result;
+}
 CUresult cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart,
                                CUevent hEnd);
 CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags);
@@ -4207,6 +4233,8 @@ extern "C" CUresult cuEventQuery(CUevent hEvent) {
   if (conn == nullptr) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
+  std::shared_lock<std::shared_mutex> event_lifecycle_lock(
+      lupine_event_lifecycle_mutex());
   uint64_t recorded = 0;
   if (!lupine_event_query_needed(hEvent, &recorded)) {
     return lupine_sync_mapped_device_to_host();
@@ -8470,6 +8498,75 @@ conn_t *rpc_client_get_connection(unsigned int index) {
 
 int rpc_size() { return nconns; }
 
+#if CUDA_VERSION >= 12000
+extern "C" CUresult cuTensorMapEncodeTiled(
+    CUtensorMap *tensorMap, CUtensorMapDataType tensorDataType,
+    cuuint32_t tensorRank, void *globalAddress, const cuuint64_t *globalDim,
+    const cuuint64_t *globalStrides, const cuuint32_t *boxDim,
+    const cuuint32_t *elementStrides, CUtensorMapInterleave interleave,
+    CUtensorMapSwizzle swizzle, CUtensorMapL2promotion l2Promotion,
+    CUtensorMapFloatOOBfill oobFill) {
+  if (tensorMap == nullptr || tensorRank == 0 || tensorRank > 5 ||
+      globalAddress == nullptr || globalDim == nullptr || boxDim == nullptr ||
+      elementStrides == nullptr ||
+      (tensorRank > 1 && globalStrides == nullptr)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  CUdeviceptr address_rpc = reinterpret_cast<CUdeviceptr>(globalAddress);
+  const bool managed_alias =
+      lupine_translate_managed_host_ptr(address_rpc, &address_rpc);
+  if (managed_alias) {
+    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
+    if (flush_result != CUDA_SUCCESS) {
+      return flush_result;
+    }
+  }
+
+  lupine_route route = lupine_route_for_deviceptr(address_rpc);
+  using real_fn_t = CUresult (*)(
+      CUtensorMap *, CUtensorMapDataType, cuuint32_t, void *,
+      const cuuint64_t *, const cuuint64_t *, const cuuint32_t *,
+      const cuuint32_t *, CUtensorMapInterleave, CUtensorMapSwizzle,
+      CUtensorMapL2promotion, CUtensorMapFloatOOBfill);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTensorMapEncodeTiled", &result, tensorMap, tensorDataType,
+          tensorRank, globalAddress, globalDim, globalStrides, boxDim,
+          elementStrides, interleave, swizzle, l2Promotion, oobFill)) {
+    return result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  void *remote_address =
+      reinterpret_cast<void *>(static_cast<uintptr_t>(address_rpc));
+  const size_t rank_bytes_u64 = tensorRank * sizeof(cuuint64_t);
+  const size_t stride_bytes = (tensorRank - 1) * sizeof(cuuint64_t);
+  const size_t rank_bytes_u32 = tensorRank * sizeof(cuuint32_t);
+
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuTensorMapEncodeTiled) < 0 ||
+      rpc_write(conn, &tensorDataType, sizeof(tensorDataType)) < 0 ||
+      rpc_write(conn, &tensorRank, sizeof(tensorRank)) < 0 ||
+      rpc_write(conn, &remote_address, sizeof(remote_address)) < 0 ||
+      rpc_write(conn, globalDim, rank_bytes_u64) < 0 ||
+      (stride_bytes != 0 &&
+       rpc_write(conn, globalStrides, stride_bytes) < 0) ||
+      rpc_write(conn, boxDim, rank_bytes_u32) < 0 ||
+      rpc_write(conn, elementStrides, rank_bytes_u32) < 0 ||
+      rpc_write(conn, &interleave, sizeof(interleave)) < 0 ||
+      rpc_write(conn, &swizzle, sizeof(swizzle)) < 0 ||
+      rpc_write(conn, &l2Promotion, sizeof(l2Promotion)) < 0 ||
+      rpc_write(conn, &oobFill, sizeof(oobFill)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, tensorMap, sizeof(*tensorMap)) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return result;
+}
+#endif
+
 #ifdef cuGetProcAddress
 #undef cuGetProcAddress
 #endif
@@ -8738,6 +8835,7 @@ lupine_manual_function_map() {
       {"cuProfilerStop", (void *)cuProfilerStop},
       {"cuStreamDestroy", (void *)cuStreamDestroy},
       {"cuEventDestroy", (void *)cuEventDestroy},
+      {"cuEventDestroy_v2", (void *)cuEventDestroy_v2},
       {"cuEventElapsedTime", (void *)cuEventElapsedTime},
       {"cuMemPoolSetAttribute", (void *)cuMemPoolSetAttribute},
       {"cuMemPoolGetAttribute", (void *)cuMemPoolGetAttribute},
@@ -8775,6 +8873,8 @@ lupine_manual_function_map() {
       {"cuDevicePrimaryCtxReset_v2", (void *)cuDevicePrimaryCtxReset_v2},
       {"cuMemcpyHtoD", (void *)cuMemcpyHtoD_v2},
       {"cuMemcpyHtoD_v2", (void *)cuMemcpyHtoD_v2},
+      {"cuMemcpy", (void *)cuMemcpy},
+      {"cuMemcpy_ptds", (void *)cuMemcpy},
       {"cuMemcpyDtoH", (void *)cuMemcpyDtoH_v2},
       {"cuMemcpyDtoH_v2", (void *)cuMemcpyDtoH_v2},
       {"cuMemcpyDtoA", (void *)cuMemcpyDtoA_v2},
@@ -8901,6 +9001,9 @@ lupine_manual_function_map() {
        (void *)cuStreamUpdateCaptureDependencies_v2},
       {"cuStreamUpdateCaptureDependencies_ptsz",
        (void *)cuStreamUpdateCaptureDependencies_ptsz},
+#if CUDA_VERSION >= 12000
+      {"cuTensorMapEncodeTiled", (void *)cuTensorMapEncodeTiled},
+#endif
   };
   return manual_function_map;
 }

--- a/client_routing.h
+++ b/client_routing.h
@@ -113,6 +113,7 @@ extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size,
 extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);
 extern "C" void lupine_forget_context_owner(CUcontext ctx);
 extern "C" void lupine_forget_stream_owner(CUstream stream);
+extern "C" void lupine_forget_event_owner(CUevent event);
 
 extern "C" void lupine_note_context_owner_route(CUcontext ctx,
                                                 lupine_route route);

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2694,6 +2694,7 @@ CUresult cuMemHostRegister_v2(void *p, size_t bytesize, unsigned int Flags);
  */
 CUresult cuMemHostUnregister(void *p);
 /**
+ * @disabled client
  * @routingkey DEVICEPTR dst
  * @crossservercopy dst src ByteCount
  * @param dst SEND_ONLY
@@ -3563,6 +3564,7 @@ CUresult cuEventQuery(CUevent hEvent);
  */
 CUresult cuEventSynchronize(CUevent hEvent);
 /**
+ * @disabled client
  * @routingkey EVENT hEvent
  * @param hEvent SEND_ONLY
  */
@@ -4736,10 +4738,11 @@ CUresult cuSurfObjectDestroy(CUsurfObject surfObject);
 CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
                                      CUsurfObject surfObject);
 /**
+ * @disabled both
  * @param tensorMap SEND_RECV
  * @param tensorDataType SEND_ONLY
  * @param tensorRank SEND_ONLY
- * @param globalAddress SEND_RECV
+ * @param globalAddress SEND_ONLY
  * @param globalDim SEND_RECV
  * @param globalStrides SEND_RECV
  * @param boxDim SEND_RECV

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -169,6 +169,7 @@ NVML_RPC_FUNCTIONS = [
     "nvmlDeviceIsMigDeviceHandle",
     "nvmlDeviceGetNvLinkRemoteDeviceType",
     "nvmlDeviceGetNvLinkRemotePciInfo_v2",
+    "nvmlDeviceGetCudaComputeCapability",
 ]
 
 NVML_MANUAL_SERVER_FUNCTIONS = {

--- a/codegen/gen_api.h
+++ b/codegen/gen_api.h
@@ -342,6 +342,7 @@
 #define RPC_cuSurfObjectCreate 1855246974
 #define RPC_cuSurfObjectDestroy 1635365862
 #define RPC_cuSurfObjectGetResourceDesc 1009289841
+#define RPC_cuTensorMapEncodeTiled 1386204641
 #define RPC_cuDeviceCanAccessPeer 1419231701
 #define RPC_cuCtxEnablePeerAccess 1737933368
 #define RPC_cuCtxDisablePeerAccess 1900602041
@@ -380,7 +381,6 @@
 #define RPC_cuStreamGetCaptureInfo_v2 501626002
 #define RPC_cuStreamUpdateCaptureDependencies_v2 434730116
 #define RPC_cuTensorMapEncodeIm2col 1203430832
-#define RPC_cuTensorMapEncodeTiled 1386204641
 #define RPC_cuTensorMapReplaceAddress 1209139891
 #define RPC_cuUserObjectCreate 1748907400
 #define RPC_nvmlInit_v2 2103095296
@@ -445,6 +445,7 @@
 #define RPC_nvmlDeviceIsMigDeviceHandle 1693389219
 #define RPC_nvmlDeviceGetNvLinkRemoteDeviceType 65527014
 #define RPC_nvmlDeviceGetNvLinkRemotePciInfo_v2 1998574024
+#define RPC_nvmlDeviceGetCudaComputeCapability 1264755594
 
 #define LUPINE_RPC_cuGetExportTableMetadata 565915314
 #define LUPINE_RPC_cuGraphAddNode_v2 1958016248

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -1347,29 +1347,6 @@ CUresult cuIpcCloseMemHandle(CUdeviceptr dptr) {
   return return_value;
 }
 
-CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount) {
-  lupine_route route = lupine_route_for_deviceptr(dst);
-  if (!lupine_deviceptrs_share_route(dst, src)) {
-    return lupine_cuMemcpyDtoD_via_client(dst, src, ByteCount, nullptr, false);
-  }
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemcpy", &return_value, dst, src, ByteCount)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
-      rpc_write(conn, &dst, sizeof(CUdeviceptr)) < 0 ||
-      rpc_write(conn, &src, sizeof(CUdeviceptr)) < 0 ||
-      rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
                       CUdeviceptr srcDevice, CUcontext srcContext,
                       size_t ByteCount) {
@@ -3151,25 +3128,6 @@ CUresult cuEventSynchronize(CUevent hEvent) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (return_value == CUDA_SUCCESS)
     return_value = lupine_sync_mapped_device_to_host();
-  return return_value;
-}
-
-CUresult cuEventDestroy_v2(CUevent hEvent) {
-  lupine_route route = lupine_route_for_event(hEvent);
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUevent);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventDestroy_v2",
-                                                  &return_value, hEvent)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
   return return_value;
 }
 
@@ -6791,14 +6749,6 @@ extern "C" CUresult cuGraphExecUpdate(CUgraphExec hGraphExec, CUgraph hGraph,
 
 #endif
 
-#ifdef cuMemcpy_ptds
-#undef cuMemcpy_ptds
-#endif
-extern "C" CUresult cuMemcpy_ptds(CUdeviceptr dst, CUdeviceptr src,
-                                  size_t ByteCount) {
-  return cuMemcpy(dst, src, ByteCount);
-}
-
 #ifdef cuMemcpyPeer_ptds
 #undef cuMemcpyPeer_ptds
 #endif
@@ -7402,7 +7352,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemsetD2D32", (void *)cuMemsetD2D32_v2},
     {"cuIpcOpenMemHandle", (void *)cuIpcOpenMemHandle_v2},
     {"cuGraphExecUpdate", (void *)cuGraphExecUpdate_v2},
-    {"cuMemcpy_ptds", (void *)cuMemcpy},
     {"cuMemcpyPeer_ptds", (void *)cuMemcpyPeer},
     {"cuMemcpyPeerAsync_ptsz", (void *)cuMemcpyPeerAsync},
     {"cuMemsetD8Async_ptsz", (void *)cuMemsetD8Async},

--- a/codegen/gen_nvml_client.inc
+++ b/codegen/gen_nvml_client.inc
@@ -1202,3 +1202,32 @@ nvmlDeviceGetNvLinkRemotePciInfo_v2(nvmlDevice_t device, unsigned int link,
   return lupine_rpc_nvmlDeviceGetNvLinkRemotePciInfo_v2(conn, device, link,
                                                         pci);
 }
+
+static nvmlReturn_t
+lupine_rpc_nvmlDeviceGetCudaComputeCapability(conn_t *conn, nvmlDevice_t device,
+                                              int *major, int *minor) {
+  nvmlReturn_t return_value = rpc_error();
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_nvmlDeviceGetCudaComputeCapability) <
+          0 ||
+      rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, major, sizeof(int)) < 0 ||
+      rpc_read(conn, minor, sizeof(int)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return rpc_error();
+  }
+  return return_value;
+}
+
+extern "C" nvmlReturn_t nvmlDeviceGetCudaComputeCapability(nvmlDevice_t device,
+                                                           int *major,
+                                                           int *minor) {
+  if (major == nullptr || minor == nullptr) {
+    return NVML_ERROR_INVALID_ARGUMENT;
+  }
+  conn_t *conn = connection_for_device(&device);
+  return lupine_rpc_nvmlDeviceGetCudaComputeCapability(conn, device, major,
+                                                       minor);
+}

--- a/codegen/gen_nvml_server.h
+++ b/codegen/gen_nvml_server.h
@@ -56,3 +56,4 @@ int handle_nvmlDeviceGetVirtualizationMode(conn_t *conn);
 int handle_nvmlDeviceIsMigDeviceHandle(conn_t *conn);
 int handle_nvmlDeviceGetNvLinkRemoteDeviceType(conn_t *conn);
 int handle_nvmlDeviceGetNvLinkRemotePciInfo_v2(conn_t *conn);
+int handle_nvmlDeviceGetCudaComputeCapability(conn_t *conn);

--- a/codegen/gen_nvml_server.inc
+++ b/codegen/gen_nvml_server.inc
@@ -1700,3 +1700,35 @@ int handle_nvmlDeviceGetNvLinkRemotePciInfo_v2(conn_t *conn) {
 ERROR_0:
   return -1;
 }
+
+int handle_nvmlDeviceGetCudaComputeCapability(conn_t *conn) {
+  nvmlDevice_t device;
+  int major;
+  major = {};
+  int minor;
+  minor = {};
+  int request_id;
+  nvmlReturn_t return_value;
+  using fn_t = nvmlReturn_t (*)(nvmlDevice_t, int *, int *);
+  fn_t fn = nullptr;
+  if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+
+  fn = nvml_symbol<fn_t>("nvmlDeviceGetCudaComputeCapability");
+  return_value =
+      fn == nullptr ? function_not_found() : fn(device, &major, &minor);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &major, sizeof(int)) < 0 ||
+      rpc_write(conn, &minor, sizeof(int)) < 0 ||
+      rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+  return 0;
+ERROR_0:
+  return -1;
+}

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -8812,6 +8812,8 @@ static const std::unordered_map<int, RequestHandler> opHandlers = {
      handle_nvmlDeviceGetNvLinkRemoteDeviceType},
     {RPC_nvmlDeviceGetNvLinkRemotePciInfo_v2,
      handle_nvmlDeviceGetNvLinkRemotePciInfo_v2},
+    {RPC_nvmlDeviceGetCudaComputeCapability,
+     handle_nvmlDeviceGetCudaComputeCapability},
 };
 
 RequestHandler get_handler(const int op) {

--- a/events.cpp
+++ b/events.cpp
@@ -19,6 +19,15 @@ void lupine_event_note_recorded(lupine_event_table *table, CUevent event) {
   *victim = {event, seq, 0};
 }
 
+void lupine_event_note_destroyed(lupine_event_table *table, CUevent event) {
+  std::lock_guard<std::mutex> lock(table->mutex);
+  for (auto &slot : table->slots) {
+    if (slot.event == event) {
+      slot = {};
+    }
+  }
+}
+
 bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
                                uint64_t *recorded) {
   bool copies_pending = table->dtoh_issued.load(std::memory_order_relaxed) !=
@@ -94,8 +103,17 @@ static lupine_event_table &lupine_event_table_instance() {
   return table;
 }
 
+std::shared_mutex &lupine_event_lifecycle_mutex() {
+  static std::shared_mutex mutex;
+  return mutex;
+}
+
 void lupine_note_event_recorded(CUevent event) {
   lupine_event_note_recorded(&lupine_event_table_instance(), event);
+}
+
+void lupine_note_event_destroyed(CUevent event) {
+  lupine_event_note_destroyed(&lupine_event_table_instance(), event);
 }
 
 bool lupine_event_query_needed(CUevent event, uint64_t *recorded) {

--- a/events.h
+++ b/events.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <cstdint>
 #include <mutex>
+#include <shared_mutex>
 
 #define LUPINE_CUDA_COMPAT_TYPES_ONLY
 #include "cuda_compat.h"
@@ -41,6 +42,7 @@ struct lupine_event_table {
 typedef conn_t *(*lupine_event_conn_resolver)(CUevent event);
 
 void lupine_event_note_recorded(lupine_event_table *table, CUevent event);
+void lupine_event_note_destroyed(lupine_event_table *table, CUevent event);
 bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
                                uint64_t *recorded);
 uint32_t lupine_event_collect_query_prefetch(
@@ -56,6 +58,8 @@ void lupine_event_note_dtoh_drained(lupine_event_table *table,
                                     uint64_t drained);
 
 void lupine_note_event_recorded(CUevent event);
+void lupine_note_event_destroyed(CUevent event);
+std::shared_mutex &lupine_event_lifecycle_mutex();
 bool lupine_event_query_needed(CUevent event, uint64_t *recorded);
 uint32_t lupine_collect_event_query_prefetch(CUevent exclude, conn_t *conn,
                                              CUevent *events,

--- a/events_test.cpp
+++ b/events_test.cpp
@@ -168,6 +168,26 @@ bool test_query_results_cache_only_successes() {
   return true;
 }
 
+bool test_destroyed_event_is_removed_from_prefetch() {
+  lupine_event_table table;
+  CUevent events[kLupineEventQueryBatch];
+  uint64_t recorded[kLupineEventQueryBatch];
+  CUevent primary = fake_event(0);
+  CUevent destroyed = fake_event(1);
+  lupine_event_note_recorded(&table, primary);
+  lupine_event_note_recorded(&table, destroyed);
+  lupine_event_note_destroyed(&table, destroyed);
+
+  uint32_t count = lupine_event_collect_query_prefetch(
+      &table, nullptr, kConnA, resolve_all_to_a, events, recorded);
+  if (count != 1 || events[0] != primary ||
+      batch_contains(events, count, destroyed)) {
+    std::cerr << "FAIL: destroyed event remained in the prefetch batch\n";
+    return false;
+  }
+  return true;
+}
+
 bool test_pending_dtoh_suppresses_local_answer() {
   lupine_event_table table;
   CUevent event = fake_event(0);
@@ -200,6 +220,7 @@ int main() {
       !test_eviction_is_oldest_recorded() ||
       !test_prefetch_batch_excludes_and_filters() ||
       !test_query_results_cache_only_successes() ||
+      !test_destroyed_event_is_removed_from_prefetch() ||
       !test_pending_dtoh_suppresses_local_answer()) {
     return 1;
   }

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3179,20 +3179,29 @@ int handle_manual_lupineEventQueryBatch(conn_t *conn) {
   uint32_t count = 0;
   if (rpc_read(conn, &count, sizeof(count)) < 0 || count == 0 ||
       count > LUPINE_EVENT_QUERY_BATCH_MAX) {
+    LUPINE_LOG_ERROR("cuEventQuery RPC failed while reading count: count="
+                     << count);
     return -1;
   }
   CUevent events[LUPINE_EVENT_QUERY_BATCH_MAX];
   if (rpc_read(conn, events, count * sizeof(events[0])) < 0) {
+    LUPINE_LOG_ERROR("cuEventQuery RPC failed while reading events");
     return -1;
   }
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
+    LUPINE_LOG_ERROR("cuEventQuery RPC failed while finishing request");
     return -1;
   }
 
   CUresult results[LUPINE_EVENT_QUERY_BATCH_MAX];
   for (uint32_t i = 0; i < count; ++i) {
     results[i] = cuEventQuery(events[i]);
+    if (results[i] != CUDA_SUCCESS && results[i] != CUDA_ERROR_NOT_READY) {
+      LUPINE_LOG_ERROR("cuEventQuery failed on the server: result="
+                       << results[i] << " event=" << events[i]
+                       << " batch_index=" << i);
+    }
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -4173,3 +4182,66 @@ int handle_manual_cuGetErrorName(conn_t *conn) {
 int handle_manual_cuGetErrorString(conn_t *conn) {
   return lupine_handle_error_string(conn, cuGetErrorString);
 }
+
+#if CUDA_VERSION >= 12000
+int handle_manual_cuTensorMapEncodeTiled(conn_t *conn) {
+  CUtensorMapDataType tensor_data_type;
+  cuuint32_t tensor_rank = 0;
+  void *global_address = nullptr;
+  std::array<cuuint64_t, 5> global_dim{};
+  std::array<cuuint64_t, 4> global_strides{};
+  std::array<cuuint32_t, 5> box_dim{};
+  std::array<cuuint32_t, 5> element_strides{};
+
+  if (rpc_read(conn, &tensor_data_type, sizeof(tensor_data_type)) < 0 ||
+      rpc_read(conn, &tensor_rank, sizeof(tensor_rank)) < 0 ||
+      rpc_read(conn, &global_address, sizeof(global_address)) < 0) {
+    return -1;
+  }
+
+  if (tensor_rank == 0 || tensor_rank > global_dim.size()) {
+    return -1;
+  }
+
+  const size_t rank_bytes_u64 = tensor_rank * sizeof(cuuint64_t);
+  const size_t stride_bytes = (tensor_rank - 1) * sizeof(cuuint64_t);
+  const size_t rank_bytes_u32 = tensor_rank * sizeof(cuuint32_t);
+  if (rpc_read(conn, global_dim.data(), rank_bytes_u64) < 0 ||
+      (stride_bytes != 0 &&
+       rpc_read(conn, global_strides.data(), stride_bytes) < 0) ||
+      rpc_read(conn, box_dim.data(), rank_bytes_u32) < 0 ||
+      rpc_read(conn, element_strides.data(), rank_bytes_u32) < 0) {
+    return -1;
+  }
+
+  CUtensorMapInterleave interleave;
+  CUtensorMapSwizzle swizzle;
+  CUtensorMapL2promotion l2_promotion;
+  CUtensorMapFloatOOBfill oob_fill;
+  if (rpc_read(conn, &interleave, sizeof(interleave)) < 0 ||
+      rpc_read(conn, &swizzle, sizeof(swizzle)) < 0 ||
+      rpc_read(conn, &l2_promotion, sizeof(l2_promotion)) < 0 ||
+      rpc_read(conn, &oob_fill, sizeof(oob_fill)) < 0) {
+    return -1;
+  }
+
+  const int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  CUtensorMap tensor_map{};
+  CUresult result = cuTensorMapEncodeTiled(
+      &tensor_map, tensor_data_type, tensor_rank, global_address,
+      global_dim.data(),
+      stride_bytes == 0 ? nullptr : global_strides.data(), box_dim.data(),
+      element_strides.data(), interleave, swizzle, l2_promotion, oob_fill);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &tensor_map, sizeof(tensor_map)) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+#endif

--- a/manual_server.h
+++ b/manual_server.h
@@ -89,5 +89,8 @@ int handle_manual_cuGraphLaunch(conn_t *conn);
 int handle_manual_cuEventSynchronize(conn_t *conn);
 int handle_manual_cuOccupancyMaxPotentialBlockSize(conn_t *conn,
                                                    bool with_flags);
+#if CUDA_VERSION >= 12000
+int handle_manual_cuTensorMapEncodeTiled(conn_t *conn);
+#endif
 
 #endif

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -26,8 +26,14 @@ static void lupine_pointer_attribute_cache_clear();
 #include "rpc.h"
 
 extern int rpc_size();
+CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
+                         size_t ByteCount);
 CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
                          size_t ByteCount);
+extern "C" CUresult
+lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                               size_t ByteCount, CUstream stream,
+                               bool async_copy);
 
 #ifdef CU_MEM_LOCATION_TYPE_HOST
 static constexpr CUmemLocationType LUPINE_CU_MEM_LOCATION_TYPE_HOST =
@@ -806,6 +812,33 @@ extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
   return true;
 }
 
+static bool
+lupine_translate_client_host_ptr_to_server(CUdeviceptr ptr,
+                                            CUdeviceptr *translated,
+                                            CUdeviceptr *server_base = nullptr,
+                                            CUdeviceptr *device_base = nullptr) {
+  void *host = reinterpret_cast<void *>(ptr);
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(host);
+  if (it == lupine_mutable_host_allocations_locked().end() ||
+      it->second.server_host_ptr == 0 || it->second.local_cuda) {
+    return false;
+  }
+
+  uintptr_t client_base = reinterpret_cast<uintptr_t>(it->first);
+  uintptr_t client_addr = reinterpret_cast<uintptr_t>(host);
+  if (translated != nullptr) {
+    *translated = it->second.server_host_ptr + (client_addr - client_base);
+  }
+  if (server_base != nullptr) {
+    *server_base = it->second.server_host_ptr;
+  }
+  if (device_base != nullptr) {
+    *device_base = it->second.device_ptr;
+  }
+  return true;
+}
+
 static bool lupine_host_ptr_is_tracked(CUdeviceptr ptr) {
   void *host = reinterpret_cast<void *>(ptr);
   std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
@@ -833,6 +866,85 @@ static void lupine_mark_mapped_device_dirty(void *host) {
       !it->second.client_to_server_only) {
     it->second.device_dirty = true;
   }
+}
+
+static bool lupine_is_client_host_address(CUdeviceptr ptr) {
+  if (ptr == 0) {
+    return false;
+  }
+  long page_size = sysconf(_SC_PAGESIZE);
+  if (page_size <= 0) {
+    return false;
+  }
+  uintptr_t page = static_cast<uintptr_t>(ptr) &
+                   ~(static_cast<uintptr_t>(page_size) - 1);
+  unsigned char residency = 0;
+  return mincore(reinterpret_cast<void *>(page), page_size, &residency) == 0;
+}
+
+extern "C" CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src,
+                             size_t ByteCount) {
+  if (ByteCount == 0) {
+    return CUDA_SUCCESS;
+  }
+
+  CUdeviceptr dst_rpc = dst;
+  CUdeviceptr src_rpc = src;
+  bool dst_host_alias =
+      lupine_translate_client_host_ptr_to_server(dst, &dst_rpc);
+  bool src_host_alias =
+      lupine_translate_client_host_ptr_to_server(src, &src_rpc);
+  bool dst_device = lupine_deviceptr_is_tracked(dst_rpc);
+  bool src_device = lupine_deviceptr_is_tracked(src_rpc);
+  bool dst_is_host =
+      dst_host_alias || (!dst_device && lupine_is_client_host_address(dst));
+  bool src_is_host =
+      src_host_alias || (!src_device && lupine_is_client_host_address(src));
+
+  if (dst_is_host && src_is_host) {
+    memmove(reinterpret_cast<void *>(dst), reinterpret_cast<const void *>(src),
+            ByteCount);
+    return CUDA_SUCCESS;
+  }
+  if (src_is_host) {
+    return cuMemcpyHtoD_v2(dst_rpc, reinterpret_cast<const void *>(src),
+                           ByteCount);
+  }
+  if (dst_is_host) {
+    return cuMemcpyDtoH_v2(reinterpret_cast<void *>(dst), src_rpc, ByteCount);
+  }
+
+  lupine_route route = lupine_route_for_deviceptr(dst_rpc);
+  if (!lupine_deviceptrs_share_route(dst_rpc, src_rpc)) {
+    return lupine_cuMemcpyDtoD_via_client(dst_rpc, src_rpc, ByteCount, nullptr,
+                                          false);
+  }
+
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpy", &result, dst, src, ByteCount)) {
+    return result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
+      rpc_write(conn, &dst_rpc, sizeof(dst_rpc)) < 0 ||
+      rpc_write(conn, &src_rpc, sizeof(src_rpc)) < 0 ||
+      rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return result;
+}
+
+#ifdef cuMemcpy_ptds
+#undef cuMemcpy_ptds
+#endif
+extern "C" CUresult cuMemcpy_ptds(CUdeviceptr dst, CUdeviceptr src,
+                                   size_t ByteCount) {
+  return cuMemcpy(dst, src, ByteCount);
 }
 
 CUresult lupine_sync_mapped_host_to_device_for_launch(
@@ -2188,6 +2300,13 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
 
   CUdeviceptr query_ptr = ptr;
   bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  CUdeviceptr remote_host_base = 0;
+  CUdeviceptr remote_device_base = 0;
+  bool remote_host_alias = false;
+  if (!managed_alias) {
+    remote_host_alias = lupine_translate_client_host_ptr_to_server(
+        ptr, &query_ptr, &remote_host_base, &remote_device_base);
+  }
   lupine_route route = lupine_route_for_deviceptr(query_ptr);
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(void *, CUpointer_attribute, CUdeviceptr);
@@ -2209,9 +2328,15 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
   }
   if (return_value == CUDA_SUCCESS) {
     memcpy(data, value, value_size);
-    if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+    if ((managed_alias || remote_host_alias) &&
+        attribute == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
       void *host = reinterpret_cast<void *>(ptr);
       memcpy(data, &host, sizeof(host));
+    } else if (remote_host_alias &&
+               attribute == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
+      CUdeviceptr device_alias =
+          remote_device_base + (query_ptr - remote_host_base);
+      memcpy(data, &device_alias, sizeof(device_alias));
     } else if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
       int is_managed = 1;
       memcpy(data, &is_managed, sizeof(is_managed));
@@ -2231,7 +2356,9 @@ extern "C" CUresult cuPointerSetAttribute(const void *value,
   }
 
   CUdeviceptr target_ptr = ptr;
-  lupine_translate_managed_host_ptr(ptr, &target_ptr);
+  if (!lupine_translate_managed_host_ptr(ptr, &target_ptr)) {
+    lupine_translate_client_host_ptr_to_server(ptr, &target_ptr);
+  }
   lupine_route route = lupine_route_for_deviceptr(target_ptr);
   if (lupine_route_is_local(route)) {
     using real_fn_t =
@@ -2322,6 +2449,13 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
 
   CUdeviceptr query_ptr = ptr;
   bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  CUdeviceptr remote_host_base = 0;
+  CUdeviceptr remote_device_base = 0;
+  bool remote_host_alias = false;
+  if (!managed_alias) {
+    remote_host_alias = lupine_translate_client_host_ptr_to_server(
+        ptr, &query_ptr, &remote_host_base, &remote_device_base);
+  }
   lupine_route route = lupine_route_for_deviceptr(query_ptr);
   if (lupine_route_is_local(route)) {
     using real_fn_t =
@@ -2394,8 +2528,13 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
   // aliases are recomputed for the queried pointer on a hit.
   lupine_pointer_attribute_cache_key cache_key;
   std::vector<std::vector<unsigned char>> cached_values;
-  bool cacheable =
-      managed_alias && lupine_managed_host_alias_base(ptr, &cache_key.ptr);
+  bool cacheable = false;
+  if (managed_alias) {
+    cacheable = lupine_managed_host_alias_base(ptr, &cache_key.ptr);
+  } else if (remote_host_alias) {
+    cache_key.ptr = remote_host_base;
+    cacheable = true;
+  }
   if (cacheable) {
     cache_key.attributes.assign(attributes, attributes + numAttributes);
     if (lupine_pointer_attribute_cache().find(cache_key, cached_values)) {
@@ -2404,12 +2543,20 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
           return CUDA_ERROR_INVALID_VALUE;
         }
         memcpy(data[i], cached_values[i].data(), cached_values[i].size());
-        if (attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+        if ((managed_alias || remote_host_alias) &&
+            attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
           void *host = reinterpret_cast<void *>(ptr);
           memcpy(data[i], &host, sizeof(host));
-        } else if (attributes[i] == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
+        } else if (managed_alias &&
+                   attributes[i] == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
           memcpy(data[i], &query_ptr, sizeof(query_ptr));
-        } else if (attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
+        } else if (remote_host_alias &&
+                   attributes[i] == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
+          CUdeviceptr device_alias =
+              remote_device_base + (query_ptr - remote_host_base);
+          memcpy(data[i], &device_alias, sizeof(device_alias));
+        } else if (managed_alias &&
+                   attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
           int is_managed = 1;
           memcpy(data[i], &is_managed, sizeof(is_managed));
         }
@@ -2457,9 +2604,15 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
         return CUDA_ERROR_INVALID_VALUE;
       }
       memcpy(data[i], values[i].data(), values[i].size());
-      if (managed_alias && attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+      if ((managed_alias || remote_host_alias) &&
+          attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
         void *host = reinterpret_cast<void *>(ptr);
         memcpy(data[i], &host, sizeof(host));
+      } else if (remote_host_alias &&
+                 attributes[i] == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
+        CUdeviceptr device_alias =
+            remote_device_base + (query_ptr - remote_host_base);
+        memcpy(data[i], &device_alias, sizeof(device_alias));
       } else if (managed_alias &&
                  attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
         int is_managed = 1;

--- a/routing.cpp
+++ b/routing.cpp
@@ -11,6 +11,7 @@
 #include "cache.h"
 #include "client_routing.h"
 #include "codegen/gen_api.h"
+#include "events.h"
 
 extern int rpc_open();
 extern int rpc_size();
@@ -615,6 +616,14 @@ extern "C" void lupine_forget_context_owner(CUcontext ctx) {
 extern "C" void lupine_forget_stream_owner(CUstream stream) {
   std::lock_guard<std::mutex> lock(lupine_routing_mutex());
   lupine_owners<CUstream>().erase(stream);
+}
+
+extern "C" void lupine_forget_event_owner(CUevent event) {
+  {
+    std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+    lupine_owners<CUevent>().erase(event);
+  }
+  lupine_note_event_destroyed(event);
 }
 
 template <typename Handle>

--- a/server.cpp
+++ b/server.cpp
@@ -77,6 +77,14 @@ lupine_reap_connection_children(std::unordered_set<pid_t> &children) {
     if (child <= 0) {
       break;
     }
+    if (WIFSIGNALED(status)) {
+      LUPINE_LOG_ERROR("Connection child "
+                       << child << " terminated by signal "
+                       << WTERMSIG(status));
+    } else if (!WIFEXITED(status) || WEXITSTATUS(status) != EXIT_SUCCESS) {
+      LUPINE_LOG_ERROR("Connection child "
+                       << child << " exited abnormally with status " << status);
+    }
     children.erase(child);
   }
   lupine_parent_child_exited = 0;
@@ -293,6 +301,10 @@ lupine_manual_handlers() {
        {handle_manual_cuStreamSynchronize, "cuStreamSynchronize"}},
       {RPC_cuEventSynchronize,
        {handle_manual_cuEventSynchronize, "cuEventSynchronize"}},
+#if CUDA_VERSION >= 12000
+      {RPC_cuTensorMapEncodeTiled,
+       {handle_manual_cuTensorMapEncodeTiled, "cuTensorMapEncodeTiled"}},
+#endif
   };
   return handlers;
 }


### PR DESCRIPTION
## Summary

- add rank-aware RPC support for `cuTensorMapEncodeTiled`
- expose `nvmlDeviceGetCudaComputeCapability` through the NVML shim
- translate process-local pinned-host UVA aliases for pointer attributes and generic `cuMemcpy`
- remove destroyed events from query batches and serialize destruction against in-flight queries

## Validation

- Release CTest: 10/10 passed
- pinned/pageable host UVA and generic copy regression passed
- event destroy/query regression passed
- vLLM 0.25.1 served Qwen3-0.6B and completed an OpenAI-compatible inference request

Fixes #512
