### PR TITLE
Centralize null remote-connection handling in rpc_write_start_request

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -825,7 +825,7 @@ static bool lupine_cuda_is_initialized() {
 
 static CUresult lupine_remote_cuInit(conn_t *conn, unsigned int flags) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuInit) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuInit) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -908,8 +908,7 @@ extern "C" CUresult cuDeviceGetP2PAttribute(int *value,
 
   conn_t *conn = lupine_route_remote_conn(src_route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
       rpc_write(conn, value, sizeof(*value)) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
@@ -982,8 +981,7 @@ extern "C" CUresult cuCtxEnablePeerAccess(CUcontext peerContext,
   }
   conn_t *conn = lupine_route_remote_conn(current_route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxEnablePeerAccess) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxEnablePeerAccess) < 0 ||
       rpc_write(conn, &peerContext, sizeof(peerContext)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1007,8 +1005,7 @@ extern "C" CUresult cuCtxDisablePeerAccess(CUcontext peerContext) {
   }
   conn_t *conn = lupine_route_remote_conn(current_route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxDisablePeerAccess) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxDisablePeerAccess) < 0 ||
       rpc_write(conn, &peerContext, sizeof(peerContext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -1084,8 +1081,7 @@ extern "C" CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -1153,8 +1149,7 @@ static void lupine_prefetch_function_param_layout(CUfunction function,
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, LUPINE_RPC_lupineFunctionParamLayoutSnapshot) < 0 ||
       rpc_write(conn, &function, sizeof(function)) < 0 ||
       rpc_wait_for_response(conn) < 0) {
@@ -1191,7 +1186,7 @@ static void lupine_prefetch_function_param_layout(CUfunction function,
 static void lupine_prefill_function_attribute_snapshot(CUfunction function,
                                                        lupine_route route,
                                                        conn_t *conn) {
-  if (function == nullptr || conn == nullptr) {
+  if (function == nullptr) {
     return;
   }
 
@@ -1224,8 +1219,7 @@ extern "C" CUresult cuModuleGetFunction(CUfunction *function, CUmodule module,
 
   conn_t *conn = lupine_route_remote_conn(route);
   size_t name_len = std::strlen(name) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuModuleGetFunction) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuModuleGetFunction) < 0 ||
       rpc_write(conn, &module, sizeof(module)) < 0 ||
       rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -1290,8 +1284,7 @@ static CUresult lupine_load_recorded_module_on_route(CUmodule source_module,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     size_t image_size = record.image.size();
-    if (conn == nullptr ||
-        rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
+    if (rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
         rpc_write(conn, &record.kind, sizeof(record.kind)) < 0 ||
         rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
         rpc_write_payload(conn, record.image.data(), image_size) < 0 ||
@@ -1365,13 +1358,13 @@ extern "C" CUresult cuModuleLoad(CUmodule *module, const char *fname) {
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
 
-  bool failed =
-      conn == nullptr || rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
-      rpc_write(conn, &mapped_size, sizeof(mapped_size)) < 0 ||
-      rpc_write_payload(conn, mapping, mapped_size) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
-      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0;
+  bool failed = rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
+                rpc_write(conn, &mapped_size, sizeof(mapped_size)) < 0 ||
+                rpc_write_payload(conn, mapping, mapped_size) < 0 ||
+                rpc_wait_for_response(conn) < 0 ||
+                rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
+                rpc_read(conn, &result, sizeof(result)) < 0 ||
+                rpc_read_end(conn) < 0;
   munmap(mapping, mapped_size);
   if (failed) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -1432,8 +1425,7 @@ static CUresult lupine_load_recorded_library_on_route(CUlibrary source_library,
     conn_t *conn = lupine_route_remote_conn(route);
     size_t image_size = record.image.size();
     unsigned int zero_options = 0;
-    if (conn == nullptr ||
-        rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
+    if (rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
         rpc_write(conn, &record.kind, sizeof(record.kind)) < 0 ||
         rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
         rpc_write_payload(conn, record.image.data(), image_size) < 0 ||
@@ -1512,8 +1504,7 @@ static CUresult lupine_resolve_library_kernel_for_route(CUfunction function,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     std::size_t name_len = record.name.size() + 1;
-    if (conn == nullptr ||
-        rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
+    if (rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
         rpc_write(conn, &library, sizeof(library)) < 0 ||
         rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
         rpc_write(conn, record.name.c_str(), name_len) < 0 ||
@@ -1592,8 +1583,7 @@ static CUresult lupine_resolve_module_function_for_route(CUfunction function,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     std::size_t name_len = record.name.size() + 1;
-    if (conn == nullptr ||
-        rpc_write_start_request(conn, RPC_cuModuleGetFunction) < 0 ||
+    if (rpc_write_start_request(conn, RPC_cuModuleGetFunction) < 0 ||
         rpc_write(conn, &module, sizeof(module)) < 0 ||
         rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
         rpc_write(conn, record.name.c_str(), name_len) < 0 ||
@@ -1976,8 +1966,7 @@ extern "C" CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib,
   }
   CUresult return_value;
   int value = 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetAttribute) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(remote_dev)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2021,8 +2010,7 @@ extern "C" CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
     }
   }
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetName) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetName) < 0 ||
       rpc_write(conn, &len, sizeof(int)) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2060,8 +2048,7 @@ extern "C" CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev) {
     return CUDA_SUCCESS;
   }
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       (lupine_prepare_host_range_write(uuid, 16 * sizeof(CUuuid)), false) ||
@@ -2097,8 +2084,7 @@ extern "C" CUresult cuDeviceTotalMem_v2(size_t *bytes, CUdevice dev) {
     return CUDA_SUCCESS;
   }
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, bytes, sizeof(size_t)) < 0 ||
@@ -2140,8 +2126,7 @@ extern "C" CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRetain) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRetain) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pctx, sizeof(CUcontext)) < 0 ||
@@ -2172,8 +2157,7 @@ extern "C" CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRelease_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRelease_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2202,8 +2186,7 @@ extern "C" CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxSetFlags_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxSetFlags_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2237,8 +2220,7 @@ cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags, int *active) {
     }
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxGetState) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxGetState) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, flags, sizeof(unsigned int)) < 0 ||
@@ -2271,8 +2253,7 @@ extern "C" CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxReset_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxReset_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2352,7 +2333,7 @@ static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
   size_t size = 0;
   conn_t *conn = lupine_route_remote_conn(route);
   int rpc = kernel ? RPC_cuKernelGetParamInfo : RPC_cuFuncGetParamInfo;
-  if (conn == nullptr || rpc_write_start_request(conn, rpc) < 0 ||
+  if (rpc_write_start_request(conn, rpc) < 0 ||
       rpc_write(conn, &handle, sizeof(handle)) < 0 ||
       rpc_write(conn, &param_index, sizeof(param_index)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2424,8 +2405,7 @@ extern "C" CUresult cuKernelGetFunction(CUfunction *pFunc, CUkernel kernel) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction function = nullptr;
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuKernelGetFunction) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuKernelGetFunction) < 0 ||
       rpc_write(conn, &route_kernel, sizeof(route_kernel)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &function, sizeof(function)) < 0 ||
@@ -2469,8 +2449,7 @@ extern "C" CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   int value = 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuKernelGetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuKernelGetAttribute) < 0 ||
       rpc_write(conn, &value, sizeof(value)) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &kernel, sizeof(kernel)) < 0 ||
@@ -2510,8 +2489,7 @@ extern "C" CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
 
   conn_t *conn = lupine_route_remote_conn(route);
   int value = 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuFuncGetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuFuncGetAttribute) < 0 ||
       rpc_write(conn, &value, sizeof(value)) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
@@ -2585,7 +2563,7 @@ static CUresult lupine_cuOccupancy_cached(int *numBlocks, CUfunction func,
   int opcode = with_flags
                    ? RPC_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
                    : RPC_cuOccupancyMaxActiveBlocksPerMultiprocessor;
-  if (conn == nullptr || rpc_write_start_request(conn, opcode) < 0 ||
+  if (rpc_write_start_request(conn, opcode) < 0 ||
       rpc_write(conn, &remote_num_blocks, sizeof(remote_num_blocks)) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &blockSize, sizeof(blockSize)) < 0 ||
@@ -2652,8 +2630,7 @@ static CUresult lupine_get_remote_private_module_node(CUcontext context,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_UNKNOWN;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, LUPINE_RPC_cuPrivateGetModuleNode) < 0 ||
+  if (rpc_write_start_request(conn, LUPINE_RPC_cuPrivateGetModuleNode) < 0 ||
       rpc_write(conn, &context, sizeof(context)) < 0 ||
       rpc_write(conn, &module, sizeof(module)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2996,10 +2973,6 @@ static const void *lupine_remote_private_export_table(const CUuuid *uuid) {
   }
 
   conn_t *conn = rpc_client_get_connection(0);
-  if (conn == nullptr) {
-    return nullptr;
-  }
-
   CUresult result = CUDA_ERROR_UNKNOWN;
   uint64_t byte_size = 0;
   uint32_t slot_count = 0;
@@ -3130,7 +3103,7 @@ static CUresult lupine_error_string_lookup(int rpc_op, const char *symbol,
   constexpr uint32_t kMaxLength = 4096;
   conn_t *conn = lupine_route_remote_conn(route);
   uint32_t length = 0;
-  if (conn == nullptr || rpc_write_start_request(conn, rpc_op) < 0 ||
+  if (rpc_write_start_request(conn, rpc_op) < 0 ||
       rpc_write(conn, &error, sizeof(error)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &length, sizeof(length)) < 0 || length > kMaxLength) {
@@ -3272,8 +3245,7 @@ extern "C" CUresult cuMemPoolSetAttribute(CUmemoryPool pool,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolSetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolSetAttribute) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -3343,8 +3315,7 @@ CUresult cuMemExportToShareableHandle(void *shareableHandle,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   lupine_ipc_token token = {};
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemExportToShareableHandle) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemExportToShareableHandle) < 0 ||
       rpc_write(conn, &handle, sizeof(handle)) < 0 ||
       rpc_write(conn, &handleType, sizeof(handleType)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -3386,8 +3357,7 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle *handle,
     return CUDA_ERROR_INVALID_VALUE;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemImportFromShareableHandle) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemImportFromShareableHandle) < 0 ||
       rpc_write(conn, &token, sizeof(token)) < 0 ||
       rpc_write(conn, &shHandleType, sizeof(shHandleType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3413,8 +3383,7 @@ CUresult cuMemPoolExportToShareableHandle(void *handle_out, CUmemoryPool pool,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   lupine_ipc_token token = {};
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolExportToShareableHandle) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolExportToShareableHandle) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &handleType, sizeof(handleType)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -3459,8 +3428,7 @@ cuMemPoolImportFromShareableHandle(CUmemoryPool *pool_out, void *handle,
     return CUDA_ERROR_INVALID_VALUE;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolImportFromShareableHandle) <
+  if (rpc_write_start_request(conn, RPC_cuMemPoolImportFromShareableHandle) <
           0 ||
       rpc_write(conn, &token, sizeof(token)) < 0 ||
       rpc_write(conn, &handleType, sizeof(handleType)) < 0 ||
@@ -3623,8 +3591,7 @@ extern "C" CUresult cuCtxGetDevice(CUdevice *device) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUdevice remote_device = 0;
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxGetDevice) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxGetDevice) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &remote_device, sizeof(remote_device)) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -3659,8 +3626,7 @@ extern "C" CUresult cuMemPoolGetAttribute(CUmemoryPool pool,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolGetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolGetAttribute) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -3703,8 +3669,7 @@ extern "C" CUresult cuCtxGetStreamPriorityRange(int *leastPriority,
   int least = 0;
   int greatest = 0;
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxGetStreamPriorityRange) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxGetStreamPriorityRange) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &least, sizeof(least)) < 0 ||
       rpc_read(conn, &greatest, sizeof(greatest)) < 0 ||
@@ -3796,8 +3761,7 @@ extern "C" CUresult cuLinkCreate_v2(unsigned int numOptions,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLinkCreate_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLinkCreate_v2) < 0 ||
       rpc_write(conn, &numOptions, sizeof(numOptions)) < 0 ||
       rpc_write(conn, options, numOptions * sizeof(*options)) < 0 ||
       rpc_write(conn, optionValues, numOptions * sizeof(*optionValues)) < 0 ||
@@ -3835,8 +3799,7 @@ extern "C" CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type,
   size_t name_len = name == nullptr ? 0 : strlen(name) + 1;
   auto bindings =
       lupine_capture_jit_client_bindings(numOptions, options, optionValues);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLinkAddData_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLinkAddData_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_write(conn, &type, sizeof(type)) < 0 ||
       rpc_write(conn, &size, sizeof(size)) < 0 ||
@@ -3902,8 +3865,7 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
   file_payload = file_mapping;
   file_size = mapped_file_size;
   has_file_data = 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLinkAddFile_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLinkAddFile_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_write(conn, &type, sizeof(type)) < 0 ||
       rpc_write(conn, &path_len, sizeof(path_len)) < 0 ||
@@ -3941,8 +3903,7 @@ extern "C" CUresult cuLinkComplete(CUlinkState state, void **cubinOut,
   CUresult return_value;
   size_t cubin_size = 0;
   std::vector<rpc_jit_output_binding> bindings;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLinkComplete) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLinkComplete) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &cubin_size, sizeof(cubin_size)) < 0) {
@@ -3982,7 +3943,7 @@ extern "C" CUresult cuLinkDestroy(CUlinkState state) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuLinkDestroy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLinkDestroy) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -4082,8 +4043,7 @@ extern "C" CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamWaitEvent) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamWaitEvent) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &Flags, sizeof(Flags)) < 0 ||
@@ -4113,7 +4073,7 @@ extern "C" CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
   }
   lupine_note_event_recorded(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write_end(conn) < 0) {
@@ -4142,8 +4102,7 @@ extern "C" CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
   }
   lupine_note_event_recorded(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 || rpc_write_end(conn) < 0) {
@@ -4252,8 +4211,7 @@ extern "C" CUresult cuCtxCreate_v2(CUcontext *pctx, unsigned int flags,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxCreate_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxCreate_v2) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_write(conn, &dev, sizeof(dev)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4325,7 +4283,7 @@ static CUresult lupine_occupancy_max_potential_block_size(
   CUresult return_value;
   int op = with_flags ? RPC_cuOccupancyMaxPotentialBlockSizeWithFlags
                       : RPC_cuOccupancyMaxPotentialBlockSize;
-  if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
+  if (rpc_write_start_request(conn, op) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &dynamicSMemSize, sizeof(dynamicSMemSize)) < 0 ||
       rpc_write(conn, &blockSizeLimit, sizeof(blockSizeLimit)) < 0 ||
@@ -4484,8 +4442,7 @@ extern "C" CUresult cuModuleLoadData(CUmodule *module, const void *image) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t image_size = image_bytes.size();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
       rpc_write(conn, &kind, sizeof(kind)) < 0 ||
       rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
       rpc_write_payload(conn, image_bytes.data(), image_size) < 0 ||
@@ -4524,7 +4481,7 @@ struct lupine_wire_library_kernel_record {
 };
 
 static void lupine_prefill_library_snapshot(CUlibrary library, conn_t *conn) {
-  if (library == nullptr || conn == nullptr) {
+  if (library == nullptr) {
     return;
   }
 
@@ -4600,7 +4557,7 @@ static void lupine_prefill_library_snapshot(CUlibrary library, conn_t *conn) {
 
 static void lupine_prefill_library_attribute_snapshot(CUlibrary library,
                                                       conn_t *conn) {
-  if (library == nullptr || conn == nullptr) {
+  if (library == nullptr) {
     return;
   }
 
@@ -4716,8 +4673,7 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t image_size = image_bytes.size();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
       rpc_copy_alloc(conn, libraryOptionValues == nullptr
                                ? numLibraryOptions * sizeof(uintptr_t)
                                : 0) < 0 ||
@@ -4967,8 +4923,7 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
        lupine_managed_kernel_requires_launch_sync(f));
   conn_t *conn = lupine_route_remote_conn(route);
   // Fire-and-forget; launch errors are sticky and surface at the next sync.
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLaunchKernel) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLaunchKernel) < 0 ||
       rpc_write(conn, &f, sizeof(f)) < 0 ||
       rpc_write(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_write(conn, &gridDimY, sizeof(gridDimY)) < 0 ||
@@ -5086,8 +5041,7 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
   // cluster dimensions) are reported from the launch itself. The server
   // applies the same numAttrs rule when deciding whether to respond.
   bool fire_and_forget = config->numAttrs == 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLaunchKernelEx) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLaunchKernelEx) < 0 ||
       rpc_write(conn, config, sizeof(*config)) < 0 ||
       rpc_write(conn, config->attrs,
                 config->numAttrs * sizeof(*config->attrs)) < 0 ||
@@ -5169,8 +5123,7 @@ cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
       rpc_write(conn, &f, sizeof(f)) < 0 ||
       rpc_write(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_write(conn, &gridDimY, sizeof(gridDimY)) < 0 ||
@@ -5272,8 +5225,7 @@ extern "C" CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
       rpc_write(conn, &srcArray, sizeof(srcArray)) < 0 ||
       rpc_write(conn, &srcOffset, sizeof(srcOffset)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
@@ -5329,8 +5281,7 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
   lupine_note_async_dtoh_copy();
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
       rpc_write(conn, &dstHost, sizeof(dstHost)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
@@ -5441,8 +5392,7 @@ static CUresult lupine_cuMemcpy2D_common(const CUDA_MEMCPY2D *pCopy,
   }
   CUresult return_value;
   size_t returned_dst_size = 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, lupine_memcpy2d_rpc_op(async, unaligned)) <
+  if (rpc_write_start_request(conn, lupine_memcpy2d_rpc_op(async, unaligned)) <
           0 ||
       rpc_write(conn, &copy, sizeof(copy)) < 0 ||
       rpc_write(conn, &src_host_size, sizeof(src_host_size)) < 0 ||
@@ -5530,7 +5480,7 @@ static CUresult lupine_graph_mem_attribute_rpc(CUdevice device,
   CUresult result = CUDA_ERROR_UNKNOWN;
   int op =
       set ? RPC_cuDeviceSetGraphMemAttribute : RPC_cuDeviceGetGraphMemAttribute;
-  if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
+  if (rpc_write_start_request(conn, op) < 0 ||
       rpc_write(conn, &device, sizeof(device)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       (set && rpc_write(conn, value, sizeof(*value)) < 0) ||
@@ -5598,7 +5548,7 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
   }
   CUresult return_value;
   size_t returned_dst_size = 0;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemcpy3D_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpy3D_v2) < 0 ||
       rpc_write(conn, &copy, sizeof(copy)) < 0 ||
       rpc_write(conn, &src_host_size, sizeof(src_host_size)) < 0 ||
       rpc_write(conn, src_host, src_host_size) < 0 ||
@@ -5662,7 +5612,7 @@ extern "C" CUresult cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src,
     return lupine_cuMemcpyDtoD_via_client(dst, src, ByteCount, hStream, true);
   }
   CUresult return_value;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemcpyAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyAsync) < 0 ||
       rpc_write(conn, &dst, sizeof(dst)) < 0 ||
       rpc_write(conn, &src, sizeof(src)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
@@ -5844,8 +5794,7 @@ cuGraphKernelNodeGetParams_v2(CUgraphNode hNode,
       std::make_shared<lupine_graph_kernel_node_params_storage>();
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   CUresult param_info_result = CUDA_SUCCESS;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read_buffer(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -5923,8 +5872,7 @@ cuGraphKernelNodeSetParams_v2(CUgraphNode hNode,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
       rpc_copy_alloc(conn, lupine_param_info_copy_capacity()) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0) {
@@ -6007,8 +5955,7 @@ cuGraphAddKernelNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddKernelNode_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddKernelNode_v2) < 0 ||
       rpc_copy_alloc(conn, lupine_param_info_copy_capacity()) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -6098,8 +6045,7 @@ cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddMemcpyNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddMemcpyNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6138,8 +6084,7 @@ cuGraphExecKernelNodeSetParams_v2(CUgraphExec hGraphExec, CUgraphNode hNode,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecKernelNodeSetParams_v2) <
+  if (rpc_write_start_request(conn, RPC_cuGraphExecKernelNodeSetParams_v2) <
           0 ||
       rpc_copy_alloc(conn, lupine_param_info_copy_capacity()) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
@@ -6217,8 +6162,7 @@ cuGraphAddMemsetNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddMemsetNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddMemsetNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6262,8 +6206,7 @@ cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddHostNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddHostNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6298,8 +6241,7 @@ extern "C" CUresult cuGraphConditionalHandleCreate(
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, LUPINE_RPC_cuGraphConditionalHandleCreate) <
+  if (rpc_write_start_request(conn, LUPINE_RPC_cuGraphConditionalHandleCreate) <
           0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
@@ -6366,8 +6308,7 @@ extern "C" CUresult cuGraphAddNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
   size_t copy_size = nodeParams->type == CU_GRAPH_NODE_TYPE_KERNEL
                          ? lupine_param_info_copy_capacity()
                          : 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, LUPINE_RPC_cuGraphAddNode_v2) < 0 ||
+  if (rpc_write_start_request(conn, LUPINE_RPC_cuGraphAddNode_v2) < 0 ||
       rpc_copy_alloc(conn, copy_size) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -6489,8 +6430,7 @@ extern "C" CUresult cuGraphGetEdges_v2(CUgraph hGraph, CUgraphNode *from,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6533,8 +6473,7 @@ extern "C" CUresult cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6589,7 +6528,7 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (conn == nullptr || rpc_write_start_request(conn, rpc_id) < 0 ||
+  if (rpc_write_start_request(conn, rpc_id) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6670,7 +6609,7 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (conn == nullptr || rpc_write_start_request(conn, rpc_id) < 0 ||
+  if (rpc_write_start_request(conn, rpc_id) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6717,8 +6656,7 @@ cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARAMS *nodeParams) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   CUDA_HOST_NODE_PARAMS params{};
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &params, sizeof(params)) < 0 ||
@@ -6746,8 +6684,7 @@ cuGraphHostNodeSetParams(CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6775,8 +6712,7 @@ cuGraphExecHostNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -6811,8 +6747,7 @@ extern "C" CUresult cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLaunchHostFunc) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLaunchHostFunc) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &fn, sizeof(fn)) < 0 ||
       rpc_write(conn, &userData, sizeof(userData)) < 0 ||
@@ -6842,8 +6777,7 @@ extern "C" CUresult cuStreamAddCallback(CUstream hStream,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamAddCallback) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamAddCallback) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &callback, sizeof(callback)) < 0 ||
       rpc_write(conn, &userData, sizeof(userData)) < 0 ||
@@ -7090,8 +7024,7 @@ extern "C" CUresult cuStreamIsCapturing(CUstream hStream,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamIsCapturing) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamIsCapturing) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, captureStatus, sizeof(CUstreamCaptureStatus)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -7115,8 +7048,7 @@ extern "C" CUresult cuStreamBeginCapture_v2(CUstream hStream,
     return capture_guard.complete(return_value);
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &mode, sizeof(CUstreamCaptureMode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -7141,8 +7073,7 @@ extern "C" CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUgraph *phGraph_null_check;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &phGraph, sizeof(CUgraph *)) < 0 ||
       (phGraph != nullptr && rpc_write(conn, phGraph, sizeof(CUgraph)) < 0) ||
@@ -8176,8 +8107,7 @@ extern "C" CUresult cuKernelGetLibrary(CUlibrary *pLib, CUkernel kernel) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuKernelGetLibrary) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuKernelGetLibrary) < 0 ||
       rpc_write(conn, &kernel, sizeof(kernel)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pLib, sizeof(*pLib)) < 0 ||

--- a/client_routing.h
+++ b/client_routing.h
@@ -64,6 +64,8 @@ extern "C" conn_t *lupine_rpc_conn_for_event(CUevent event);
 extern "C" conn_t *lupine_rpc_conn_for_deviceptr(CUdeviceptr ptr);
 
 extern "C" bool lupine_route_is_local(lupine_route route);
+// May return null for local/invalid routes; rpc_write_start_request absorbs
+// the null, so callers need not re-check before starting a request chain.
 extern "C" conn_t *lupine_route_remote_conn(lupine_route route);
 extern "C" bool lupine_routes_share_server(lupine_route first,
                                            lupine_route second);

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1011,8 +1011,7 @@ def write_nvml_client_rpc(f, function, operations):
                 )
             )
 
-    f.write("  if (conn == nullptr ||\n")
-    f.write(f"      rpc_write_start_request(conn, RPC_{name}) < 0 ||\n")
+    f.write(f"  if (rpc_write_start_request(conn, RPC_{name}) < 0 ||\n")
     for operation in operations:
         operation.client_rpc_write(f)
     f.write("      rpc_wait_for_response(conn) < 0 ||\n")
@@ -1563,8 +1562,7 @@ def main():
             if metadata.async_fire_forget:
                 error_return = error_const(function.return_type.format())
                 f.write(
-                    "    if (conn == nullptr ||\n"
-                    "        rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
+                    "    if (rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
                         name=function.name.format()
                     )
                 )
@@ -1585,8 +1583,7 @@ def main():
                 continue
 
             f.write(
-                "    if (conn == nullptr ||\n"
-                "        rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
+                "    if (rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
                     name=function.name.format()
                 )
             )

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -102,8 +102,7 @@ CUresult cuDriverGetVersion(int *driverVersion) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, driverVersion, sizeof(int)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -129,8 +128,7 @@ CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetLuid) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetLuid) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       (lupine_prepare_host_range_write(luid, 8 * sizeof(char)), false) ||
@@ -158,8 +156,7 @@ CUresult cuDeviceGetTexture1DLinearMaxWidth(size_t *maxWidthInElements,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetTexture1DLinearMaxWidth) <
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetTexture1DLinearMaxWidth) <
           0 ||
       rpc_write(conn, &format, sizeof(CUarray_format)) < 0 ||
       rpc_write(conn, &numChannels, sizeof(unsigned)) < 0 ||
@@ -183,8 +180,7 @@ CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceSetMemPool) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceSetMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -208,8 +204,7 @@ CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetMemPool) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pool, sizeof(CUmemoryPool)) < 0 ||
@@ -236,8 +231,7 @@ CUresult cuDeviceGetDefaultMemPool(CUmemoryPool *pool_out, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetDefaultMemPool) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetDefaultMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pool_out, sizeof(CUmemoryPool)) < 0 ||
@@ -263,8 +257,7 @@ CUresult cuDeviceGetExecAffinitySupport(int *pi, CUexecAffinityType type,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetExecAffinitySupport) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetExecAffinitySupport) < 0 ||
       rpc_write(conn, &type, sizeof(CUexecAffinityType)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 || rpc_read(conn, pi, sizeof(int)) < 0 ||
@@ -285,8 +278,7 @@ CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
       rpc_write(conn, &target, sizeof(CUflushGPUDirectRDMAWritesTarget)) < 0 ||
       rpc_write(conn, &scope, sizeof(CUflushGPUDirectRDMAWritesScope)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -307,8 +299,7 @@ CUresult cuDeviceGetProperties(CUdevprop *prop, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetProperties) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetProperties) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, prop, sizeof(CUdevprop)) < 0 ||
@@ -330,8 +321,7 @@ CUresult cuDeviceComputeCapability(int *major, int *minor, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceComputeCapability) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceComputeCapability) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, major, sizeof(int)) < 0 ||
@@ -360,8 +350,7 @@ CUresult cuCtxDestroy_v2(CUcontext ctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxDestroy_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxDestroy_v2) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -383,7 +372,7 @@ CUresult cuCtxGetFlags(unsigned int *flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxGetFlags) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxGetFlags) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, flags, sizeof(unsigned int)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -401,7 +390,7 @@ CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxGetId) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxGetId) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, ctxId, sizeof(unsigned long long)) < 0 ||
@@ -426,8 +415,7 @@ CUresult cuCtxSynchronize() {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxSynchronize) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxSynchronize) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
       lupine_forward_remote_stdout(conn) < 0 ||
@@ -448,7 +436,7 @@ CUresult cuCtxSetLimit(CUlimit limit, size_t value) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxSetLimit) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxSetLimit) < 0 ||
       rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
       rpc_write(conn, &value, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -467,7 +455,7 @@ CUresult cuCtxGetLimit(size_t *pvalue, CUlimit limit) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxGetLimit) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxGetLimit) < 0 ||
       rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pvalue, sizeof(size_t)) < 0 ||
@@ -486,8 +474,7 @@ CUresult cuCtxGetCacheConfig(CUfunc_cache *pconfig) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxGetCacheConfig) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxGetCacheConfig) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pconfig, sizeof(CUfunc_cache)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -505,8 +492,7 @@ CUresult cuCtxSetCacheConfig(CUfunc_cache config) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxSetCacheConfig) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxSetCacheConfig) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -524,8 +510,7 @@ CUresult cuCtxGetApiVersion(CUcontext ctx, unsigned int *version) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxGetApiVersion) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxGetApiVersion) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, version, sizeof(unsigned int)) < 0 ||
@@ -544,8 +529,7 @@ CUresult cuCtxResetPersistingL2Cache() {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -563,8 +547,7 @@ CUresult cuCtxGetExecAffinity(CUexecAffinityParam *pExecAffinity,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxGetExecAffinity) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxGetExecAffinity) < 0 ||
       rpc_write(conn, &type, sizeof(CUexecAffinityType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pExecAffinity, sizeof(CUexecAffinityParam)) < 0 ||
@@ -583,7 +566,7 @@ CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxAttach) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxAttach) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pctx, sizeof(CUcontext)) < 0 ||
@@ -604,7 +587,7 @@ CUresult cuCtxDetach(CUcontext ctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxDetach) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxDetach) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -624,8 +607,7 @@ CUresult cuCtxGetSharedMemConfig(CUsharedconfig *pConfig) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pConfig, sizeof(CUsharedconfig)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -643,8 +625,7 @@ CUresult cuCtxSetSharedMemConfig(CUsharedconfig config) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
       rpc_write(conn, &config, sizeof(CUsharedconfig)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -664,8 +645,7 @@ CUresult cuModuleUnload(CUmodule hmod) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuModuleUnload) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuModuleUnload) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -685,8 +665,7 @@ CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode *mode) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuModuleGetLoadingMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuModuleGetLoadingMode) < 0 ||
       rpc_write(conn, mode, sizeof(CUmoduleLoadingMode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, mode, sizeof(CUmoduleLoadingMode)) < 0 ||
@@ -716,8 +695,7 @@ CUresult cuModuleGetGlobal_v2(CUdeviceptr *dptr, size_t *bytes, CUmodule hmod,
   CUdeviceptr *dptr_null_check;
   size_t *bytes_null_check;
   std::size_t name_len = std::strlen(name) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuModuleGetGlobal_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuModuleGetGlobal_v2) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
@@ -748,8 +726,7 @@ CUresult cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod, const char *name) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuModuleGetTexRef) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuModuleGetTexRef) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -771,8 +748,7 @@ CUresult cuModuleGetSurfRef(CUsurfref *pSurfRef, CUmodule hmod,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuModuleGetSurfRef) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuModuleGetSurfRef) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -815,8 +791,7 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
     return CUDA_ERROR_INVALID_VALUE;
   if (numLibraryOptions * sizeof(void *) != 0 && libraryOptionValues == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryLoadFromFile) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLibraryLoadFromFile) < 0 ||
       rpc_write(conn, &fileName_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, fileName, fileName_len) < 0 ||
       rpc_write(conn, &numJitOptions, sizeof(unsigned int)) < 0 ||
@@ -849,8 +824,7 @@ CUresult cuLibraryUnload(CUlibrary library) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -873,8 +847,7 @@ CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryGetModule) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLibraryGetModule) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pMod, sizeof(CUmodule)) < 0 ||
@@ -907,8 +880,7 @@ CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
   CUdeviceptr *dptr_null_check;
   size_t *bytes_null_check;
   std::size_t name_len = std::strlen(name) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryGetGlobal) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLibraryGetGlobal) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
@@ -949,8 +921,7 @@ CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
   CUdeviceptr *dptr_null_check;
   size_t *bytes_null_check;
   std::size_t name_len = std::strlen(name) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryGetManaged) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLibraryGetManaged) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
@@ -983,8 +954,7 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t symbol_len = std::strlen(symbol) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &symbol_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, symbol, symbol_len) < 0 ||
@@ -1012,8 +982,7 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
       rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_write(conn, &val, sizeof(int)) < 0 ||
       rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
@@ -1040,8 +1009,7 @@ CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuKernelSetCacheConfig) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuKernelSetCacheConfig) < 0 ||
       rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -1061,8 +1029,7 @@ CUresult cuMemGetInfo_v2(size_t *free, size_t *total) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemGetInfo_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemGetInfo_v2) < 0 ||
       rpc_write(conn, free, sizeof(size_t)) < 0 ||
       rpc_write(conn, total, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1088,7 +1055,7 @@ CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemAlloc_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemAlloc_v2) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1128,8 +1095,7 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr *dptr, size_t *pPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemAllocPitch_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemAllocPitch_v2) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, pPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &WidthInBytes, sizeof(size_t)) < 0 ||
@@ -1166,8 +1132,7 @@ CUresult cuMemGetAddressRange_v2(CUdeviceptr *pbase, size_t *psize,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemGetAddressRange_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemGetAddressRange_v2) < 0 ||
       rpc_write(conn, pbase, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, psize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -1196,8 +1161,7 @@ CUresult cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId) {
         conn_t *conn = lupine_route_remote_conn(route);
         CUdevice *dev_null_check;
         std::size_t pciBusId_len = std::strlen(pciBusId) + 1;
-        if (conn == nullptr ||
-            rpc_write_start_request(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
+        if (rpc_write_start_request(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
             rpc_write(conn, &dev, sizeof(CUdevice *)) < 0 ||
             rpc_write(conn, &pciBusId_len, sizeof(std::size_t)) < 0 ||
             rpc_write(conn, pciBusId, pciBusId_len) < 0 ||
@@ -1222,8 +1186,7 @@ CUresult cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetPCIBusId) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGetPCIBusId) < 0 ||
       rpc_write(conn, &len, sizeof(int)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1246,8 +1209,7 @@ CUresult cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuIpcGetEventHandle) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuIpcGetEventHandle) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUipcEventHandle)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1267,8 +1229,7 @@ CUresult cuIpcOpenEventHandle(CUevent *phEvent, CUipcEventHandle handle) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuIpcOpenEventHandle) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuIpcOpenEventHandle) < 0 ||
       rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &handle, sizeof(CUipcEventHandle)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1288,8 +1249,7 @@ CUresult cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuIpcGetMemHandle) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuIpcGetMemHandle) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUipcMemHandle)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1311,8 +1271,7 @@ CUresult cuIpcOpenMemHandle_v2(CUdeviceptr *pdptr, CUipcMemHandle handle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
       rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &handle, sizeof(CUipcMemHandle)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -1333,8 +1292,7 @@ CUresult cuIpcCloseMemHandle(CUdeviceptr dptr) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuIpcCloseMemHandle) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuIpcCloseMemHandle) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -1355,7 +1313,7 @@ CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
       rpc_write(conn, &dst, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &src, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
@@ -1383,7 +1341,7 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemcpyPeer) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyPeer) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstContext, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1410,8 +1368,7 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
   if (ByteCount != 0 && srcHost == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   lupine_ensure_mapped_host_readable(srcHost, ByteCount);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyHtoD_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyHtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
       rpc_write_payload(conn, srcHost, ByteCount) < 0 ||
@@ -1437,8 +1394,7 @@ CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
@@ -1460,8 +1416,7 @@ CUresult cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyDtoA_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoA_v2) < 0 ||
       rpc_write(conn, &dstArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &dstOffset, sizeof(size_t)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1484,8 +1439,7 @@ CUresult cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyAtoD_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyAtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &srcOffset, sizeof(size_t)) < 0 ||
@@ -1508,8 +1462,7 @@ CUresult cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
       rpc_write(conn, &dstArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &dstOffset, sizeof(size_t)) < 0 ||
       rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
@@ -1539,8 +1492,7 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyPeerAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyPeerAsync) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstContext, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1569,8 +1521,7 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
@@ -1590,7 +1541,7 @@ CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemsetD8_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD8_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1610,8 +1561,7 @@ CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD16_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD16_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1631,8 +1581,7 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD32_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD32_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1655,8 +1604,7 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD2D8_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD2D8_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
@@ -1681,8 +1629,7 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD2D16_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD2D16_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
@@ -1707,8 +1654,7 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD2D32_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD2D32_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
@@ -1731,8 +1677,7 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1754,8 +1699,7 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1777,8 +1721,7 @@ CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1802,8 +1745,7 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
@@ -1829,8 +1771,7 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
@@ -1856,8 +1797,7 @@ CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
@@ -1880,8 +1820,7 @@ CUresult cuArrayCreate_v2(CUarray *pHandle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuArrayCreate_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuArrayCreate_v2) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUarray)) < 0 ||
       rpc_write(conn, pAllocateArray, sizeof(const CUDA_ARRAY_DESCRIPTOR)) <
           0 ||
@@ -1904,8 +1843,7 @@ CUresult cuArrayGetDescriptor_v2(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
       rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY_DESCRIPTOR)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1928,8 +1866,7 @@ cuArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES *sparseProperties,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuArrayGetSparseProperties) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuArrayGetSparseProperties) < 0 ||
       rpc_write(conn, sparseProperties, sizeof(CUDA_ARRAY_SPARSE_PROPERTIES)) <
           0 ||
       rpc_write(conn, &array, sizeof(CUarray)) < 0 ||
@@ -1954,8 +1891,7 @@ CUresult cuMipmappedArrayGetSparseProperties(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMipmappedArrayGetSparseProperties) <
+  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayGetSparseProperties) <
           0 ||
       rpc_write(conn, sparseProperties, sizeof(CUDA_ARRAY_SPARSE_PROPERTIES)) <
           0 ||
@@ -1984,8 +1920,7 @@ cuArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS *memoryRequirements,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
       rpc_write(conn, memoryRequirements,
                 sizeof(CUDA_ARRAY_MEMORY_REQUIREMENTS)) < 0 ||
       rpc_write(conn, &array, sizeof(CUarray)) < 0 ||
@@ -2014,8 +1949,7 @@ CUresult cuMipmappedArrayGetMemoryRequirements(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMipmappedArrayGetMemoryRequirements) <
+  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayGetMemoryRequirements) <
           0 ||
       rpc_write(conn, memoryRequirements,
                 sizeof(CUDA_ARRAY_MEMORY_REQUIREMENTS)) < 0 ||
@@ -2041,8 +1975,7 @@ CUresult cuArrayGetPlane(CUarray *pPlaneArray, CUarray hArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuArrayGetPlane) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuArrayGetPlane) < 0 ||
       rpc_write(conn, pPlaneArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &planeIdx, sizeof(unsigned int)) < 0 ||
@@ -2063,8 +1996,7 @@ CUresult cuArrayDestroy(CUarray hArray) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuArrayDestroy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuArrayDestroy) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2084,8 +2016,7 @@ CUresult cuArray3DCreate_v2(CUarray *pHandle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuArray3DCreate_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuArray3DCreate_v2) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUarray)) < 0 ||
       rpc_write(conn, pAllocateArray, sizeof(const CUDA_ARRAY3D_DESCRIPTOR)) <
           0 ||
@@ -2108,8 +2039,7 @@ CUresult cuArray3DGetDescriptor_v2(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
       rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY3D_DESCRIPTOR)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2134,8 +2064,7 @@ cuMipmappedArrayCreate(CUmipmappedArray *pHandle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMipmappedArrayCreate) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayCreate) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, pMipmappedArrayDesc,
                 sizeof(const CUDA_ARRAY3D_DESCRIPTOR)) < 0 ||
@@ -2160,8 +2089,7 @@ CUresult cuMipmappedArrayGetLevel(CUarray *pLevelArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
       rpc_write(conn, pLevelArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &level, sizeof(unsigned int)) < 0 ||
@@ -2182,8 +2110,7 @@ CUresult cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2204,8 +2131,7 @@ CUresult cuMemAddressReserve(CUdeviceptr *ptr, size_t size, size_t alignment,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemAddressReserve) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemAddressReserve) < 0 ||
       rpc_write(conn, ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &alignment, sizeof(size_t)) < 0 ||
@@ -2228,8 +2154,7 @@ CUresult cuMemAddressFree(CUdeviceptr ptr, size_t size) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemAddressFree) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemAddressFree) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2252,7 +2177,7 @@ CUresult cuMemCreate(CUmemGenericAllocationHandle *handle, size_t size,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemCreate) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemCreate) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned long long)) < 0 ||
@@ -2273,7 +2198,7 @@ CUresult cuMemRelease(CUmemGenericAllocationHandle handle) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemRelease) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemRelease) < 0 ||
       rpc_write(conn, &handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2295,7 +2220,7 @@ CUresult cuMemMap(CUdeviceptr ptr, size_t size, size_t offset,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemMap) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemMap) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &offset, sizeof(size_t)) < 0 ||
@@ -2320,8 +2245,7 @@ CUresult cuMemMapArrayAsync(CUarrayMapInfo *mapInfoList, unsigned int count,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemMapArrayAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemMapArrayAsync) < 0 ||
       rpc_write(conn, mapInfoList, sizeof(CUarrayMapInfo)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -2342,7 +2266,7 @@ CUresult cuMemUnmap(CUdeviceptr ptr, size_t size) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemUnmap) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemUnmap) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2365,8 +2289,7 @@ CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(const CUmemAccessDesc) != 0 && desc == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemSetAccess) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemSetAccess) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &count, sizeof(size_t)) < 0 ||
@@ -2389,8 +2312,7 @@ CUresult cuMemGetAccess(unsigned long long *flags,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemGetAccess) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemGetAccess) < 0 ||
       rpc_write(conn, location, sizeof(const CUmemLocation)) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2415,8 +2337,7 @@ cuMemGetAllocationGranularity(size_t *granularity,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
       rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
       rpc_write(conn, &option, sizeof(CUmemAllocationGranularity_flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2440,8 +2361,7 @@ cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp *prop,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn,
+  if (rpc_write_start_request(conn,
                               RPC_cuMemGetAllocationPropertiesFromHandle) < 0 ||
       rpc_write(conn, prop, sizeof(CUmemAllocationProp)) < 0 ||
       rpc_write(conn, &handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
@@ -2464,8 +2384,7 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemFreeAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemFreeAsync) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2492,8 +2411,7 @@ CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemAllocAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemAllocAsync) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -2519,8 +2437,7 @@ CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolTrimTo) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolTrimTo) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, &minBytesToKeep, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2542,8 +2459,7 @@ CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc *map,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(const CUmemAccessDesc) != 0 && map == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolSetAccess) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolSetAccess) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, &count, sizeof(size_t)) < 0 ||
       rpc_write(conn, map, count * sizeof(const CUmemAccessDesc)) < 0 ||
@@ -2566,8 +2482,7 @@ CUresult cuMemPoolGetAccess(CUmemAccess_flags *flags, CUmemoryPool memPool,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolGetAccess) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolGetAccess) < 0 ||
       rpc_write(conn, flags, sizeof(CUmemAccess_flags)) < 0 ||
       rpc_write(conn, &memPool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, location, sizeof(CUmemLocation)) < 0 ||
@@ -2592,8 +2507,7 @@ CUresult cuMemPoolCreate(CUmemoryPool *pool, const CUmemPoolProps *poolProps) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolCreate) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolCreate) < 0 ||
       rpc_write(conn, pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, poolProps, sizeof(const CUmemPoolProps)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2616,8 +2530,7 @@ CUresult cuMemPoolDestroy(CUmemoryPool pool) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolDestroy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolDestroy) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2643,8 +2556,7 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t bytesize,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
@@ -2672,8 +2584,7 @@ CUresult cuMemPoolExportPointer(CUmemPoolPtrExportData *shareData_out,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolExportPointer) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolExportPointer) < 0 ||
       rpc_write(conn, shareData_out, sizeof(CUmemPoolPtrExportData)) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2696,8 +2607,7 @@ CUresult cuMemPoolImportPointer(CUdeviceptr *ptr_out, CUmemoryPool pool,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemPoolImportPointer) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPoolImportPointer) < 0 ||
       rpc_write(conn, ptr_out, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, shareData, sizeof(CUmemPoolPtrExportData)) < 0 ||
@@ -2724,8 +2634,7 @@ CUresult cuMemRangeGetAttributes(void **data, size_t *dataSizes,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
       rpc_write(conn, data, sizeof(void *)) < 0 ||
       rpc_write(conn, dataSizes, sizeof(size_t)) < 0 ||
       rpc_write(conn, attributes, sizeof(CUmem_range_attribute)) < 0 ||
@@ -2754,8 +2663,7 @@ CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamCreate) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamCreate) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2783,8 +2691,7 @@ CUresult cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamCreateWithPriority) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamCreateWithPriority) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &priority, sizeof(int)) < 0 ||
@@ -2809,8 +2716,7 @@ CUresult cuStreamGetPriority(CUstream hStream, int *priority) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamGetPriority) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamGetPriority) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, priority, sizeof(int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2831,8 +2737,7 @@ CUresult cuStreamGetFlags(CUstream hStream, unsigned int *flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamGetFlags) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamGetFlags) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2853,7 +2758,7 @@ CUresult cuStreamGetId(CUstream hStream, unsigned long long *streamId) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuStreamGetId) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamGetId) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, streamId, sizeof(unsigned long long)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2874,8 +2779,7 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamGetCtx) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamGetCtx) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, pctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2895,8 +2799,7 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuThreadExchangeStreamCaptureMode) <
+  if (rpc_write_start_request(conn, RPC_cuThreadExchangeStreamCaptureMode) <
           0 ||
       rpc_write(conn, mode, sizeof(CUstreamCaptureMode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2929,8 +2832,7 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &dptr_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &length, sizeof(size_t)) < 0 ||
@@ -2958,7 +2860,7 @@ CUresult cuStreamQuery(CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuStreamQuery) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamQuery) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2985,8 +2887,7 @@ CUresult cuStreamSynchronize(CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamSynchronize) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamSynchronize) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -3011,8 +2912,7 @@ CUresult cuStreamDestroy_v2(CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamDestroy_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamDestroy_v2) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3033,8 +2933,7 @@ CUresult cuStreamCopyAttributes(CUstream dst, CUstream src) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamCopyAttributes) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamCopyAttributes) < 0 ||
       rpc_write(conn, &dst, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &src, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3056,8 +2955,7 @@ CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamGetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamGetAttribute) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
       rpc_write(conn, value_out, sizeof(CUstreamAttrValue)) < 0 ||
@@ -3081,8 +2979,7 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamSetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamSetAttribute) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
       rpc_write(conn, value, sizeof(const CUstreamAttrValue)) < 0 ||
@@ -3105,7 +3002,7 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventCreate) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuEventCreate) < 0 ||
       rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3134,8 +3031,7 @@ CUresult cuEventSynchronize(CUevent hEvent) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuEventSynchronize) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuEventSynchronize) < 0 ||
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -3157,8 +3053,7 @@ CUresult cuEventDestroy_v2(CUevent hEvent) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3178,8 +3073,7 @@ CUresult cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuEventElapsedTime_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuEventElapsedTime_v2) < 0 ||
       rpc_write(conn, pMilliseconds, sizeof(float)) < 0 ||
       rpc_write(conn, &hStart, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &hEnd, sizeof(CUevent)) < 0 ||
@@ -3204,8 +3098,7 @@ cuImportExternalMemory(CUexternalMemory *extMem_out,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuImportExternalMemory) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuImportExternalMemory) < 0 ||
       rpc_write(conn, extMem_out, sizeof(CUexternalMemory)) < 0 ||
       rpc_write(conn, memHandleDesc,
                 sizeof(const CUDA_EXTERNAL_MEMORY_HANDLE_DESC)) < 0 ||
@@ -3230,8 +3123,7 @@ CUresult cuExternalMemoryGetMappedBuffer(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
       rpc_write(conn, devPtr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
       rpc_write(conn, bufferDesc,
@@ -3258,8 +3150,7 @@ CUresult cuExternalMemoryGetMappedMipmappedArray(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, RPC_cuExternalMemoryGetMappedMipmappedArray) < 0 ||
       rpc_write(conn, mipmap, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
@@ -3282,8 +3173,7 @@ CUresult cuDestroyExternalMemory(CUexternalMemory extMem) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDestroyExternalMemory) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDestroyExternalMemory) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3305,8 +3195,7 @@ CUresult cuImportExternalSemaphore(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuImportExternalSemaphore) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuImportExternalSemaphore) < 0 ||
       rpc_write(conn, extSem_out, sizeof(CUexternalSemaphore)) < 0 ||
       rpc_write(conn, semHandleDesc,
                 sizeof(const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC)) < 0 ||
@@ -3340,8 +3229,7 @@ CUresult cuSignalExternalSemaphoresAsync(
   if (numExtSems * sizeof(const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS) != 0 &&
       paramsArray == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
       rpc_write(conn, &numExtSems, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, extSemArray,
                 numExtSems * sizeof(const CUexternalSemaphore)) < 0 ||
@@ -3378,8 +3266,7 @@ CUresult cuWaitExternalSemaphoresAsync(
   if (numExtSems * sizeof(const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS) != 0 &&
       paramsArray == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
       rpc_write(conn, &numExtSems, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, extSemArray,
                 numExtSems * sizeof(const CUexternalSemaphore)) < 0 ||
@@ -3403,8 +3290,7 @@ CUresult cuDestroyExternalSemaphore(CUexternalSemaphore extSem) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
       rpc_write(conn, &extSem, sizeof(CUexternalSemaphore)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3426,8 +3312,7 @@ CUresult cuStreamWaitValue32_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint32_t)) < 0 ||
@@ -3452,8 +3337,7 @@ CUresult cuStreamWaitValue64_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint64_t)) < 0 ||
@@ -3478,8 +3362,7 @@ CUresult cuStreamWriteValue32_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint32_t)) < 0 ||
@@ -3504,8 +3387,7 @@ CUresult cuStreamWriteValue64_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint64_t)) < 0 ||
@@ -3531,8 +3413,7 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, paramArray, sizeof(CUstreamBatchMemOpParams)) < 0 ||
@@ -3560,8 +3441,7 @@ CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuFuncSetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuFuncSetAttribute) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_write(conn, &value, sizeof(int)) < 0 ||
@@ -3586,8 +3466,7 @@ CUresult cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuFuncSetCacheConfig) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuFuncSetCacheConfig) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3610,8 +3489,7 @@ CUresult cuFuncGetModule(CUmodule *hmod, CUfunction hfunc) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuFuncGetModule) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuFuncGetModule) < 0 ||
       rpc_write(conn, hmod, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3639,8 +3517,7 @@ cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
+  if (rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
           0 ||
       rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
       rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
@@ -3663,8 +3540,7 @@ CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuFuncSetBlockShape) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuFuncSetBlockShape) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &x, sizeof(int)) < 0 ||
       rpc_write(conn, &y, sizeof(int)) < 0 ||
@@ -3685,8 +3561,7 @@ CUresult cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuFuncSetSharedSize) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuFuncSetSharedSize) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &bytes, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3706,8 +3581,7 @@ CUresult cuParamSetSize(CUfunction hfunc, unsigned int numbytes) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuParamSetSize) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuParamSetSize) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &numbytes, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3727,7 +3601,7 @@ CUresult cuParamSeti(CUfunction hfunc, int offset, unsigned int value) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuParamSeti) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuParamSeti) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &offset, sizeof(int)) < 0 ||
       rpc_write(conn, &value, sizeof(unsigned int)) < 0 ||
@@ -3748,7 +3622,7 @@ CUresult cuParamSetf(CUfunction hfunc, int offset, float value) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuParamSetf) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuParamSetf) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &offset, sizeof(int)) < 0 ||
       rpc_write(conn, &value, sizeof(float)) < 0 ||
@@ -3769,7 +3643,7 @@ CUresult cuLaunch(CUfunction f) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuLaunch) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLaunch) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3788,7 +3662,7 @@ CUresult cuLaunchGrid(CUfunction f, int grid_width, int grid_height) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuLaunchGrid) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLaunchGrid) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &grid_width, sizeof(int)) < 0 ||
       rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
@@ -3811,8 +3685,7 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuLaunchGridAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuLaunchGridAsync) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &grid_width, sizeof(int)) < 0 ||
       rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
@@ -3834,8 +3707,7 @@ CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuParamSetTexRef) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuParamSetTexRef) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &texunit, sizeof(int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -3856,8 +3728,7 @@ CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &config, sizeof(CUsharedconfig)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3879,7 +3750,7 @@ CUresult cuGraphCreate(CUgraph *phGraph, unsigned int flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuGraphCreate) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphCreate) < 0 ||
       rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3904,8 +3775,7 @@ CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(CUDA_MEMCPY3D)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3927,8 +3797,7 @@ CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(const CUDA_MEMCPY3D)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3949,8 +3818,7 @@ CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(CUDA_MEMSET_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3972,8 +3840,7 @@ CUresult cuGraphMemsetNodeSetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(const CUDA_MEMSET_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4002,8 +3869,7 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4034,8 +3900,7 @@ CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph *phGraph) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4068,8 +3933,7 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddEmptyNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddEmptyNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4105,8 +3969,7 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4134,8 +3997,7 @@ CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, event_out, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4156,8 +4018,7 @@ CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4186,8 +4047,7 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4215,8 +4075,7 @@ CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, event_out, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4236,8 +4095,7 @@ CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4269,8 +4127,7 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn,
+  if (rpc_write_start_request(conn,
                               RPC_cuGraphAddExternalSemaphoresSignalNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
@@ -4309,8 +4166,7 @@ CUresult cuGraphExternalSemaphoresSignalNodeGetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (params_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, RPC_cuGraphExternalSemaphoresSignalNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4362,8 +4218,7 @@ CUresult cuGraphExternalSemaphoresSignalNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, RPC_cuGraphExternalSemaphoresSignalNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -4401,8 +4256,7 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresWaitNode) <
+  if (rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresWaitNode) <
           0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
@@ -4440,8 +4294,7 @@ CUresult cuGraphExternalSemaphoresWaitNodeGetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (params_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, RPC_cuGraphExternalSemaphoresWaitNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4493,8 +4346,7 @@ CUresult cuGraphExternalSemaphoresWaitNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, RPC_cuGraphExternalSemaphoresWaitNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -4532,8 +4384,7 @@ CUresult cuGraphAddBatchMemOpNode(
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddBatchMemOpNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddBatchMemOpNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4567,8 +4418,7 @@ cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode,
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeGetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       (lupine_deep_cache_reset((const void *)nodeParams_out), false) ||
@@ -4606,8 +4456,7 @@ CUresult cuGraphBatchMemOpNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeSetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       rpc_write(conn, nodeParams->paramArray,
@@ -4634,8 +4483,7 @@ CUresult cuGraphExecBatchMemOpNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecBatchMemOpNodeSetParams) <
+  if (rpc_write_start_request(conn, RPC_cuGraphExecBatchMemOpNodeSetParams) <
           0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -4669,8 +4517,7 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4700,8 +4547,7 @@ CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, params_out, sizeof(CUDA_MEM_ALLOC_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4731,8 +4577,7 @@ CUresult cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4760,8 +4605,7 @@ CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr *dptr_out) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, dptr_out, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4783,8 +4627,7 @@ CUresult cuDeviceGraphMemTrim(CUdevice device) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
       rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4805,7 +4648,7 @@ CUresult cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuGraphClone) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphClone) < 0 ||
       rpc_write(conn, phGraphClone, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &originalGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4833,8 +4676,7 @@ CUresult cuGraphNodeFindInClone(CUgraphNode *phNode, CUgraphNode hOriginalNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphNodeFindInClone) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphNodeFindInClone) < 0 ||
       rpc_write(conn, phNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hOriginalNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hClonedGraph, sizeof(CUgraph)) < 0 ||
@@ -4858,8 +4700,7 @@ CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphNodeGetType) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphNodeGetType) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, type, sizeof(CUgraphNodeType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4881,8 +4722,7 @@ CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
   conn_t *conn = lupine_route_remote_conn(route);
   size_t numNodes_requested = (nodes != nullptr) ? *numNodes : 0;
   uint8_t nodes_present = nodes != nullptr ? 1 : 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphGetNodes) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphGetNodes) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numNodes_requested, sizeof(size_t)) < 0 ||
       rpc_write(conn, &nodes_present, sizeof(uint8_t)) < 0 ||
@@ -4909,8 +4749,7 @@ CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
   conn_t *conn = lupine_route_remote_conn(route);
   size_t numRootNodes_requested = (rootNodes != nullptr) ? *numRootNodes : 0;
   uint8_t rootNodes_present = rootNodes != nullptr ? 1 : 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphGetRootNodes) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphGetRootNodes) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numRootNodes_requested, sizeof(size_t)) < 0 ||
       rpc_write(conn, &rootNodes_present, sizeof(uint8_t)) < 0 ||
@@ -4933,8 +4772,7 @@ CUresult cuGraphDestroyNode(CUgraphNode hNode) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphDestroyNode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphDestroyNode) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4957,8 +4795,7 @@ CUresult cuGraphInstantiateWithFlags(CUgraphExec *phGraphExec, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
       rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned long long)) < 0 ||
@@ -4989,8 +4826,7 @@ cuGraphInstantiateWithParams(CUgraphExec *phGraphExec, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
       rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, instantiateParams,
@@ -5017,8 +4853,7 @@ CUresult cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t *flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecGetFlags) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphExecGetFlags) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, flags, sizeof(cuuint64_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5043,8 +4878,7 @@ CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, copyParams, sizeof(const CUDA_MEMCPY3D)) < 0 ||
@@ -5070,8 +4904,7 @@ cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, memsetParams, sizeof(const CUDA_MEMSET_NODE_PARAMS)) <
@@ -5096,8 +4929,7 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecChildGraphNodeSetParams) <
+  if (rpc_write_start_request(conn, RPC_cuGraphExecChildGraphNodeSetParams) <
           0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5120,8 +4952,7 @@ CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecEventRecordNodeSetEvent) <
+  if (rpc_write_start_request(conn, RPC_cuGraphExecEventRecordNodeSetEvent) <
           0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5144,8 +4975,7 @@ CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
@@ -5171,8 +5001,7 @@ CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, RPC_cuGraphExecExternalSemaphoresSignalNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5205,8 +5034,7 @@ CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, RPC_cuGraphExecExternalSemaphoresWaitNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5235,8 +5063,7 @@ CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &isEnabled, sizeof(unsigned int)) < 0 ||
@@ -5258,8 +5085,7 @@ CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, isEnabled, sizeof(unsigned int)) < 0 ||
@@ -5280,7 +5106,7 @@ CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuGraphUpload) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphUpload) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5299,7 +5125,7 @@ CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuGraphLaunch) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphLaunch) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5318,8 +5144,7 @@ CUresult cuGraphExecDestroy(CUgraphExec hGraphExec) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecDestroy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphExecDestroy) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -5337,8 +5162,7 @@ CUresult cuGraphDestroy(CUgraph hGraph) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphDestroy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphDestroy) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -5359,8 +5183,7 @@ CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, resultInfo, sizeof(CUgraphExecUpdateResultInfo)) < 0 ||
@@ -5381,8 +5204,7 @@ CUresult cuGraphKernelNodeCopyAttributes(CUgraphNode dst, CUgraphNode src) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
       rpc_write(conn, &dst, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &src, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5405,8 +5227,7 @@ CUresult cuGraphKernelNodeGetAttribute(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUkernelNodeAttrID)) < 0 ||
       rpc_write(conn, value_out, sizeof(CUkernelNodeAttrValue)) < 0 ||
@@ -5431,8 +5252,7 @@ CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUkernelNodeAttrID)) < 0 ||
       rpc_write(conn, value, sizeof(const CUkernelNodeAttrValue)) < 0 ||
@@ -5454,8 +5274,7 @@ CUresult cuGraphDebugDotPrint(CUgraph hGraph, const char *path,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t path_len = std::strlen(path) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphDebugDotPrint) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphDebugDotPrint) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &path_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, path, path_len) < 0 ||
@@ -5476,8 +5295,7 @@ CUresult cuUserObjectRetain(CUuserObject object, unsigned int count) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuUserObjectRetain) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuUserObjectRetain) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5496,8 +5314,7 @@ CUresult cuUserObjectRelease(CUuserObject object, unsigned int count) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuUserObjectRelease) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuUserObjectRelease) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5519,8 +5336,7 @@ CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphRetainUserObject) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphRetainUserObject) < 0 ||
       rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -5543,8 +5359,7 @@ CUresult cuGraphReleaseUserObject(CUgraph graph, CUuserObject object,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphReleaseUserObject) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphReleaseUserObject) < 0 ||
       rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -5568,8 +5383,7 @@ CUresult cuOccupancyAvailableDynamicSMemPerBlock(size_t *dynamicSmemSize,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, RPC_cuOccupancyAvailableDynamicSMemPerBlock) < 0 ||
       rpc_write(conn, dynamicSmemSize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &func_rpc, sizeof(CUfunction)) < 0 ||
@@ -5597,8 +5411,7 @@ CUresult cuOccupancyMaxPotentialClusterSize(int *clusterSize, CUfunction func,
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
   if (config == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuOccupancyMaxPotentialClusterSize) <
+  if (rpc_write_start_request(conn, RPC_cuOccupancyMaxPotentialClusterSize) <
           0 ||
       rpc_write(conn, clusterSize, sizeof(int)) < 0 ||
       rpc_write(conn, &func_rpc, sizeof(CUfunction)) < 0 ||
@@ -5627,8 +5440,7 @@ CUresult cuOccupancyMaxActiveClusters(int *numClusters, CUfunction func,
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
   if (config == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
       rpc_write(conn, numClusters, sizeof(int)) < 0 ||
       rpc_write(conn, &func_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, config, sizeof(*config)) < 0 ||
@@ -5652,8 +5464,7 @@ CUresult cuTexRefSetArray(CUtexref hTexRef, CUarray hArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetArray) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetArray) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -5676,8 +5487,7 @@ CUresult cuTexRefSetMipmappedArray(CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -5699,8 +5509,7 @@ CUresult cuTexRefSetAddress_v2(size_t *ByteOffset, CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
       rpc_write(conn, ByteOffset, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -5726,8 +5535,7 @@ CUresult cuTexRefSetAddress2D_v3(CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, desc, sizeof(const CUDA_ARRAY_DESCRIPTOR)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -5750,8 +5558,7 @@ CUresult cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetFormat) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetFormat) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &fmt, sizeof(CUarray_format)) < 0 ||
       rpc_write(conn, &NumPackedComponents, sizeof(int)) < 0 ||
@@ -5771,8 +5578,7 @@ CUresult cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetAddressMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetAddressMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &dim, sizeof(int)) < 0 ||
       rpc_write(conn, &am, sizeof(CUaddress_mode)) < 0 ||
@@ -5792,8 +5598,7 @@ CUresult cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetFilterMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetFilterMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &fm, sizeof(CUfilter_mode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5812,8 +5617,7 @@ CUresult cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &fm, sizeof(CUfilter_mode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5832,8 +5636,7 @@ CUresult cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &bias, sizeof(float)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5855,8 +5658,7 @@ CUresult cuTexRefSetMipmapLevelClamp(CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &minMipmapLevelClamp, sizeof(float)) < 0 ||
       rpc_write(conn, &maxMipmapLevelClamp, sizeof(float)) < 0 ||
@@ -5877,8 +5679,7 @@ CUresult cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &maxAniso, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5898,8 +5699,7 @@ CUresult cuTexRefSetBorderColor(CUtexref hTexRef, float *pBorderColor) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetBorderColor) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetBorderColor) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, pBorderColor, sizeof(float)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5919,8 +5719,7 @@ CUresult cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefSetFlags) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefSetFlags) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5939,8 +5738,7 @@ CUresult cuTexRefGetAddress_v2(CUdeviceptr *pdptr, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
       rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5960,8 +5758,7 @@ CUresult cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetArray) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetArray) < 0 ||
       rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5983,8 +5780,7 @@ CUresult cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
       rpc_write(conn, phMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6005,8 +5801,7 @@ CUresult cuTexRefGetAddressMode(CUaddress_mode *pam, CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetAddressMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetAddressMode) < 0 ||
       rpc_write(conn, pam, sizeof(CUaddress_mode)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &dim, sizeof(int)) < 0 ||
@@ -6027,8 +5822,7 @@ CUresult cuTexRefGetFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetFilterMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetFilterMode) < 0 ||
       rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6050,8 +5844,7 @@ CUresult cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetFormat) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetFormat) < 0 ||
       rpc_write(conn, pFormat, sizeof(CUarray_format)) < 0 ||
       rpc_write(conn, pNumChannels, sizeof(int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6073,8 +5866,7 @@ CUresult cuTexRefGetMipmapFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
       rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6094,8 +5886,7 @@ CUresult cuTexRefGetMipmapLevelBias(float *pbias, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
       rpc_write(conn, pbias, sizeof(float)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6118,8 +5909,7 @@ CUresult cuTexRefGetMipmapLevelClamp(float *pminMipmapLevelClamp,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
       rpc_write(conn, pminMipmapLevelClamp, sizeof(float)) < 0 ||
       rpc_write(conn, pmaxMipmapLevelClamp, sizeof(float)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6142,8 +5932,7 @@ CUresult cuTexRefGetMaxAnisotropy(int *pmaxAniso, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
       rpc_write(conn, pmaxAniso, sizeof(int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6164,8 +5953,7 @@ CUresult cuTexRefGetBorderColor(float *pBorderColor, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetBorderColor) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetBorderColor) < 0 ||
       rpc_write(conn, pBorderColor, sizeof(float)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6185,8 +5973,7 @@ CUresult cuTexRefGetFlags(unsigned int *pFlags, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefGetFlags) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefGetFlags) < 0 ||
       rpc_write(conn, pFlags, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6206,8 +5993,7 @@ CUresult cuTexRefCreate(CUtexref *pTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefCreate) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefCreate) < 0 ||
       rpc_write(conn, pTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pTexRef, sizeof(CUtexref)) < 0 ||
@@ -6226,8 +6012,7 @@ CUresult cuTexRefDestroy(CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexRefDestroy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexRefDestroy) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6246,8 +6031,7 @@ CUresult cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuSurfRefSetArray) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuSurfRefSetArray) < 0 ||
       rpc_write(conn, &hSurfRef, sizeof(CUsurfref)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -6267,8 +6051,7 @@ CUresult cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuSurfRefGetArray) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuSurfRefGetArray) < 0 ||
       rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hSurfRef, sizeof(CUsurfref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6294,8 +6077,7 @@ CUresult cuTexObjectCreate(CUtexObject *pTexObject,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexObjectCreate) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexObjectCreate) < 0 ||
       rpc_write(conn, pTexObject, sizeof(CUtexObject)) < 0 ||
       rpc_write(conn, pResDesc, sizeof(const CUDA_RESOURCE_DESC)) < 0 ||
       rpc_write(conn, &pTexDesc, sizeof(const CUDA_TEXTURE_DESC *)) < 0 ||
@@ -6323,8 +6105,7 @@ CUresult cuTexObjectDestroy(CUtexObject texObject) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexObjectDestroy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexObjectDestroy) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6344,8 +6125,7 @@ CUresult cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
       rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6367,8 +6147,7 @@ CUresult cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
       rpc_write(conn, pTexDesc, sizeof(CUDA_TEXTURE_DESC)) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6390,8 +6169,7 @@ CUresult cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC *pResViewDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
       rpc_write(conn, pResViewDesc, sizeof(CUDA_RESOURCE_VIEW_DESC)) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6412,8 +6190,7 @@ CUresult cuSurfObjectCreate(CUsurfObject *pSurfObject,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuSurfObjectCreate) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuSurfObjectCreate) < 0 ||
       rpc_write(conn, pSurfObject, sizeof(CUsurfObject)) < 0 ||
       rpc_write(conn, pResDesc, sizeof(const CUDA_RESOURCE_DESC)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6433,8 +6210,7 @@ CUresult cuSurfObjectDestroy(CUsurfObject surfObject) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuSurfObjectDestroy) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuSurfObjectDestroy) < 0 ||
       rpc_write(conn, &surfObject, sizeof(CUsurfObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6454,8 +6230,7 @@ CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
       rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
       rpc_write(conn, &surfObject, sizeof(CUsurfObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6475,8 +6250,7 @@ CUresult cuGraphicsUnregisterResource(CUgraphicsResource resource) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6499,8 +6273,7 @@ CUresult cuGraphicsSubResourceGetMappedArray(CUarray *pArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphicsSubResourceGetMappedArray) <
+  if (rpc_write_start_request(conn, RPC_cuGraphicsSubResourceGetMappedArray) <
           0 ||
       rpc_write(conn, pArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
@@ -6526,8 +6299,7 @@ cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray *pMipmappedArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(
+  if (rpc_write_start_request(
           conn, RPC_cuGraphicsResourceGetMappedMipmappedArray) < 0 ||
       rpc_write(conn, pMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
@@ -6551,8 +6323,7 @@ CUresult cuGraphicsResourceGetMappedPointer_v2(CUdeviceptr *pDevPtr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) <
+  if (rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) <
           0 ||
       rpc_write(conn, pDevPtr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, pSize, sizeof(size_t)) < 0 ||
@@ -6577,8 +6348,7 @@ CUresult cuGraphicsResourceSetMapFlags_v2(CUgraphicsResource resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6603,8 +6373,7 @@ CUresult cuGraphicsMapResources(unsigned int count,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(CUgraphicsResource) != 0 && resources == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphicsMapResources) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphicsMapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, resources, count * sizeof(CUgraphicsResource)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -6630,8 +6399,7 @@ CUresult cuGraphicsUnmapResources(unsigned int count,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(CUgraphicsResource) != 0 && resources == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuGraphicsUnmapResources) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuGraphicsUnmapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, resources, count * sizeof(CUgraphicsResource)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||

--- a/codegen/gen_nvml_client.inc
+++ b/codegen/gen_nvml_client.inc
@@ -4,8 +4,7 @@ static nvmlReturn_t lupine_rpc_nvmlSystemGetDriverVersion(conn_t *conn,
                                                           char *version,
                                                           unsigned int length) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlSystemGetDriverVersion) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlSystemGetDriverVersion) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       (length * sizeof(char) != 0 &&
@@ -30,8 +29,7 @@ static nvmlReturn_t lupine_rpc_nvmlSystemGetNVMLVersion(conn_t *conn,
                                                         char *version,
                                                         unsigned int length) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlSystemGetNVMLVersion) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlSystemGetNVMLVersion) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       (length * sizeof(char) != 0 &&
@@ -56,8 +54,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlSystemGetCudaDriverVersion(conn_t *conn,
                                           int *cudaDriverVersion) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlSystemGetCudaDriverVersion) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlSystemGetCudaDriverVersion) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, cudaDriverVersion, sizeof(int)) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -79,8 +76,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlSystemGetCudaDriverVersion_v2(conn_t *conn,
                                              int *cudaDriverVersion) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlSystemGetCudaDriverVersion_v2) <
+  if (rpc_write_start_request(conn, RPC_nvmlSystemGetCudaDriverVersion_v2) <
           0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, cudaDriverVersion, sizeof(int)) < 0 ||
@@ -105,8 +101,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetHandleByUUID(conn_t *conn,
                                                          nvmlDevice_t *device) {
   nvmlReturn_t return_value = rpc_error();
   unsigned int uuid_len = static_cast<unsigned int>(std::strlen(uuid) + 1);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetHandleByUUID) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetHandleByUUID) < 0 ||
       rpc_write(conn, &uuid_len, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, uuid, uuid_len) < 0 || rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, device, sizeof(nvmlDevice_t)) < 0 ||
@@ -134,8 +129,7 @@ lupine_rpc_nvmlDeviceGetHandleByPciBusId_v2(conn_t *conn, const char *pciBusId,
   nvmlReturn_t return_value = rpc_error();
   unsigned int pciBusId_len =
       static_cast<unsigned int>(std::strlen(pciBusId) + 1);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetHandleByPciBusId_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetHandleByPciBusId_v2) < 0 ||
       rpc_write(conn, &pciBusId_len, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, pciBusId, pciBusId_len) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -164,8 +158,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetUUID(conn_t *conn,
                                                  char *uuid,
                                                  unsigned int length) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetUUID) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetUUID) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -191,8 +184,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetMinorNumber(conn_t *conn, nvmlDevice_t device,
                                     unsigned int *minorNumber) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetMinorNumber) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetMinorNumber) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, minorNumber, sizeof(unsigned int)) < 0 ||
@@ -216,8 +208,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetPciInfo_v3(conn_t *conn,
                                                        nvmlDevice_t device,
                                                        nvmlPciInfo_t *pci) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetPciInfo_v3) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetPciInfo_v3) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pci, sizeof(nvmlPciInfo_t)) < 0 ||
@@ -241,8 +232,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetMemoryInfo(conn_t *conn,
                                                        nvmlDevice_t device,
                                                        nvmlMemory_t *memory) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetMemoryInfo) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetMemoryInfo) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, memory, sizeof(nvmlMemory_t)) < 0 ||
@@ -266,8 +256,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetUtilizationRates(conn_t *conn, nvmlDevice_t device,
                                          nvmlUtilization_t *utilization) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetUtilizationRates) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetUtilizationRates) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, utilization, sizeof(nvmlUtilization_t)) < 0 ||
@@ -293,8 +282,7 @@ lupine_rpc_nvmlDeviceGetTemperature(conn_t *conn, nvmlDevice_t device,
                                     nvmlTemperatureSensors_t sensorType,
                                     unsigned int *temp) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetTemperature) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetTemperature) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &sensorType, sizeof(nvmlTemperatureSensors_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -321,8 +309,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetPowerUsage(conn_t *conn,
                                                        nvmlDevice_t device,
                                                        unsigned int *power) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetPowerUsage) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetPowerUsage) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, power, sizeof(unsigned int)) < 0 ||
@@ -346,8 +333,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetPowerManagementLimit(conn_t *conn, nvmlDevice_t device,
                                              unsigned int *limit) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetPowerManagementLimit) <
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetPowerManagementLimit) <
           0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -373,8 +359,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetClockInfo(conn_t *conn,
                                                       nvmlClockType_t type,
                                                       unsigned int *clock) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetClockInfo) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetClockInfo) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &type, sizeof(nvmlClockType_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -401,8 +386,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetMaxClockInfo(conn_t *conn,
                                                          nvmlClockType_t type,
                                                          unsigned int *clock) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetMaxClockInfo) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetMaxClockInfo) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &type, sizeof(nvmlClockType_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -428,8 +412,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetPerformanceState(conn_t *conn, nvmlDevice_t device,
                                          nvmlPstates_t *pState) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetPerformanceState) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetPerformanceState) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pState, sizeof(nvmlPstates_t)) < 0 ||
@@ -453,8 +436,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetComputeMode(conn_t *conn, nvmlDevice_t device,
                                     nvmlComputeMode_t *mode) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetComputeMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetComputeMode) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, mode, sizeof(nvmlComputeMode_t)) < 0 ||
@@ -478,8 +460,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetPersistenceMode(conn_t *conn, nvmlDevice_t device,
                                         nvmlEnableState_t *mode) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetPersistenceMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetPersistenceMode) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, mode, sizeof(nvmlEnableState_t)) < 0 ||
@@ -503,8 +484,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetFanSpeed(conn_t *conn,
                                                      nvmlDevice_t device,
                                                      unsigned int *speed) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetFanSpeed) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetFanSpeed) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, speed, sizeof(unsigned int)) < 0 ||
@@ -528,8 +508,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetBrand(conn_t *conn,
                                                   nvmlDevice_t device,
                                                   nvmlBrandType_t *type) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetBrand) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetBrand) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, type, sizeof(nvmlBrandType_t)) < 0 ||
@@ -554,8 +533,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetVbiosVersion(conn_t *conn,
                                                          char *version,
                                                          unsigned int length) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetVbiosVersion) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetVbiosVersion) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -583,8 +561,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetSerial(conn_t *conn,
                                                    char *serial,
                                                    unsigned int length) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetSerial) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetSerial) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -610,8 +587,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetBoardPartNumber(conn_t *conn, nvmlDevice_t device,
                                         char *partNumber, unsigned int length) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetBoardPartNumber) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetBoardPartNumber) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -639,8 +615,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetDisplayMode(conn_t *conn, nvmlDevice_t device,
                                     nvmlEnableState_t *display) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetDisplayMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetDisplayMode) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, display, sizeof(nvmlEnableState_t)) < 0 ||
@@ -664,8 +639,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetDisplayActive(conn_t *conn, nvmlDevice_t device,
                                       nvmlEnableState_t *isActive) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetDisplayActive) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetDisplayActive) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, isActive, sizeof(nvmlEnableState_t)) < 0 ||
@@ -688,8 +662,7 @@ nvmlDeviceGetDisplayActive(nvmlDevice_t device, nvmlEnableState_t *isActive) {
 static nvmlReturn_t lupine_rpc_nvmlDeviceGetCurrPcieLinkGeneration(
     conn_t *conn, nvmlDevice_t device, unsigned int *currLinkGen) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetCurrPcieLinkGeneration) <
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetCurrPcieLinkGeneration) <
           0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -716,8 +689,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetCurrPcieLinkWidth(conn_t *conn, nvmlDevice_t device,
                                           unsigned int *currLinkWidth) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetCurrPcieLinkWidth) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetCurrPcieLinkWidth) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, currLinkWidth, sizeof(unsigned int)) < 0 ||
@@ -742,8 +714,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetMaxPcieLinkGeneration(conn_t *conn, nvmlDevice_t device,
                                               unsigned int *maxLinkGen) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetMaxPcieLinkGeneration) <
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetMaxPcieLinkGeneration) <
           0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -770,8 +741,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetMaxPcieLinkWidth(conn_t *conn, nvmlDevice_t device,
                                          unsigned int *maxLinkWidth) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetMaxPcieLinkWidth) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetMaxPcieLinkWidth) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, maxLinkWidth, sizeof(unsigned int)) < 0 ||
@@ -796,8 +766,7 @@ lupine_rpc_nvmlDeviceGetPcieThroughput(conn_t *conn, nvmlDevice_t device,
                                        nvmlPcieUtilCounter_t counter,
                                        unsigned int *value) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetPcieThroughput) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetPcieThroughput) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &counter, sizeof(nvmlPcieUtilCounter_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -823,8 +792,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetPcieReplayCounter(conn_t *conn, nvmlDevice_t device,
                                           unsigned int *value) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetPcieReplayCounter) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetPcieReplayCounter) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, value, sizeof(unsigned int)) < 0 ||
@@ -848,8 +816,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetMaxMigDeviceCount(conn_t *conn, nvmlDevice_t device,
                                           unsigned int *count) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetMaxMigDeviceCount) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetMaxMigDeviceCount) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, count, sizeof(unsigned int)) < 0 ||
@@ -873,8 +840,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetTotalEccErrors(
     conn_t *conn, nvmlDevice_t device, nvmlMemoryErrorType_t errorType,
     nvmlEccCounterType_t counterType, unsigned long long *eccCounts) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetTotalEccErrors) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetTotalEccErrors) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &errorType, sizeof(nvmlMemoryErrorType_t)) < 0 ||
       rpc_write(conn, &counterType, sizeof(nvmlEccCounterType_t)) < 0 ||
@@ -902,8 +868,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetDetailedEccErrors(
     conn_t *conn, nvmlDevice_t device, nvmlMemoryErrorType_t errorType,
     nvmlEccCounterType_t counterType, nvmlEccErrorCounts_t *eccCounts) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetDetailedEccErrors) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetDetailedEccErrors) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &errorType, sizeof(nvmlMemoryErrorType_t)) < 0 ||
       rpc_write(conn, &counterType, sizeof(nvmlEccCounterType_t)) < 0 ||
@@ -932,8 +897,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetMemoryErrorCounter(
     nvmlEccCounterType_t counterType, nvmlMemoryLocation_t locationType,
     unsigned long long *count) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetMemoryErrorCounter) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetMemoryErrorCounter) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &errorType, sizeof(nvmlMemoryErrorType_t)) < 0 ||
       rpc_write(conn, &counterType, sizeof(nvmlEccCounterType_t)) < 0 ||
@@ -964,8 +928,7 @@ lupine_rpc_nvmlDeviceGetEccMode(conn_t *conn, nvmlDevice_t device,
                                 nvmlEnableState_t *current,
                                 nvmlEnableState_t *pending) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetEccMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetEccMode) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, current, sizeof(nvmlEnableState_t)) < 0 ||
@@ -991,8 +954,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetTemperatureV(conn_t *conn, nvmlDevice_t device,
                                      lupine_nvmlTemperature_t *temperature) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetTemperatureV) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetTemperatureV) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, temperature, sizeof(lupine_nvmlTemperature_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1018,8 +980,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetEnforcedPowerLimit(conn_t *conn, nvmlDevice_t device,
                                            unsigned int *limit) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetEnforcedPowerLimit) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetEnforcedPowerLimit) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, limit, sizeof(unsigned int)) < 0 ||
@@ -1043,8 +1004,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceGetMemoryInfo_v2(conn_t *conn, nvmlDevice_t device,
                                       nvmlMemory_v2_t *memory) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetMemoryInfo_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetMemoryInfo_v2) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, memory, sizeof(nvmlMemory_v2_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1070,8 +1030,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetMigMode(conn_t *conn,
                                                     unsigned int *currentMode,
                                                     unsigned int *pendingMode) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetMigMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetMigMode) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, currentMode, sizeof(unsigned int)) < 0 ||
@@ -1098,8 +1057,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetVirtualizationMode(
     conn_t *conn, nvmlDevice_t device,
     nvmlGpuVirtualizationMode_t *pVirtualMode) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetVirtualizationMode) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetVirtualizationMode) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pVirtualMode, sizeof(nvmlGpuVirtualizationMode_t)) < 0 ||
@@ -1124,8 +1082,7 @@ static nvmlReturn_t
 lupine_rpc_nvmlDeviceIsMigDeviceHandle(conn_t *conn, nvmlDevice_t device,
                                        unsigned int *isMigDevice) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceIsMigDeviceHandle) < 0 ||
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceIsMigDeviceHandle) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, isMigDevice, sizeof(unsigned int)) < 0 ||
@@ -1149,8 +1106,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetNvLinkRemoteDeviceType(
     conn_t *conn, nvmlDevice_t device, unsigned int link,
     nvmlIntNvLinkDeviceType_t *pNvLinkDeviceType) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetNvLinkRemoteDeviceType) <
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetNvLinkRemoteDeviceType) <
           0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &link, sizeof(unsigned int)) < 0 ||
@@ -1178,8 +1134,7 @@ extern "C" nvmlReturn_t nvmlDeviceGetNvLinkRemoteDeviceType(
 static nvmlReturn_t lupine_rpc_nvmlDeviceGetNvLinkRemotePciInfo_v2(
     conn_t *conn, nvmlDevice_t device, unsigned int link, nvmlPciInfo_t *pci) {
   nvmlReturn_t return_value = rpc_error();
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_nvmlDeviceGetNvLinkRemotePciInfo_v2) <
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetNvLinkRemotePciInfo_v2) <
           0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &link, sizeof(unsigned int)) < 0 ||

--- a/copy_pipeline.cpp
+++ b/copy_pipeline.cpp
@@ -26,8 +26,7 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -93,9 +92,6 @@ extern "C" CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
   }
   lupine_ensure_mapped_host_readable(srcHost, ByteCount);
   conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
   if (rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(dstDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1002,12 +1002,25 @@ void test_rpc_lz4_payload_round_trip() {
           "lz4 payload did not use direct receive");
 }
 
+// Handlers start request chains without their own null checks; an unreachable
+// server (null route conn) or a failed connection must fail the chain here
+// instead of dereferencing the conn.
+void test_request_start_rejects_null_and_closed_conn() {
+  require(rpc_write_start_request(nullptr, 42) == -1,
+          "null conn request start did not fail");
+  conn_t closed = {};
+  closed.closed = 1;
+  require(rpc_write_start_request(&closed, 42) == -1,
+          "closed conn request start did not fail");
+}
+
 } // namespace
 
 int main() {
 #ifdef LUPINE_H2_UNKNOWN_CUDA_VERSION_TEST
   test_head_probe_cuda_version_metadata();
 #else
+  test_request_start_rejects_null_and_closed_conn();
   test_rpc_write_queue_grows();
   test_rpc_write_buffer_uses_fixed_allocation();
   test_rpc_write_buffer_cleans_up_on_transport_failure_and_destroy();

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -887,7 +887,7 @@ static bool lupine_fetch_stale_range(lupine_host_allocation *allocation,
   conn_t *conn = allocation->stale_fetch_conn;
   auto *dst = reinterpret_cast<unsigned char *>(allocation->host_base + offset);
   CUdeviceptr src = allocation->device_ptr + offset;
-  if (conn == nullptr || allocation->host_base == 0 || bytes == 0 ||
+  if (allocation->host_base == 0 || bytes == 0 ||
       allocation->device_ptr == 0) {
     return bytes == 0;
   }
@@ -1308,8 +1308,7 @@ static CUresult lupine_remote_cuMemHostAlloc(void **remote_host,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   *remote_host = nullptr;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemHostAlloc) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemHostAlloc) < 0 ||
       rpc_write(conn, remote_host, sizeof(*remote_host)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(bytesize)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -1337,7 +1336,7 @@ static CUresult lupine_remote_cuMemFreeHost(void *remote_host,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemFreeHost) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemFreeHost) < 0 ||
       rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -1364,8 +1363,7 @@ static CUresult lupine_remote_cuMemHostGetDevicePointer(CUdeviceptr *device_ptr,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   *device_ptr = 0;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemHostGetDevicePointer_v2) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemHostGetDevicePointer_v2) < 0 ||
       rpc_write(conn, device_ptr, sizeof(*device_ptr)) < 0 ||
       rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -1393,8 +1391,7 @@ static CUresult lupine_remote_cuMemHostGetFlags(unsigned int *flags,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemHostGetFlags) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemHostGetFlags) < 0 ||
       rpc_write(conn, flags, sizeof(*flags)) < 0 ||
       rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2014,8 +2011,7 @@ extern "C" CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
   size_t backing_size = std::max(bytesize, LUPINE_MANAGED_ALLOCATION_MIN_BYTES);
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemAllocManaged) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemAllocManaged) < 0 ||
       rpc_write(conn, &device_alloc_base, sizeof(device_alloc_base)) < 0 ||
       rpc_write(conn, &backing_size, sizeof(backing_size)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -2118,8 +2114,7 @@ extern "C" CUresult cuMemFree_v2(CUdeviceptr dptr) {
     }
     conn_t *conn = lupine_route_remote_conn(route);
     CUresult return_value;
-    if (conn == nullptr ||
-        rpc_write_start_request(conn, RPC_cuMemFree_v2) < 0 ||
+    if (rpc_write_start_request(conn, RPC_cuMemFree_v2) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2253,8 +2248,7 @@ extern "C" CUresult cuPointerSetAttribute(const void *value,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuPointerSetAttribute) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuPointerSetAttribute) < 0 ||
       rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
       rpc_write(conn, &target_ptr, sizeof(target_ptr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -2535,8 +2529,7 @@ static CUresult lupine_cuMemPrefetchAsync_location(CUdeviceptr devPtr,
   conn_t *conn = lupine_route_remote_conn(route);
   int location_type = static_cast<int>(route_location.type);
   CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, LUPINE_RPC_cuMemPrefetchAsync) < 0 ||
+  if (rpc_write_start_request(conn, LUPINE_RPC_cuMemPrefetchAsync) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &location_type, sizeof(location_type)) < 0 ||

--- a/routing.cpp
+++ b/routing.cpp
@@ -190,7 +190,7 @@ lupine_route lupine_route_from_known_kernel_deviceptr_args(
 
 static CUresult lupine_remote_cuDeviceGetCount(conn_t *conn, int *count) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr || count == nullptr ||
+  if (count == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetCount) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, count, sizeof(*count)) < 0 ||
@@ -203,8 +203,7 @@ static CUresult lupine_remote_cuDeviceGetCount(conn_t *conn, int *count) {
 static CUresult lupine_remote_cuDeviceGet(conn_t *conn, CUdevice *device,
                                           int ordinal) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr || device == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGet) < 0 ||
+  if (device == nullptr || rpc_write_start_request(conn, RPC_cuDeviceGet) < 0 ||
       rpc_write(conn, &ordinal, sizeof(ordinal)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, device, sizeof(*device)) < 0 ||
@@ -741,8 +740,7 @@ CUresult lupine_set_current_context_on_route(lupine_route route,
     result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(ctx);
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
-    if (conn == nullptr ||
-        rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
+    if (rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
         rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -480,7 +480,7 @@ int rpc_wait_for_response(conn_t *conn) {
 // only one request can be active at a time, so this function will take the
 // request lock from the connection.
 int rpc_write_start_request(conn_t *conn, const int op) {
-  if (conn->closed) {
+  if (conn == nullptr || conn->closed) {
     return -1;
   }
   if (pthread_mutex_lock(&conn->call_mutex) < 0) {

--- a/rpc.h
+++ b/rpc.h
@@ -95,6 +95,9 @@ extern int rpc_read_end(conn_t *conn);
 
 extern int rpc_wait_for_response(conn_t *conn);
 
+// Owns connection validation for the request chain: a null conn (route with no
+// remote server) or a closed conn fails here, so callers surface their
+// unavailable-server result without per-call-site null checks.
 extern int rpc_write_start_request(conn_t *conn, const int op);
 extern int rpc_write_start_response(conn_t *conn, const int read_id);
 // A zero-size write is a successful no-op, including when data is null.


### PR DESCRIPTION
Fixes #516.

`rpc_write_start_request()` now owns connection validation: a null conn (route with no remote server) or a closed conn fails the request builder before any dereference, so handler short-circuit chains produce the same unavailable-server result as before. Ownership is documented in `rpc.h` / `client_routing.h`, and ~399 per-handler `conn == nullptr` guards are removed (net −345 lines). Guards protecting non-RPC work (socket setup, map inserts, translate-then-succeed paths) were audited and kept.

No behavior change: no-server and dead-port probes return byte-identical results vs. the base branch (`CUDA_ERROR_DEVICE_UNAVAILABLE`, NVML unavailable codes), covered by a new h2_test case.

Perf: neutral — one null/closed check per request start replaces the equivalent per-handler branch; nothing added to the hot path.