### PR TITLE
Translate client host UVA aliases for pointer APIs and generic copies

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -8821,6 +8821,8 @@ lupine_manual_function_map() {
       {"cuDevicePrimaryCtxReset_v2", (void *)cuDevicePrimaryCtxReset_v2},
       {"cuMemcpyHtoD", (void *)cuMemcpyHtoD_v2},
       {"cuMemcpyHtoD_v2", (void *)cuMemcpyHtoD_v2},
+      {"cuMemcpy", (void *)cuMemcpy},
+      {"cuMemcpy_ptds", (void *)cuMemcpy},
       {"cuMemcpyDtoH", (void *)cuMemcpyDtoH_v2},
       {"cuMemcpyDtoH_v2", (void *)cuMemcpyDtoH_v2},
       {"cuMemcpyDtoA", (void *)cuMemcpyDtoA_v2},

--- a/client.cpp
+++ b/client.cpp
@@ -813,8 +813,6 @@ extern "C" void *lupine_real_cuda_symbol(const char *name) {
   return lupine_real_dlsym(handle, name);
 }
 
-static bool lupine_is_local_address(const void *ptr);
-
 // Client-answered entry points must fail with NOT_INITIALIZED until cuInit;
 // forwarded ones get the server's own state.
 static std::atomic<bool> lupine_cuda_initialized{false};
@@ -5300,20 +5298,6 @@ extern "C" CUresult cuMemcpyDtoHAsync(void *dstHost, CUdeviceptr srcDevice,
   return cuMemcpyDtoHAsync_v2(dstHost, srcDevice, ByteCount, hStream);
 }
 
-static bool lupine_is_local_address(const void *ptr) {
-  if (ptr == nullptr) {
-    return false;
-  }
-  long page_size = sysconf(_SC_PAGESIZE);
-  if (page_size <= 0) {
-    return false;
-  }
-  uintptr_t page = reinterpret_cast<uintptr_t>(ptr) &
-                   ~(static_cast<uintptr_t>(page_size) - 1);
-  unsigned char vec = 0;
-  return mincore(reinterpret_cast<void *>(page), page_size, &vec) == 0;
-}
-
 static size_t lupine_memcpy3d_host_span(const CUDA_MEMCPY3D &copy,
                                         bool source) {
   size_t x = source ? copy.srcXInBytes : copy.dstXInBytes;
@@ -5585,52 +5569,6 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
 #endif
 extern "C" CUresult cuMemcpy3D(const CUDA_MEMCPY3D *pCopy) {
   return cuMemcpy3D_v2(pCopy);
-}
-
-extern "C" CUresult cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src,
-                                  size_t ByteCount, CUstream hStream) {
-  bool dst_is_host = lupine_is_local_address(reinterpret_cast<void *>(dst));
-  bool src_is_host = lupine_is_local_address(reinterpret_cast<void *>(src));
-
-  if (dst_is_host && !src_is_host) {
-    return cuMemcpyDtoHAsync_v2(reinterpret_cast<void *>(dst), src, ByteCount,
-                                hStream);
-  }
-  if (!dst_is_host && src_is_host) {
-    return cuMemcpyHtoDAsync_v2(dst, reinterpret_cast<const void *>(src),
-                                ByteCount, hStream);
-  }
-  if (dst_is_host && src_is_host) {
-    memcpy(reinterpret_cast<void *>(dst), reinterpret_cast<const void *>(src),
-           ByteCount);
-    return CUDA_SUCCESS;
-  }
-
-  conn_t *conn = lupine_rpc_conn_for_deviceptr(dst);
-  conn_t *src_conn = lupine_rpc_conn_for_deviceptr(src);
-  if (conn != src_conn) {
-    return lupine_cuMemcpyDtoD_via_client(dst, src, ByteCount, hStream, true);
-  }
-  CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuMemcpyAsync) < 0 ||
-      rpc_write(conn, &dst, sizeof(dst)) < 0 ||
-      rpc_write(conn, &src, sizeof(src)) < 0 ||
-      rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
-      rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return return_value;
-}
-
-#ifdef cuMemcpyAsync_ptsz
-#undef cuMemcpyAsync_ptsz
-#endif
-extern "C" CUresult cuMemcpyAsync_ptsz(CUdeviceptr dst, CUdeviceptr src,
-                                       size_t ByteCount, CUstream hStream) {
-  return cuMemcpyAsync(dst, src, ByteCount, hStream);
 }
 
 static CUresult

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2694,6 +2694,7 @@ CUresult cuMemHostRegister_v2(void *p, size_t bytesize, unsigned int Flags);
  */
 CUresult cuMemHostUnregister(void *p);
 /**
+ * @disabled client
  * @routingkey DEVICEPTR dst
  * @crossservercopy dst src ByteCount
  * @param dst SEND_ONLY

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -1301,29 +1301,6 @@ CUresult cuIpcCloseMemHandle(CUdeviceptr dptr) {
   return return_value;
 }
 
-CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount) {
-  lupine_route route = lupine_route_for_deviceptr(dst);
-  if (!lupine_deviceptrs_share_route(dst, src)) {
-    return lupine_cuMemcpyDtoD_via_client(dst, src, ByteCount, nullptr, false);
-  }
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemcpy", &return_value, dst, src, ByteCount)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
-      rpc_write(conn, &dst, sizeof(CUdeviceptr)) < 0 ||
-      rpc_write(conn, &src, sizeof(CUdeviceptr)) < 0 ||
-      rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
                       CUdeviceptr srcDevice, CUcontext srcContext,
                       size_t ByteCount) {
@@ -6520,14 +6497,6 @@ extern "C" CUresult cuGraphExecUpdate(CUgraphExec hGraphExec, CUgraph hGraph,
 
 #endif
 
-#ifdef cuMemcpy_ptds
-#undef cuMemcpy_ptds
-#endif
-extern "C" CUresult cuMemcpy_ptds(CUdeviceptr dst, CUdeviceptr src,
-                                  size_t ByteCount) {
-  return cuMemcpy(dst, src, ByteCount);
-}
-
 #ifdef cuMemcpyPeer_ptds
 #undef cuMemcpyPeer_ptds
 #endif
@@ -7131,7 +7100,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemsetD2D32", (void *)cuMemsetD2D32_v2},
     {"cuIpcOpenMemHandle", (void *)cuIpcOpenMemHandle_v2},
     {"cuGraphExecUpdate", (void *)cuGraphExecUpdate_v2},
-    {"cuMemcpy_ptds", (void *)cuMemcpy},
     {"cuMemcpyPeer_ptds", (void *)cuMemcpyPeer},
     {"cuMemcpyPeerAsync_ptsz", (void *)cuMemcpyPeerAsync},
     {"cuMemsetD8Async_ptsz", (void *)cuMemsetD8Async},

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -30,10 +30,14 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
                          size_t ByteCount);
 CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
                          size_t ByteCount);
-extern "C" CUresult
-lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
-                               size_t ByteCount, CUstream stream,
-                               bool async_copy);
+CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                         size_t ByteCount);
+CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
+                              size_t ByteCount, CUstream hStream);
+CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
+                              size_t ByteCount, CUstream hStream);
+CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                              size_t ByteCount, CUstream hStream);
 
 #ifdef CU_MEM_LOCATION_TYPE_HOST
 static constexpr CUmemLocationType LUPINE_CU_MEM_LOCATION_TYPE_HOST =
@@ -868,7 +872,7 @@ static void lupine_mark_mapped_device_dirty(void *host) {
   }
 }
 
-static bool lupine_is_client_host_address(CUdeviceptr ptr) {
+static bool lupine_is_client_mapped_address(CUdeviceptr ptr) {
   if (ptr == 0) {
     return false;
   }
@@ -882,61 +886,58 @@ static bool lupine_is_client_host_address(CUdeviceptr ptr) {
   return mincore(reinterpret_cast<void *>(page), page_size, &residency) == 0;
 }
 
+static bool lupine_copy_pointer_is_host(CUdeviceptr ptr) {
+  if (lupine_host_ptr_is_tracked(ptr)) {
+    return true;
+  }
+  if (lupine_deviceptr_is_tracked(ptr)) {
+    return false;
+  }
+  return lupine_is_client_mapped_address(ptr);
+}
+
+enum class lupine_copy_direction {
+  host_to_host,
+  host_to_device,
+  device_to_host,
+  device_to_device,
+};
+
+static lupine_copy_direction lupine_infer_copy_direction(CUdeviceptr dst,
+                                                         CUdeviceptr src) {
+  const bool dst_is_host = lupine_copy_pointer_is_host(dst);
+  const bool src_is_host = lupine_copy_pointer_is_host(src);
+  if (dst_is_host && src_is_host) {
+    return lupine_copy_direction::host_to_host;
+  }
+  if (src_is_host) {
+    return lupine_copy_direction::host_to_device;
+  }
+  if (dst_is_host) {
+    return lupine_copy_direction::device_to_host;
+  }
+  return lupine_copy_direction::device_to_device;
+}
+
 extern "C" CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src,
                              size_t ByteCount) {
   if (ByteCount == 0) {
     return CUDA_SUCCESS;
   }
 
-  CUdeviceptr dst_rpc = dst;
-  CUdeviceptr src_rpc = src;
-  bool dst_host_alias =
-      lupine_translate_client_host_ptr_to_server(dst, &dst_rpc);
-  bool src_host_alias =
-      lupine_translate_client_host_ptr_to_server(src, &src_rpc);
-  bool dst_device = lupine_deviceptr_is_tracked(dst_rpc);
-  bool src_device = lupine_deviceptr_is_tracked(src_rpc);
-  bool dst_is_host =
-      dst_host_alias || (!dst_device && lupine_is_client_host_address(dst));
-  bool src_is_host =
-      src_host_alias || (!src_device && lupine_is_client_host_address(src));
-
-  if (dst_is_host && src_is_host) {
+  switch (lupine_infer_copy_direction(dst, src)) {
+  case lupine_copy_direction::host_to_host:
     memmove(reinterpret_cast<void *>(dst), reinterpret_cast<const void *>(src),
             ByteCount);
     return CUDA_SUCCESS;
+  case lupine_copy_direction::host_to_device:
+    return cuMemcpyHtoD_v2(dst, reinterpret_cast<const void *>(src), ByteCount);
+  case lupine_copy_direction::device_to_host:
+    return cuMemcpyDtoH_v2(reinterpret_cast<void *>(dst), src, ByteCount);
+  case lupine_copy_direction::device_to_device:
+    return cuMemcpyDtoD_v2(dst, src, ByteCount);
   }
-  if (src_is_host) {
-    return cuMemcpyHtoD_v2(dst_rpc, reinterpret_cast<const void *>(src),
-                           ByteCount);
-  }
-  if (dst_is_host) {
-    return cuMemcpyDtoH_v2(reinterpret_cast<void *>(dst), src_rpc, ByteCount);
-  }
-
-  lupine_route route = lupine_route_for_deviceptr(dst_rpc);
-  if (!lupine_deviceptrs_share_route(dst_rpc, src_rpc)) {
-    return lupine_cuMemcpyDtoD_via_client(dst_rpc, src_rpc, ByteCount, nullptr,
-                                          false);
-  }
-
-  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemcpy", &result, dst, src, ByteCount)) {
-    return result;
-  }
-
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
-      rpc_write(conn, &dst_rpc, sizeof(dst_rpc)) < 0 ||
-      rpc_write(conn, &src_rpc, sizeof(src_rpc)) < 0 ||
-      rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return result;
+  return CUDA_ERROR_INVALID_VALUE;
 }
 
 #ifdef cuMemcpy_ptds
@@ -945,6 +946,33 @@ extern "C" CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src,
 extern "C" CUresult cuMemcpy_ptds(CUdeviceptr dst, CUdeviceptr src,
                                    size_t ByteCount) {
   return cuMemcpy(dst, src, ByteCount);
+}
+
+extern "C" CUresult cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src,
+                                  size_t ByteCount, CUstream hStream) {
+  switch (lupine_infer_copy_direction(dst, src)) {
+  case lupine_copy_direction::host_to_host:
+    memcpy(reinterpret_cast<void *>(dst), reinterpret_cast<const void *>(src),
+           ByteCount);
+    return CUDA_SUCCESS;
+  case lupine_copy_direction::host_to_device:
+    return cuMemcpyHtoDAsync_v2(dst, reinterpret_cast<const void *>(src),
+                                ByteCount, hStream);
+  case lupine_copy_direction::device_to_host:
+    return cuMemcpyDtoHAsync_v2(reinterpret_cast<void *>(dst), src, ByteCount,
+                                hStream);
+  case lupine_copy_direction::device_to_device:
+    return cuMemcpyDtoDAsync_v2(dst, src, ByteCount, hStream);
+  }
+  return CUDA_ERROR_INVALID_VALUE;
+}
+
+#ifdef cuMemcpyAsync_ptsz
+#undef cuMemcpyAsync_ptsz
+#endif
+extern "C" CUresult cuMemcpyAsync_ptsz(CUdeviceptr dst, CUdeviceptr src,
+                                       size_t ByteCount, CUstream hStream) {
+  return cuMemcpyAsync(dst, src, ByteCount, hStream);
 }
 
 CUresult lupine_sync_mapped_host_to_device_for_launch(

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -26,8 +26,14 @@ static void lupine_pointer_attribute_cache_clear();
 #include "rpc.h"
 
 extern int rpc_size();
+CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
+                         size_t ByteCount);
 CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
                          size_t ByteCount);
+extern "C" CUresult
+lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                               size_t ByteCount, CUstream stream,
+                               bool async_copy);
 
 #ifdef CU_MEM_LOCATION_TYPE_HOST
 static constexpr CUmemLocationType LUPINE_CU_MEM_LOCATION_TYPE_HOST =
@@ -806,6 +812,33 @@ extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
   return true;
 }
 
+static bool
+lupine_translate_client_host_ptr_to_server(CUdeviceptr ptr,
+                                            CUdeviceptr *translated,
+                                            CUdeviceptr *server_base = nullptr,
+                                            CUdeviceptr *device_base = nullptr) {
+  void *host = reinterpret_cast<void *>(ptr);
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(host);
+  if (it == lupine_mutable_host_allocations_locked().end() ||
+      it->second.server_host_ptr == 0 || it->second.local_cuda) {
+    return false;
+  }
+
+  uintptr_t client_base = reinterpret_cast<uintptr_t>(it->first);
+  uintptr_t client_addr = reinterpret_cast<uintptr_t>(host);
+  if (translated != nullptr) {
+    *translated = it->second.server_host_ptr + (client_addr - client_base);
+  }
+  if (server_base != nullptr) {
+    *server_base = it->second.server_host_ptr;
+  }
+  if (device_base != nullptr) {
+    *device_base = it->second.device_ptr;
+  }
+  return true;
+}
+
 static bool lupine_host_ptr_is_tracked(CUdeviceptr ptr) {
   void *host = reinterpret_cast<void *>(ptr);
   std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
@@ -833,6 +866,85 @@ static void lupine_mark_mapped_device_dirty(void *host) {
       !it->second.client_to_server_only) {
     it->second.device_dirty = true;
   }
+}
+
+static bool lupine_is_client_host_address(CUdeviceptr ptr) {
+  if (ptr == 0) {
+    return false;
+  }
+  long page_size = sysconf(_SC_PAGESIZE);
+  if (page_size <= 0) {
+    return false;
+  }
+  uintptr_t page = static_cast<uintptr_t>(ptr) &
+                   ~(static_cast<uintptr_t>(page_size) - 1);
+  unsigned char residency = 0;
+  return mincore(reinterpret_cast<void *>(page), page_size, &residency) == 0;
+}
+
+extern "C" CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src,
+                             size_t ByteCount) {
+  if (ByteCount == 0) {
+    return CUDA_SUCCESS;
+  }
+
+  CUdeviceptr dst_rpc = dst;
+  CUdeviceptr src_rpc = src;
+  bool dst_host_alias =
+      lupine_translate_client_host_ptr_to_server(dst, &dst_rpc);
+  bool src_host_alias =
+      lupine_translate_client_host_ptr_to_server(src, &src_rpc);
+  bool dst_device = lupine_deviceptr_is_tracked(dst_rpc);
+  bool src_device = lupine_deviceptr_is_tracked(src_rpc);
+  bool dst_is_host =
+      dst_host_alias || (!dst_device && lupine_is_client_host_address(dst));
+  bool src_is_host =
+      src_host_alias || (!src_device && lupine_is_client_host_address(src));
+
+  if (dst_is_host && src_is_host) {
+    memmove(reinterpret_cast<void *>(dst), reinterpret_cast<const void *>(src),
+            ByteCount);
+    return CUDA_SUCCESS;
+  }
+  if (src_is_host) {
+    return cuMemcpyHtoD_v2(dst_rpc, reinterpret_cast<const void *>(src),
+                           ByteCount);
+  }
+  if (dst_is_host) {
+    return cuMemcpyDtoH_v2(reinterpret_cast<void *>(dst), src_rpc, ByteCount);
+  }
+
+  lupine_route route = lupine_route_for_deviceptr(dst_rpc);
+  if (!lupine_deviceptrs_share_route(dst_rpc, src_rpc)) {
+    return lupine_cuMemcpyDtoD_via_client(dst_rpc, src_rpc, ByteCount, nullptr,
+                                          false);
+  }
+
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpy", &result, dst, src, ByteCount)) {
+    return result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
+      rpc_write(conn, &dst_rpc, sizeof(dst_rpc)) < 0 ||
+      rpc_write(conn, &src_rpc, sizeof(src_rpc)) < 0 ||
+      rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return result;
+}
+
+#ifdef cuMemcpy_ptds
+#undef cuMemcpy_ptds
+#endif
+extern "C" CUresult cuMemcpy_ptds(CUdeviceptr dst, CUdeviceptr src,
+                                   size_t ByteCount) {
+  return cuMemcpy(dst, src, ByteCount);
 }
 
 CUresult lupine_sync_mapped_host_to_device_for_launch(
@@ -2183,6 +2295,13 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
 
   CUdeviceptr query_ptr = ptr;
   bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  CUdeviceptr remote_host_base = 0;
+  CUdeviceptr remote_device_base = 0;
+  bool remote_host_alias = false;
+  if (!managed_alias) {
+    remote_host_alias = lupine_translate_client_host_ptr_to_server(
+        ptr, &query_ptr, &remote_host_base, &remote_device_base);
+  }
   lupine_route route = lupine_route_for_deviceptr(query_ptr);
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(void *, CUpointer_attribute, CUdeviceptr);
@@ -2204,9 +2323,15 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
   }
   if (return_value == CUDA_SUCCESS) {
     memcpy(data, value, value_size);
-    if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+    if ((managed_alias || remote_host_alias) &&
+        attribute == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
       void *host = reinterpret_cast<void *>(ptr);
       memcpy(data, &host, sizeof(host));
+    } else if (remote_host_alias &&
+               attribute == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
+      CUdeviceptr device_alias =
+          remote_device_base + (query_ptr - remote_host_base);
+      memcpy(data, &device_alias, sizeof(device_alias));
     } else if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
       int is_managed = 1;
       memcpy(data, &is_managed, sizeof(is_managed));
@@ -2226,7 +2351,9 @@ extern "C" CUresult cuPointerSetAttribute(const void *value,
   }
 
   CUdeviceptr target_ptr = ptr;
-  lupine_translate_managed_host_ptr(ptr, &target_ptr);
+  if (!lupine_translate_managed_host_ptr(ptr, &target_ptr)) {
+    lupine_translate_client_host_ptr_to_server(ptr, &target_ptr);
+  }
   lupine_route route = lupine_route_for_deviceptr(target_ptr);
   if (lupine_route_is_local(route)) {
     using real_fn_t =
@@ -2316,6 +2443,13 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
 
   CUdeviceptr query_ptr = ptr;
   bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  CUdeviceptr remote_host_base = 0;
+  CUdeviceptr remote_device_base = 0;
+  bool remote_host_alias = false;
+  if (!managed_alias) {
+    remote_host_alias = lupine_translate_client_host_ptr_to_server(
+        ptr, &query_ptr, &remote_host_base, &remote_device_base);
+  }
   lupine_route route = lupine_route_for_deviceptr(query_ptr);
   if (lupine_route_is_local(route)) {
     using real_fn_t =
@@ -2388,8 +2522,13 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
   // aliases are recomputed for the queried pointer on a hit.
   lupine_pointer_attribute_cache_key cache_key;
   std::vector<std::vector<unsigned char>> cached_values;
-  bool cacheable =
-      managed_alias && lupine_managed_host_alias_base(ptr, &cache_key.ptr);
+  bool cacheable = false;
+  if (managed_alias) {
+    cacheable = lupine_managed_host_alias_base(ptr, &cache_key.ptr);
+  } else if (remote_host_alias) {
+    cache_key.ptr = remote_host_base;
+    cacheable = true;
+  }
   if (cacheable) {
     cache_key.attributes.assign(attributes, attributes + numAttributes);
     if (lupine_pointer_attribute_cache().find(cache_key, cached_values)) {
@@ -2398,12 +2537,20 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
           return CUDA_ERROR_INVALID_VALUE;
         }
         memcpy(data[i], cached_values[i].data(), cached_values[i].size());
-        if (attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+        if ((managed_alias || remote_host_alias) &&
+            attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
           void *host = reinterpret_cast<void *>(ptr);
           memcpy(data[i], &host, sizeof(host));
-        } else if (attributes[i] == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
+        } else if (managed_alias &&
+                   attributes[i] == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
           memcpy(data[i], &query_ptr, sizeof(query_ptr));
-        } else if (attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
+        } else if (remote_host_alias &&
+                   attributes[i] == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
+          CUdeviceptr device_alias =
+              remote_device_base + (query_ptr - remote_host_base);
+          memcpy(data[i], &device_alias, sizeof(device_alias));
+        } else if (managed_alias &&
+                   attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
           int is_managed = 1;
           memcpy(data[i], &is_managed, sizeof(is_managed));
         }
@@ -2450,9 +2597,15 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
         return CUDA_ERROR_INVALID_VALUE;
       }
       memcpy(data[i], values[i].data(), values[i].size());
-      if (managed_alias && attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+      if ((managed_alias || remote_host_alias) &&
+          attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
         void *host = reinterpret_cast<void *>(ptr);
         memcpy(data[i], &host, sizeof(host));
+      } else if (remote_host_alias &&
+                 attributes[i] == CU_POINTER_ATTRIBUTE_DEVICE_POINTER) {
+        CUdeviceptr device_alias =
+            remote_device_base + (query_ptr - remote_host_base);
+        memcpy(data[i], &device_alias, sizeof(device_alias));
       } else if (managed_alias &&
                  attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
         int is_managed = 1;


### PR DESCRIPTION
## Summary

- translate process-local pinned and mapped host addresses to their server allocation before pointer-attribute RPCs
- translate `HOST_POINTER` and `DEVICE_POINTER` results back to client-visible aliases, including batched cache hits and interior offsets
- centralize generic `cuMemcpy` and `cuMemcpyAsync` direction inference in `memcpy.cpp`, classifying tracked host/device aliases before falling back to client address mapping
- lower host-to-host, host-to-device, device-to-host, and device-to-device copies to the existing specialized paths, including routed and cross-server D2D behavior

## Context

Pinned host allocations have different virtual addresses in the client and server processes. Passing the client address through unchanged breaks vLLM's UVA initialization, pointer queries, and generic copies.

This is the host-UVA portion extracted from #513. PR #513 remains unchanged, and the original commit authorship is preserved. Related to #512.

## Validation

- rebased onto current `main` after #524 merged; final diff remains limited to four host-UVA/memcpy files
- CUDA 13.1 codegen is reproducible
- Release build passes
- CTest: 8 passed, 2 configured skips, 0 failed
- `nm` confirms `cuMemcpy`, `cuMemcpy_ptds`, `cuMemcpyAsync`, and `cuMemcpyAsync_ptsz` are exported
- mapped-host, pointer-set, and attribute-enum regression programs compile
- `git diff --check` passes

GPU runtime coverage could not run locally because no NVIDIA runtime is available. The pinned/pageable UVA Python regression referenced by #512 is not checked into this repository.
