### PR TITLE
Preserve zero-capacity present optional output arrays in graph queries

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -6418,6 +6418,7 @@ extern "C" CUresult cuGraphGetEdges_v2(CUgraph hGraph, CUgraphNode *from,
     return CUDA_ERROR_INVALID_VALUE;
   }
   size_t requested = (from == nullptr || to == nullptr) ? 0 : *numEdges;
+  uint8_t arrays_null = (from == nullptr || to == nullptr) ? 1 : 0;
   uint8_t want_edge = edgeData != nullptr ? 1 : 0;
   lupine_route route = lupine_route_for_graph(hGraph);
   using real_fn_t = CUresult (*)(CUgraph, CUgraphNode *, CUgraphNode *,
@@ -6434,20 +6435,32 @@ extern "C" CUresult cuGraphGetEdges_v2(CUgraph hGraph, CUgraphNode *from,
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
+      rpc_write(conn, &arrays_null, sizeof(arrays_null)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &returned, sizeof(returned)) < 0 ||
-      (from != nullptr && to != nullptr && returned != 0 &&
-       rpc_read(conn, from, returned * sizeof(CUgraphNode)) < 0) ||
-      (from != nullptr && to != nullptr && returned != 0 &&
-       rpc_read(conn, to, returned * sizeof(CUgraphNode)) < 0) ||
+      // The server sends min(returned, requested) elements per non-null
+      // array and none for a count-only query, so the reads must clamp
+      // identically to stay framed.
+      (from != nullptr && to != nullptr && requested != 0 && returned != 0 &&
+       rpc_read(conn, from,
+                (returned < requested ? returned : requested) *
+                    sizeof(CUgraphNode)) < 0) ||
+      (from != nullptr && to != nullptr && requested != 0 && returned != 0 &&
+       rpc_read(conn, to,
+                (returned < requested ? returned : requested) *
+                    sizeof(CUgraphNode)) < 0) ||
       (edgeData != nullptr && from != nullptr && to != nullptr &&
-       returned != 0 &&
-       rpc_read(conn, edgeData, returned * sizeof(CUgraphEdgeData)) < 0) ||
+       requested != 0 && returned != 0 &&
+       rpc_read(conn, edgeData,
+                (returned < requested ? returned : requested) *
+                    sizeof(CUgraphEdgeData)) < 0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  *numEdges = returned;
+  *numEdges = (from == nullptr || to == nullptr)
+                  ? returned
+                  : (returned < requested ? returned : requested);
   return return_value;
 }
 extern "C" CUresult cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from,
@@ -6461,6 +6474,7 @@ extern "C" CUresult cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from,
     return CUDA_ERROR_INVALID_VALUE;
   }
   size_t requested = (from == nullptr || to == nullptr) ? 0 : *numEdges;
+  uint8_t arrays_null = (from == nullptr || to == nullptr) ? 1 : 0;
   uint8_t want_edge = 0;
   lupine_route route = lupine_route_for_graph(hGraph);
   using real_fn_t =
@@ -6477,17 +6491,27 @@ extern "C" CUresult cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from,
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
+      rpc_write(conn, &arrays_null, sizeof(arrays_null)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &returned, sizeof(returned)) < 0 ||
-      (from != nullptr && to != nullptr && returned != 0 &&
-       rpc_read(conn, from, returned * sizeof(CUgraphNode)) < 0) ||
-      (from != nullptr && to != nullptr && returned != 0 &&
-       rpc_read(conn, to, returned * sizeof(CUgraphNode)) < 0) ||
+      // The server sends min(returned, requested) elements per non-null
+      // array and none for a count-only query, so the reads must clamp
+      // identically to stay framed.
+      (from != nullptr && to != nullptr && requested != 0 && returned != 0 &&
+       rpc_read(conn, from,
+                (returned < requested ? returned : requested) *
+                    sizeof(CUgraphNode)) < 0) ||
+      (from != nullptr && to != nullptr && requested != 0 && returned != 0 &&
+       rpc_read(conn, to,
+                (returned < requested ? returned : requested) *
+                    sizeof(CUgraphNode)) < 0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  *numEdges = returned;
+  *numEdges = (from == nullptr || to == nullptr)
+                  ? returned
+                  : (returned < requested ? returned : requested);
   return return_value;
 }
 #endif
@@ -6504,6 +6528,7 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
     return CUDA_ERROR_INVALID_VALUE;
   }
   size_t requested = nodes == nullptr ? 0 : *num;
+  uint8_t nodes_null = nodes == nullptr ? 1 : 0;
   uint8_t want_edge = edgeData != nullptr ? 1 : 0;
   lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
@@ -6532,17 +6557,27 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
+      rpc_write(conn, &nodes_null, sizeof(nodes_null)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &returned, sizeof(returned)) < 0 ||
-      (nodes != nullptr && returned != 0 &&
-       rpc_read(conn, nodes, returned * sizeof(CUgraphNode)) < 0) ||
-      (edgeData != nullptr && nodes != nullptr && returned != 0 &&
-       rpc_read(conn, edgeData, returned * sizeof(CUgraphEdgeData)) < 0) ||
+      // The server sends min(returned, requested) elements per non-null
+      // array and none for a count-only query, so the reads must clamp
+      // identically to stay framed.
+      (nodes != nullptr && requested != 0 && returned != 0 &&
+       rpc_read(conn, nodes,
+                (returned < requested ? returned : requested) *
+                    sizeof(CUgraphNode)) < 0) ||
+      (edgeData != nullptr && nodes != nullptr && requested != 0 &&
+       returned != 0 &&
+       rpc_read(conn, edgeData,
+                (returned < requested ? returned : requested) *
+                    sizeof(CUgraphEdgeData)) < 0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  *num = returned;
+  *num = (nodes == nullptr) ? returned
+                            : (returned < requested ? returned : requested);
   return return_value;
 }
 
@@ -6587,6 +6622,7 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
     return CUDA_ERROR_INVALID_VALUE;
   }
   size_t requested = nodes == nullptr ? 0 : *num;
+  uint8_t nodes_null = nodes == nullptr ? 1 : 0;
   uint8_t want_edge = 0;
   lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
@@ -6613,15 +6649,22 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
+      rpc_write(conn, &nodes_null, sizeof(nodes_null)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &returned, sizeof(returned)) < 0 ||
-      (nodes != nullptr && returned != 0 &&
-       rpc_read(conn, nodes, returned * sizeof(CUgraphNode)) < 0) ||
+      // The server sends min(returned, requested) elements when the array is
+      // non-null and none for a count-only query, so the read must clamp
+      // identically to stay framed.
+      (nodes != nullptr && requested != 0 && returned != 0 &&
+       rpc_read(conn, nodes,
+                (returned < requested ? returned : requested) *
+                    sizeof(CUgraphNode)) < 0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  *num = returned;
+  *num = (nodes == nullptr) ? returned
+                            : (returned < requested ? returned : requested);
   return return_value;
 }
 

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -10,6 +10,10 @@ Specifically, the order of `@param` annotations indicates the order in which the
 available are `NULL_TERMINATED` (to indicate that this is a null-terminated string), or `LENGTH:<param>` and
 `SIZE:<value>` to specify the size (aka width) of the parameter. If `LENGTH:<param>` is specified, `<param>` must
 be placed in front of the parameter referencing it, otherwise the generated code will not compile.
+`NULLABLE` marks a pointer that may be null. It composes with `LENGTH`: `NULLABLE LENGTH:<count>`
+on a `RECV_ONLY` pointer whose `<count>` is `SEND_RECV` declares an optional out-array sized by an
+in/out count (the `cuGraphGetNodes` query pattern). Each such array leads with its own presence
+byte on the wire, and several arrays may share one count.
 
 Client routing can also be annotated for handles that belong to a specific LUPINE
 server connection. `@routingkey <kind> <param>` selects the connection for the

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -4182,13 +4182,13 @@ CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type);
 /**
  * @param hGraph SEND_ONLY
  * @param numNodes SEND_RECV
- * @param nodes RECV_ONLY LENGTH:numNodes OPTIONAL
+ * @param nodes RECV_ONLY NULLABLE LENGTH:numNodes
  */
 CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes);
 /**
  * @param hGraph SEND_ONLY
  * @param numRootNodes SEND_RECV
- * @param rootNodes RECV_ONLY LENGTH:numRootNodes OPTIONAL
+ * @param rootNodes RECV_ONLY NULLABLE LENGTH:numRootNodes
  */
 CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
                              size_t *numRootNodes);

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -16,7 +16,7 @@ from ops import (
     NullableOperation,
     ArrayOperation,
     InOutCountOperation,
-    OptionalArrayOperation,
+    NullableArrayOperation,
     DeepStructOperation,
     NullTerminatedOperation,
     OpaqueTypeOperation,
@@ -399,13 +399,15 @@ def parse_annotation(
                 nullable = "NULLABLE" in args
                 deref = "DEREF" in args
 
-                # validate that only one of the arguments is present
+                # NULLABLE composes with LENGTH (an optional out-array
+                # sized by an in/out count); every other combination is
+                # mutually exclusive.
                 if (
                     sum([bool(length_arg), bool(size_arg), null_terminated, nullable])
                     > 1
-                ):
+                ) and not (nullable and length_arg and not size_arg and not null_terminated):
                     raise NotImplementedError(
-                        "Only one of LENGTH, SIZE, NULL_TERMINATED, or NULLABLE can be specified"
+                        "Only one of LENGTH, SIZE, NULL_TERMINATED, or NULLABLE can be specified (except NULLABLE LENGTH)"
                     )
 
                 if deref:
@@ -422,12 +424,16 @@ def parse_annotation(
                     length_param = next(
                         p for p in params if p.name == length_arg.split(":")[1]
                     )
-                    if "OPTIONAL" in args:
-                        # optional out-array sized by an in/out count param (the
-                        # cuGraphGetNodes query pattern); linked to its count in
-                        # the post-pass below.
+                    if nullable:
+                        # NULLABLE LENGTH: an optional out-array sized by an
+                        # in/out count param (the cuGraphGetNodes query
+                        # pattern); linked to its count in the post-pass below.
+                        if send or not recv:
+                            raise NotImplementedError(
+                                "NULLABLE LENGTH requires a RECV_ONLY out-array"
+                            )
                         operations.append(
-                            OptionalArrayOperation(
+                            NullableArrayOperation(
                                 parameter=param,
                                 ptr=param.type,
                                 count=length_param,
@@ -633,7 +639,9 @@ def parse_annotation(
     # InOutCountOperation. Several arrays may share one count (cuGraphGetEdges);
     # the first one is the anchor whose presence the client uses to decide
     # between a count-only query and a fill.
-    optional_ops = [op for op in operations if isinstance(op, OptionalArrayOperation)]
+    optional_ops = [
+        op for op in operations if isinstance(op, NullableArrayOperation)
+    ]
     if optional_ops:
         anchors: dict[str, str] = {}
         for op in optional_ops:
@@ -1165,7 +1173,7 @@ def validate_async_annotation(
             f"{name}: @async requires a CUresult return type, got {return_type}"
         )
     for operation in metadata.operations:
-        # OptionalArrayOperation is an out-parameter with no send/recv flags.
+        # NullableArrayOperation is an out-parameter with no send/recv flags.
         if getattr(operation, "recv", True):
             raise RuntimeError(
                 f"{name}: @async requires every parameter to be SEND_ONLY, "
@@ -1521,7 +1529,7 @@ def main():
                     f.write(operation.client_declaration())
                 if (
                     isinstance(operation, InOutCountOperation)
-                    or isinstance(operation, OptionalArrayOperation)
+                    or isinstance(operation, NullableArrayOperation)
                     or isinstance(operation, DeepStructOperation)
                 ):
                     f.write(operation.client_declaration())

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -4721,15 +4721,18 @@ CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t numNodes_requested = (nodes != nullptr) ? *numNodes : 0;
-  uint8_t nodes_present = nodes != nullptr ? 1 : 0;
+  uint8_t nodes_null = nodes == nullptr ? 1 : 0;
   if (rpc_write_start_request(conn, RPC_cuGraphGetNodes) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numNodes_requested, sizeof(size_t)) < 0 ||
-      rpc_write(conn, &nodes_present, sizeof(uint8_t)) < 0 ||
+      rpc_write(conn, &nodes_null, sizeof(uint8_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, numNodes, sizeof(size_t)) < 0 ||
-      (nodes != nullptr && *numNodes != 0 &&
-       rpc_read(conn, nodes, *numNodes * sizeof(CUgraphNode)) < 0) ||
+      (nodes != nullptr && numNodes_requested != 0 && *numNodes != 0 &&
+       rpc_read(
+           conn, nodes,
+           (*numNodes < numNodes_requested ? *numNodes : numNodes_requested) *
+               sizeof(CUgraphNode)) < 0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -4748,15 +4751,20 @@ CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t numRootNodes_requested = (rootNodes != nullptr) ? *numRootNodes : 0;
-  uint8_t rootNodes_present = rootNodes != nullptr ? 1 : 0;
+  uint8_t rootNodes_null = rootNodes == nullptr ? 1 : 0;
   if (rpc_write_start_request(conn, RPC_cuGraphGetRootNodes) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numRootNodes_requested, sizeof(size_t)) < 0 ||
-      rpc_write(conn, &rootNodes_present, sizeof(uint8_t)) < 0 ||
+      rpc_write(conn, &rootNodes_null, sizeof(uint8_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, numRootNodes, sizeof(size_t)) < 0 ||
-      (rootNodes != nullptr && *numRootNodes != 0 &&
-       rpc_read(conn, rootNodes, *numRootNodes * sizeof(CUgraphNode)) < 0) ||
+      (rootNodes != nullptr && numRootNodes_requested != 0 &&
+       *numRootNodes != 0 &&
+       rpc_read(conn, rootNodes,
+                (*numRootNodes < numRootNodes_requested
+                     ? *numRootNodes
+                     : numRootNodes_requested) *
+                    sizeof(CUgraphNode)) < 0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -6161,16 +6161,18 @@ int handle_cuGraphGetNodes(conn_t *conn) {
   size_t numNodes = 0;
   size_t numNodes_requested = 0;
   CUgraphNode *nodes = nullptr;
-  uint8_t nodes_present = 0;
+  uint8_t nodes_null = 0;
   int request_id;
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numNodes_requested, sizeof(size_t)) < 0 ||
       ((numNodes = numNodes_requested), false) ||
-      rpc_read(conn, &nodes_present, sizeof(uint8_t)) < 0 || false)
+      rpc_read(conn, &nodes_null, sizeof(uint8_t)) < 0 || false)
     goto ERROR_0;
-  if (nodes_present && numNodes_requested != 0) {
-    nodes = (CUgraphNode *)malloc(numNodes_requested * sizeof(CUgraphNode));
+  if (!nodes_null) {
+    nodes = (CUgraphNode *)malloc(
+        (numNodes_requested != 0 ? numNodes_requested : 1) *
+        sizeof(CUgraphNode));
     if (nodes == nullptr)
       goto ERROR_0;
   }
@@ -6184,8 +6186,11 @@ int handle_cuGraphGetNodes(conn_t *conn) {
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &numNodes, sizeof(size_t)) < 0 ||
-      (nodes_present &&
-       rpc_write(conn, nodes, numNodes * sizeof(CUgraphNode)) < 0) ||
+      (!nodes_null &&
+       rpc_write(
+           conn, nodes,
+           (numNodes < numNodes_requested ? numNodes : numNodes_requested) *
+               sizeof(CUgraphNode)) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -6202,17 +6207,18 @@ int handle_cuGraphGetRootNodes(conn_t *conn) {
   size_t numRootNodes = 0;
   size_t numRootNodes_requested = 0;
   CUgraphNode *rootNodes = nullptr;
-  uint8_t rootNodes_present = 0;
+  uint8_t rootNodes_null = 0;
   int request_id;
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numRootNodes_requested, sizeof(size_t)) < 0 ||
       ((numRootNodes = numRootNodes_requested), false) ||
-      rpc_read(conn, &rootNodes_present, sizeof(uint8_t)) < 0 || false)
+      rpc_read(conn, &rootNodes_null, sizeof(uint8_t)) < 0 || false)
     goto ERROR_0;
-  if (rootNodes_present && numRootNodes_requested != 0) {
-    rootNodes =
-        (CUgraphNode *)malloc(numRootNodes_requested * sizeof(CUgraphNode));
+  if (!rootNodes_null) {
+    rootNodes = (CUgraphNode *)malloc(
+        (numRootNodes_requested != 0 ? numRootNodes_requested : 1) *
+        sizeof(CUgraphNode));
     if (rootNodes == nullptr)
       goto ERROR_0;
   }
@@ -6227,8 +6233,11 @@ int handle_cuGraphGetRootNodes(conn_t *conn) {
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &numRootNodes, sizeof(size_t)) < 0 ||
-      (rootNodes_present &&
-       rpc_write(conn, rootNodes, numRootNodes * sizeof(CUgraphNode)) < 0) ||
+      (!rootNodes_null && rpc_write(conn, rootNodes,
+                                    (numRootNodes < numRootNodes_requested
+                                         ? numRootNodes
+                                         : numRootNodes_requested) *
+                                        sizeof(CUgraphNode)) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -501,7 +501,7 @@ class ArrayOperation:
 class InOutCountOperation:
     """
     A ``size_t *`` count that is simultaneously an input capacity and an output
-    count for one or more :class:`OptionalArrayOperation` out-arrays -- the
+    count for one or more :class:`NullableArrayOperation` out-arrays -- the
     cuGraphGetNodes pattern. The client sends the requested capacity (0 when the
     anchor array is null, which is a count-only query); the server runs the API
     once with that capacity and returns the actual count.
@@ -557,12 +557,12 @@ class InOutCountOperation:
 
 
 @dataclass
-class OptionalArrayOperation:
+class NullableArrayOperation:
     """
-    An optional out-array sized by an in/out :class:`InOutCountOperation`. The
-    array may be null (the caller is querying the count, or does not want this
-    particular array). Several optional arrays can share one count, e.g.
-    cuGraphGetEdges' from/to/edgeData.
+    A ``NULLABLE LENGTH:<count>`` out-array sized by an in/out
+    :class:`InOutCountOperation`. The array may be null (the caller is querying
+    the count, or does not want this particular array). Several nullable arrays
+    can share one count, e.g. cuGraphGetEdges' from/to/edgeData.
     """
 
     parameter: Parameter
@@ -580,18 +580,18 @@ class OptionalArrayOperation:
     def server_declaration(self) -> str:
         return (
             f"    {self.element_type()} *{self.parameter.name} = nullptr;\n"
-            f"    uint8_t {self.parameter.name}_present = 0;\n"
+            f"    uint8_t {self.parameter.name}_null = 0;\n"
         )
 
     def client_declaration(self) -> str:
         return (
-            f"    uint8_t {self.parameter.name}_present = "
-            f"{self.parameter.name} != nullptr ? 1 : 0;\n"
+            f"    uint8_t {self.parameter.name}_null = "
+            f"{self.parameter.name} == nullptr ? 1 : 0;\n"
         )
 
     def client_rpc_write(self, f):
         f.write(
-            f"        rpc_write(conn, &{self.parameter.name}_present, sizeof(uint8_t)) < 0 ||\n"
+            f"        rpc_write(conn, &{self.parameter.name}_null, sizeof(uint8_t)) < 0 ||\n"
         )
 
     def server_rpc_read(self, f) -> Optional[str]:
@@ -599,13 +599,17 @@ class OptionalArrayOperation:
         name = self.parameter.name
         count = self.count.name
         f.write(
-            f"        rpc_read(conn, &{name}_present, sizeof(uint8_t)) < 0 ||\n"
+            f"        rpc_read(conn, &{name}_null, sizeof(uint8_t)) < 0 ||\n"
         )
         f.write("        false)\n")
         f.write("        goto ERROR_0;\n")
-        f.write(f"    if ({name}_present && {count}_requested != 0) {{\n")
+        # A present pointer must reach CUDA non-null even at zero capacity:
+        # null selects count-query semantics, which can report a count larger
+        # than the zero-length storage the response would then be read from.
+        f.write(f"    if (!{name}_null) {{\n")
         f.write(
-            f"        {name} = ({elem} *)malloc({count}_requested * sizeof({elem}));\n"
+            f"        {name} = ({elem} *)malloc(\n"
+            f"            ({count}_requested != 0 ? {count}_requested : 1) * sizeof({elem}));\n"
         )
         f.write(f"        if ({name} == nullptr)\n")
         f.write("            goto ERROR_0;\n")
@@ -618,12 +622,18 @@ class OptionalArrayOperation:
         return self.parameter.name
 
     def server_rpc_write(self, f):
+        # Both sides clamp the element count to the requested capacity: only
+        # that many elements were allocated, and the clamp keeps the write and
+        # the client read sized identically even if the API reports a larger
+        # count.
         elem = self.element_type()
         name = self.parameter.name
         count = self.count.name
         f.write(
-            f"        ({name}_present && "
-            f"rpc_write(conn, {name}, {count} * sizeof({elem})) < 0) ||\n"
+            f"        (!{name}_null && "
+            f"rpc_write(conn, {name}, "
+            f"({count} < {count}_requested ? {count} : {count}_requested)"
+            f" * sizeof({elem})) < 0) ||\n"
         )
 
     def client_rpc_read(self, f):
@@ -631,8 +641,10 @@ class OptionalArrayOperation:
         name = self.parameter.name
         count = self.count.name
         f.write(
-            f"        ({name} != nullptr && *{count} != 0 && "
-            f"rpc_read(conn, {name}, *{count} * sizeof({elem})) < 0) ||\n"
+            f"        ({name} != nullptr && {count}_requested != 0 && *{count} != 0 && "
+            f"rpc_read(conn, {name}, "
+            f"(*{count} < {count}_requested ? *{count} : {count}_requested)"
+            f" * sizeof({elem})) < 0) ||\n"
         )
 
 

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3172,12 +3172,18 @@ static int lupine_handle_node_dependency_query(conn_t *conn, bool dependent) {
   CUgraphNode hNode = nullptr;
   size_t requested = 0;
   uint8_t want_edge = 0;
+  // The null byte is sent separately from `requested`: a null out-pointer is
+  // a count-only query, while a non-null pointer with zero capacity must
+  // still reach the driver non-null (it reports INVALID_VALUE, not the
+  // count).
+  uint8_t nodes_null = 1;
   size_t count = 0;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
   if (rpc_read(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_read(conn, &requested, sizeof(requested)) < 0 ||
-      rpc_read(conn, &want_edge, sizeof(want_edge)) < 0) {
+      rpc_read(conn, &want_edge, sizeof(want_edge)) < 0 ||
+      rpc_read(conn, &nodes_null, sizeof(nodes_null)) < 0) {
     return -1;
   }
   int request_id = rpc_read_end(conn);
@@ -3193,13 +3199,13 @@ static int lupine_handle_node_dependency_query(conn_t *conn, bool dependent) {
     return dependent ? cuGraphNodeGetDependentNodes_v2(hNode, out, edge, n)
                      : cuGraphNodeGetDependencies_v2(hNode, out, edge, n);
   };
-  if (requested == 0) {
+  if (nodes_null) {
     result = call(nullptr, nullptr, &count);
   } else {
     count = requested;
-    nodes.resize(count);
+    nodes.resize(requested != 0 ? requested : 1);
     if (want_edge) {
-      edges.resize(count);
+      edges.resize(requested != 0 ? requested : 1);
     }
     result = call(nodes.data(), want_edge ? edges.data() : nullptr, &count);
   }
@@ -3208,25 +3214,27 @@ static int lupine_handle_node_dependency_query(conn_t *conn, bool dependent) {
     return dependent ? cuGraphNodeGetDependentNodes(hNode, out, n)
                      : cuGraphNodeGetDependencies(hNode, out, n);
   };
-  if (requested == 0) {
+  if (nodes_null) {
     result = call(nullptr, &count);
   } else {
     count = requested;
-    nodes.resize(count);
+    nodes.resize(requested != 0 ? requested : 1);
     result = call(nodes.data(), &count);
   }
 #endif
 
-  bool send_arrays = requested != 0 && count != 0;
+  // Never send more elements than the `requested`-sized buffers hold; the
+  // client reads min(count, requested) per array, so the sizes must match.
+  size_t sent = count < requested ? count : requested;
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
-      (send_arrays &&
-       rpc_write(conn, nodes.data(), count * sizeof(CUgraphNode)) < 0)) {
+      (sent != 0 &&
+       rpc_write(conn, nodes.data(), sent * sizeof(CUgraphNode)) < 0)) {
     return -1;
   }
 #if CUDA_VERSION >= 12030
-  if (send_arrays && want_edge &&
-      rpc_write(conn, edges.data(), count * sizeof(CUgraphEdgeData)) < 0) {
+  if (sent != 0 && want_edge &&
+      rpc_write(conn, edges.data(), sent * sizeof(CUgraphEdgeData)) < 0) {
     return -1;
   }
 #endif
@@ -3253,9 +3261,14 @@ int handle_manual_cuGraphGetEdges(conn_t *conn) {
   size_t count = 0;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
+  // The null byte is sent separately from `requested`: null from/to is a
+  // count-only query, while non-null pointers with zero capacity must still
+  // reach the driver non-null (it reports INVALID_VALUE, not the count).
+  uint8_t arrays_null = 1;
   if (rpc_read(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_read(conn, &requested, sizeof(requested)) < 0 ||
-      rpc_read(conn, &want_edge, sizeof(want_edge)) < 0) {
+      rpc_read(conn, &want_edge, sizeof(want_edge)) < 0 ||
+      rpc_read(conn, &arrays_null, sizeof(arrays_null)) < 0) {
     return -1;
   }
   int request_id = rpc_read_end(conn);
@@ -3267,41 +3280,43 @@ int handle_manual_cuGraphGetEdges(conn_t *conn) {
   std::vector<CUgraphNode> to;
 #if CUDA_VERSION >= 12030
   std::vector<CUgraphEdgeData> edges;
-  if (requested == 0) {
+  if (arrays_null) {
     result = cuGraphGetEdges_v2(hGraph, nullptr, nullptr, nullptr, &count);
   } else {
     count = requested;
-    from.resize(count);
-    to.resize(count);
+    from.resize(requested != 0 ? requested : 1);
+    to.resize(requested != 0 ? requested : 1);
     if (want_edge) {
-      edges.resize(count);
+      edges.resize(requested != 0 ? requested : 1);
     }
     result = cuGraphGetEdges_v2(hGraph, from.data(), to.data(),
                                 want_edge ? edges.data() : nullptr, &count);
   }
 #else
-  if (requested == 0) {
+  if (arrays_null) {
     result = cuGraphGetEdges(hGraph, nullptr, nullptr, &count);
   } else {
     count = requested;
-    from.resize(count);
-    to.resize(count);
+    from.resize(requested != 0 ? requested : 1);
+    to.resize(requested != 0 ? requested : 1);
     result = cuGraphGetEdges(hGraph, from.data(), to.data(), &count);
   }
 #endif
 
-  bool send_arrays = requested != 0 && count != 0;
+  // Never send more elements than the `requested`-sized buffers hold; the
+  // client reads min(count, requested) per array, so the sizes must match.
+  size_t sent = count < requested ? count : requested;
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
-      (send_arrays &&
-       rpc_write(conn, from.data(), count * sizeof(CUgraphNode)) < 0) ||
-      (send_arrays &&
-       rpc_write(conn, to.data(), count * sizeof(CUgraphNode)) < 0)) {
+      (sent != 0 &&
+       rpc_write(conn, from.data(), sent * sizeof(CUgraphNode)) < 0) ||
+      (sent != 0 &&
+       rpc_write(conn, to.data(), sent * sizeof(CUgraphNode)) < 0)) {
     return -1;
   }
 #if CUDA_VERSION >= 12030
-  if (send_arrays && want_edge &&
-      rpc_write(conn, edges.data(), count * sizeof(CUgraphEdgeData)) < 0) {
+  if (sent != 0 && want_edge &&
+      rpc_write(conn, edges.data(), sent * sizeof(CUgraphEdgeData)) < 0) {
     return -1;
   }
 #endif

--- a/test/test_cuda_graph_api.cu
+++ b/test/test_cuda_graph_api.cu
@@ -148,6 +148,73 @@ int main() {
   CHECK(ndependents == 1 && dependents[0] == B,
         "cuGraphNodeGetDependentNodes(A) == {B}");
 
+  // ---- zero-capacity present pointers (issue #515): a non-null out-array
+  // with a requested count of 0 is array mode, not a count query. The driver
+  // rejects it with INVALID_VALUE, leaves the count 0, and writes nothing;
+  // the wire must not desync or serialize elements from unallocated storage.
+  {
+    const CUgraphNode sentinel = (CUgraphNode)0x1;
+    size_t zc = 0;
+    CUgraphNode buf[4] = {sentinel, sentinel, sentinel, sentinel};
+    CHECK(cuGraphGetNodes(graph, buf, &zc) == CUDA_ERROR_INVALID_VALUE &&
+              zc == 0 && buf[0] == sentinel,
+          "cuGraphGetNodes zero-capacity: INVALID_VALUE, count 0, untouched");
+    zc = 0;
+    CHECK(cuGraphGetRootNodes(graph, buf, &zc) == CUDA_ERROR_INVALID_VALUE &&
+              zc == 0 && buf[0] == sentinel,
+          "cuGraphGetRootNodes zero-capacity: INVALID_VALUE, count 0, "
+          "untouched");
+    zc = 0;
+    CUgraphNode fbuf[4] = {sentinel, sentinel, sentinel, sentinel};
+    CUgraphNode tbuf[4] = {sentinel, sentinel, sentinel, sentinel};
+#ifdef cuGraphGetEdges
+    CUresult ez = cuGraphGetEdges(graph, fbuf, tbuf, nullptr, &zc);
+#else
+    CUresult ez = cuGraphGetEdges(graph, fbuf, tbuf, &zc);
+#endif
+    CHECK(ez == CUDA_ERROR_INVALID_VALUE && zc == 0 && fbuf[0] == sentinel &&
+              tbuf[0] == sentinel,
+          "cuGraphGetEdges zero-capacity: INVALID_VALUE, count 0, untouched");
+    zc = 0;
+#ifdef cuGraphNodeGetDependencies
+    CUresult dz = cuGraphNodeGetDependencies(D, buf, nullptr, &zc);
+#else
+    CUresult dz = cuGraphNodeGetDependencies(D, buf, &zc);
+#endif
+    CHECK(dz == CUDA_ERROR_INVALID_VALUE && zc == 0 && buf[0] == sentinel,
+          "cuGraphNodeGetDependencies zero-capacity: INVALID_VALUE, count 0, "
+          "untouched");
+    zc = 0;
+#ifdef cuGraphNodeGetDependentNodes
+    CUresult pz = cuGraphNodeGetDependentNodes(A, buf, nullptr, &zc);
+#else
+    CUresult pz = cuGraphNodeGetDependentNodes(A, buf, &zc);
+#endif
+    CHECK(pz == CUDA_ERROR_INVALID_VALUE && zc == 0 && buf[0] == sentinel,
+          "cuGraphNodeGetDependentNodes zero-capacity: INVALID_VALUE, count "
+          "0, untouched");
+
+    // Partial capacity truncates: 2 of the 4 nodes/edges come back and the
+    // entries past the capacity stay untouched.
+    size_t pc = 2;
+    CUgraphNode pbuf[4] = {sentinel, sentinel, sentinel, sentinel};
+    CHECK(cuGraphGetNodes(graph, pbuf, &pc) == CUDA_SUCCESS && pc == 2 &&
+              pbuf[0] != sentinel && pbuf[1] != sentinel &&
+              pbuf[2] == sentinel,
+          "cuGraphGetNodes partial capacity: 2 filled, rest untouched");
+    pc = 2;
+    CUgraphNode pf[4] = {sentinel, sentinel, sentinel, sentinel};
+    CUgraphNode pt[4] = {sentinel, sentinel, sentinel, sentinel};
+#ifdef cuGraphGetEdges
+    CUresult ep = cuGraphGetEdges(graph, pf, pt, nullptr, &pc);
+#else
+    CUresult ep = cuGraphGetEdges(graph, pf, pt, &pc);
+#endif
+    CHECK(ep == CUDA_SUCCESS && pc == 2 && pf[0] != sentinel &&
+              pt[0] != sentinel && pf[2] == sentinel && pt[2] == sentinel,
+          "cuGraphGetEdges partial capacity: 2 filled, rest untouched");
+  }
+
   // ---- host-node params: GetParams unwraps the trampoline to the original
   // fn/userData; SetParams updates them; the callback fires on launch ----
   CUDA_HOST_NODE_PARAMS got = {};


### PR DESCRIPTION
Fixes #515.

Present-but-zero-capacity optional output arrays no longer collapse to a null pointer on the server. The server allocates whenever the pointer is present (so the driver applies its own zero-capacity semantics, `CUDA_ERROR_INVALID_VALUE`), and both sides clamp serialized elements to `min(count, requested)` so the response never reads past allocated storage.

Also fixes the manual multi-array variants (`cuGraphGetEdges`, `cuGraphNodeGetDependencies`, `cuGraphNodeGetDependentNodes`): their wire had no presence bit at all, so present-plus-zero desynced the connection. They now carry a presence byte with the same allocate-and-clamp scheme.

Perf: neutral — one extra presence byte on the manual-API wire; no additional copies or round trips. Verified against a real GPU (regression checks fail on pre-fix HEAD, pass with the fix).