### PR TITLE
Add CUDA and NVML API coverage for vLLM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ else()
     )
     add_test(
         NAME nvml_ecc_exports
-        COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter"
+        COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetCudaComputeCapability"
     )
     set_source_files_properties(
         ${SERVER_SOURCES}

--- a/client.cpp
+++ b/client.cpp
@@ -8449,6 +8449,73 @@ conn_t *rpc_client_get_connection(unsigned int index) {
 
 int rpc_size() { return nconns; }
 
+#if CUDA_VERSION >= 12000
+extern "C" CUresult cuTensorMapEncodeTiled(
+    CUtensorMap *tensorMap, CUtensorMapDataType tensorDataType,
+    cuuint32_t tensorRank, void *globalAddress, const cuuint64_t *globalDim,
+    const cuuint64_t *globalStrides, const cuuint32_t *boxDim,
+    const cuuint32_t *elementStrides, CUtensorMapInterleave interleave,
+    CUtensorMapSwizzle swizzle, CUtensorMapL2promotion l2Promotion,
+    CUtensorMapFloatOOBfill oobFill) {
+  if (tensorMap == nullptr || tensorRank == 0 || tensorRank > 5 ||
+      globalAddress == nullptr || globalDim == nullptr || boxDim == nullptr ||
+      elementStrides == nullptr ||
+      (tensorRank > 1 && globalStrides == nullptr)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  CUdeviceptr address_rpc = reinterpret_cast<CUdeviceptr>(globalAddress);
+  const bool managed_alias =
+      lupine_translate_managed_host_ptr(address_rpc, &address_rpc);
+  if (managed_alias) {
+    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
+    if (flush_result != CUDA_SUCCESS) {
+      return flush_result;
+    }
+  }
+
+  lupine_route route = lupine_route_for_deviceptr(address_rpc);
+  using real_fn_t = CUresult (*)(
+      CUtensorMap *, CUtensorMapDataType, cuuint32_t, void *,
+      const cuuint64_t *, const cuuint64_t *, const cuuint32_t *,
+      const cuuint32_t *, CUtensorMapInterleave, CUtensorMapSwizzle,
+      CUtensorMapL2promotion, CUtensorMapFloatOOBfill);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTensorMapEncodeTiled", &result, tensorMap, tensorDataType,
+          tensorRank, globalAddress, globalDim, globalStrides, boxDim,
+          elementStrides, interleave, swizzle, l2Promotion, oobFill)) {
+    return result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  void *remote_address =
+      reinterpret_cast<void *>(static_cast<uintptr_t>(address_rpc));
+  const size_t rank_bytes_u64 = tensorRank * sizeof(cuuint64_t);
+  const size_t stride_bytes = (tensorRank - 1) * sizeof(cuuint64_t);
+  const size_t rank_bytes_u32 = tensorRank * sizeof(cuuint32_t);
+
+  if (rpc_write_start_request(conn, RPC_cuTensorMapEncodeTiled) < 0 ||
+      rpc_write(conn, &tensorDataType, sizeof(tensorDataType)) < 0 ||
+      rpc_write(conn, &tensorRank, sizeof(tensorRank)) < 0 ||
+      rpc_write(conn, &remote_address, sizeof(remote_address)) < 0 ||
+      rpc_write(conn, globalDim, rank_bytes_u64) < 0 ||
+      (stride_bytes != 0 && rpc_write(conn, globalStrides, stride_bytes) < 0) ||
+      rpc_write(conn, boxDim, rank_bytes_u32) < 0 ||
+      rpc_write(conn, elementStrides, rank_bytes_u32) < 0 ||
+      rpc_write(conn, &interleave, sizeof(interleave)) < 0 ||
+      rpc_write(conn, &swizzle, sizeof(swizzle)) < 0 ||
+      rpc_write(conn, &l2Promotion, sizeof(l2Promotion)) < 0 ||
+      rpc_write(conn, &oobFill, sizeof(oobFill)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, tensorMap, sizeof(*tensorMap)) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return result;
+}
+#endif
+
 #ifdef cuGetProcAddress
 #undef cuGetProcAddress
 #endif
@@ -8880,6 +8947,9 @@ lupine_manual_function_map() {
        (void *)cuStreamUpdateCaptureDependencies_v2},
       {"cuStreamUpdateCaptureDependencies_ptsz",
        (void *)cuStreamUpdateCaptureDependencies_ptsz},
+#if CUDA_VERSION >= 12000
+      {"cuTensorMapEncodeTiled", (void *)cuTensorMapEncodeTiled},
+#endif
   };
   return manual_function_map;
 }

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -4736,10 +4736,11 @@ CUresult cuSurfObjectDestroy(CUsurfObject surfObject);
 CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
                                      CUsurfObject surfObject);
 /**
+ * @disabled both
  * @param tensorMap SEND_RECV
  * @param tensorDataType SEND_ONLY
  * @param tensorRank SEND_ONLY
- * @param globalAddress SEND_RECV
+ * @param globalAddress SEND_ONLY
  * @param globalDim SEND_RECV
  * @param globalStrides SEND_RECV
  * @param boxDim SEND_RECV

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -174,6 +174,7 @@ NVML_RPC_FUNCTIONS = [
     "nvmlDeviceIsMigDeviceHandle",
     "nvmlDeviceGetNvLinkRemoteDeviceType",
     "nvmlDeviceGetNvLinkRemotePciInfo_v2",
+    "nvmlDeviceGetCudaComputeCapability",
 ]
 
 NVML_MANUAL_SERVER_FUNCTIONS = {

--- a/codegen/gen_api.h
+++ b/codegen/gen_api.h
@@ -342,6 +342,7 @@
 #define RPC_cuSurfObjectCreate 1855246974
 #define RPC_cuSurfObjectDestroy 1635365862
 #define RPC_cuSurfObjectGetResourceDesc 1009289841
+#define RPC_cuTensorMapEncodeTiled 1386204641
 #define RPC_cuDeviceCanAccessPeer 1419231701
 #define RPC_cuCtxEnablePeerAccess 1737933368
 #define RPC_cuCtxDisablePeerAccess 1900602041
@@ -380,7 +381,6 @@
 #define RPC_cuStreamGetCaptureInfo_v2 501626002
 #define RPC_cuStreamUpdateCaptureDependencies_v2 434730116
 #define RPC_cuTensorMapEncodeIm2col 1203430832
-#define RPC_cuTensorMapEncodeTiled 1386204641
 #define RPC_cuTensorMapReplaceAddress 1209139891
 #define RPC_cuUserObjectCreate 1748907400
 #define RPC_nvmlInit_v2 2103095296
@@ -445,6 +445,7 @@
 #define RPC_nvmlDeviceIsMigDeviceHandle 1693389219
 #define RPC_nvmlDeviceGetNvLinkRemoteDeviceType 65527014
 #define RPC_nvmlDeviceGetNvLinkRemotePciInfo_v2 1998574024
+#define RPC_nvmlDeviceGetCudaComputeCapability 1264755594
 
 #define LUPINE_RPC_cuGetExportTableMetadata 565915314
 #define LUPINE_RPC_cuGraphAddNode_v2 1958016248

--- a/codegen/gen_nvml_client.inc
+++ b/codegen/gen_nvml_client.inc
@@ -1157,3 +1157,31 @@ nvmlDeviceGetNvLinkRemotePciInfo_v2(nvmlDevice_t device, unsigned int link,
   return lupine_rpc_nvmlDeviceGetNvLinkRemotePciInfo_v2(conn, device, link,
                                                         pci);
 }
+
+static nvmlReturn_t
+lupine_rpc_nvmlDeviceGetCudaComputeCapability(conn_t *conn, nvmlDevice_t device,
+                                              int *major, int *minor) {
+  nvmlReturn_t return_value = rpc_error();
+  if (rpc_write_start_request(conn, RPC_nvmlDeviceGetCudaComputeCapability) <
+          0 ||
+      rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, major, sizeof(int)) < 0 ||
+      rpc_read(conn, minor, sizeof(int)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return rpc_error();
+  }
+  return return_value;
+}
+
+extern "C" nvmlReturn_t nvmlDeviceGetCudaComputeCapability(nvmlDevice_t device,
+                                                           int *major,
+                                                           int *minor) {
+  if (major == nullptr || minor == nullptr) {
+    return NVML_ERROR_INVALID_ARGUMENT;
+  }
+  conn_t *conn = connection_for_device(&device);
+  return lupine_rpc_nvmlDeviceGetCudaComputeCapability(conn, device, major,
+                                                       minor);
+}

--- a/codegen/gen_nvml_server.h
+++ b/codegen/gen_nvml_server.h
@@ -56,3 +56,4 @@ int handle_nvmlDeviceGetVirtualizationMode(conn_t *conn);
 int handle_nvmlDeviceIsMigDeviceHandle(conn_t *conn);
 int handle_nvmlDeviceGetNvLinkRemoteDeviceType(conn_t *conn);
 int handle_nvmlDeviceGetNvLinkRemotePciInfo_v2(conn_t *conn);
+int handle_nvmlDeviceGetCudaComputeCapability(conn_t *conn);

--- a/codegen/gen_nvml_server.inc
+++ b/codegen/gen_nvml_server.inc
@@ -1693,3 +1693,35 @@ int handle_nvmlDeviceGetNvLinkRemotePciInfo_v2(conn_t *conn) {
 ERROR_0:
   return -1;
 }
+
+int handle_nvmlDeviceGetCudaComputeCapability(conn_t *conn) {
+  nvmlDevice_t device;
+  int major;
+  major = {};
+  int minor;
+  minor = {};
+  int request_id;
+  nvmlReturn_t return_value;
+  using fn_t = nvmlReturn_t (*)(nvmlDevice_t, int *, int *);
+  fn_t fn = nullptr;
+  if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+
+  fn = nvml_symbol<fn_t>("nvmlDeviceGetCudaComputeCapability");
+  return_value =
+      fn == nullptr ? function_not_found() : fn(device, &major, &minor);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &major, sizeof(int)) < 0 ||
+      rpc_write(conn, &minor, sizeof(int)) < 0 ||
+      rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+  return 0;
+ERROR_0:
+  return -1;
+}

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -8801,6 +8801,8 @@ static const std::unordered_map<int, RequestHandler> opHandlers = {
      handle_nvmlDeviceGetNvLinkRemoteDeviceType},
     {RPC_nvmlDeviceGetNvLinkRemotePciInfo_v2,
      handle_nvmlDeviceGetNvLinkRemotePciInfo_v2},
+    {RPC_nvmlDeviceGetCudaComputeCapability,
+     handle_nvmlDeviceGetCudaComputeCapability},
 };
 
 RequestHandler get_handler(const int op) {

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -4510,3 +4510,66 @@ int handle_manual_cuGetErrorName(conn_t *conn) {
 int handle_manual_cuGetErrorString(conn_t *conn) {
   return lupine_handle_error_string(conn, cuGetErrorString);
 }
+
+#if CUDA_VERSION >= 12000
+int handle_manual_cuTensorMapEncodeTiled(conn_t *conn) {
+  CUtensorMapDataType tensor_data_type;
+  cuuint32_t tensor_rank = 0;
+  void *global_address = nullptr;
+  std::array<cuuint64_t, 5> global_dim{};
+  std::array<cuuint64_t, 4> global_strides{};
+  std::array<cuuint32_t, 5> box_dim{};
+  std::array<cuuint32_t, 5> element_strides{};
+
+  if (rpc_read(conn, &tensor_data_type, sizeof(tensor_data_type)) < 0 ||
+      rpc_read(conn, &tensor_rank, sizeof(tensor_rank)) < 0 ||
+      rpc_read(conn, &global_address, sizeof(global_address)) < 0) {
+    return -1;
+  }
+
+  if (tensor_rank == 0 || tensor_rank > global_dim.size()) {
+    return -1;
+  }
+
+  const size_t rank_bytes_u64 = tensor_rank * sizeof(cuuint64_t);
+  const size_t stride_bytes = (tensor_rank - 1) * sizeof(cuuint64_t);
+  const size_t rank_bytes_u32 = tensor_rank * sizeof(cuuint32_t);
+  if (rpc_read(conn, global_dim.data(), rank_bytes_u64) < 0 ||
+      (stride_bytes != 0 &&
+       rpc_read(conn, global_strides.data(), stride_bytes) < 0) ||
+      rpc_read(conn, box_dim.data(), rank_bytes_u32) < 0 ||
+      rpc_read(conn, element_strides.data(), rank_bytes_u32) < 0) {
+    return -1;
+  }
+
+  CUtensorMapInterleave interleave;
+  CUtensorMapSwizzle swizzle;
+  CUtensorMapL2promotion l2_promotion;
+  CUtensorMapFloatOOBfill oob_fill;
+  if (rpc_read(conn, &interleave, sizeof(interleave)) < 0 ||
+      rpc_read(conn, &swizzle, sizeof(swizzle)) < 0 ||
+      rpc_read(conn, &l2_promotion, sizeof(l2_promotion)) < 0 ||
+      rpc_read(conn, &oob_fill, sizeof(oob_fill)) < 0) {
+    return -1;
+  }
+
+  const int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  CUtensorMap tensor_map{};
+  CUresult result = cuTensorMapEncodeTiled(
+      &tensor_map, tensor_data_type, tensor_rank, global_address,
+      global_dim.data(),
+      stride_bytes == 0 ? nullptr : global_strides.data(), box_dim.data(),
+      element_strides.data(), interleave, swizzle, l2_promotion, oob_fill);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &tensor_map, sizeof(tensor_map)) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+#endif

--- a/manual_server.h
+++ b/manual_server.h
@@ -89,5 +89,8 @@ int handle_manual_cuGraphLaunch(conn_t *conn);
 int handle_manual_cuEventSynchronize(conn_t *conn);
 int handle_manual_cuOccupancyMaxPotentialBlockSize(conn_t *conn,
                                                    bool with_flags);
+#if CUDA_VERSION >= 12000
+int handle_manual_cuTensorMapEncodeTiled(conn_t *conn);
+#endif
 
 #endif

--- a/server.cpp
+++ b/server.cpp
@@ -293,6 +293,10 @@ lupine_manual_handlers() {
        {handle_manual_cuStreamSynchronize, "cuStreamSynchronize"}},
       {RPC_cuEventSynchronize,
        {handle_manual_cuEventSynchronize, "cuEventSynchronize"}},
+#if CUDA_VERSION >= 12000
+      {RPC_cuTensorMapEncodeTiled,
+       {handle_manual_cuTensorMapEncodeTiled, "cuTensorMapEncodeTiled"}},
+#endif
   };
   return handlers;
 }


### PR DESCRIPTION
## Summary

- add a manual, rank-aware RPC path for `cuTensorMapEncodeTiled`, transferring only the dimension and stride entries selected by `tensorRank`
- preserve local routing and managed-host alias translation while exposing the CUDA symbol through `cuGetProcAddress`
- expose `nvmlDeviceGetCudaComputeCapability` through the generated NVML client/server path and verify the shim export

## Context

vLLM 0.25.1 requires both symbols. The existing tensor-map generator cannot infer its rank-dependent array lengths, while the NVML function was absent from the generated RPC list.

This is the CUDA/NVML API-coverage portion extracted from #513. PR #513 remains unchanged, and the original commit authorship is preserved. Related to #512.

## Validation

- CUDA 13.1 codegen and formatting are reproducible
- Release builds pass for `lupine_driver`, `lupine_nvml`, and `lupine_driver_server`
- `nvml_ecc_exports`: 1/1 passed
- `nm` confirms `cuTensorMapEncodeTiled` and `nvmlDeviceGetCudaComputeCapability` are exported
- `git diff --check` passes

The vLLM/GPU smoke test was not rerun locally because this environment has no NVIDIA runtime.
