### PR TITLE
Limit GPU integration concurrency

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -62,7 +62,10 @@ jobs:
       COMPLIANCE_TIMEOUT: 240m
       CUDA_SAMPLE_TIMEOUT: 120
       CUDA_LONG_SAMPLE_TIMEOUT: 600
-      CUDA_SAMPLE_JOBS: 16
+      # Match the four vCPUs on g2-standard-4. Higher fan-out runs too many
+      # independent CUDA contexts on one L4 and causes device-unavailable
+      # cascades in otherwise passing cuBLAS and PyTorch tests.
+      CUDA_SAMPLE_JOBS: 4
       SSH_COMMAND_TIMEOUT: 120
       PYTORCH_TEST_TIMEOUT: 180
       USE_SPOT: "false"


### PR DESCRIPTION
The GCE integration job uses a g2-standard-4 VM (4 vCPUs, one L4) but starts 16 independent CUDA sample/server pairs concurrently. Repeated PR #510 runs showed `cudaErrorDevicesUnavailable` in UnifiedMemoryStreams followed by cuBLAS and PyTorch failures, while all 25 custom tests passed.

This caps the shared worker count at four to match the VM CPU count and reduce simultaneous CUDA-context pressure.

Evidence:
- PR #510 CUDA 12.4/13.0 failed repeatedly only under the 16-way compliance harness.
- matrixMulCUBLAS passed on main and every staged #510 image in isolation.
- UnifiedMemoryStreams passed 5/5 in isolation and 16/16 when run alone on an RTX 4090.
- The failed GCE artifacts show the first resource failure in UnifiedMemoryStreams, followed by device-unavailable cascades in later cuBLAS/PyTorch tests.

Validation: `git diff --check`; the PR GPU matrix exercises the new concurrency directly.