### PR TITLE
Prevent destroyed CUDA events from entering query batches

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -3150,7 +3150,32 @@ extern "C" CUresult cuProfilerStop(void) {
 }
 
 CUresult cuStreamDestroy_v2(CUstream hStream);
-CUresult cuEventDestroy_v2(CUevent hEvent);
+extern "C" CUresult cuEventDestroy_v2(CUevent hEvent) {
+  std::unique_lock<std::shared_mutex> event_lifecycle_lock(
+      lupine_event_lifecycle_mutex());
+  lupine_route route = lupine_route_for_event(hEvent);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  using real_fn_t = CUresult (*)(CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuEventDestroy_v2", &result, hEvent)) {
+    if (result == CUDA_SUCCESS) {
+      lupine_forget_event_owner(hEvent);
+    }
+    return result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (result == CUDA_SUCCESS) {
+    lupine_forget_event_owner(hEvent);
+  }
+  return result;
+}
 CUresult cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart,
                                CUevent hEnd);
 CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags);
@@ -4161,6 +4186,8 @@ extern "C" CUresult cuEventQuery(CUevent hEvent) {
   if (conn == nullptr) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
+  std::shared_lock<std::shared_mutex> event_lifecycle_lock(
+      lupine_event_lifecycle_mutex());
   uint64_t recorded = 0;
   if (!lupine_event_query_needed(hEvent, &recorded)) {
     return lupine_sync_mapped_device_to_host();
@@ -8717,6 +8744,7 @@ lupine_manual_function_map() {
       {"cuProfilerStop", (void *)cuProfilerStop},
       {"cuStreamDestroy", (void *)cuStreamDestroy},
       {"cuEventDestroy", (void *)cuEventDestroy},
+      {"cuEventDestroy_v2", (void *)cuEventDestroy_v2},
       {"cuEventElapsedTime", (void *)cuEventElapsedTime},
       {"cuMemPoolSetAttribute", (void *)cuMemPoolSetAttribute},
       {"cuMemPoolGetAttribute", (void *)cuMemPoolGetAttribute},

--- a/client_routing.h
+++ b/client_routing.h
@@ -115,6 +115,7 @@ extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size,
 extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);
 extern "C" void lupine_forget_context_owner(CUcontext ctx);
 extern "C" void lupine_forget_stream_owner(CUstream stream);
+extern "C" void lupine_forget_event_owner(CUevent event);
 
 extern "C" void lupine_note_context_owner_route(CUcontext ctx,
                                                 lupine_route route);

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -3563,6 +3563,7 @@ CUresult cuEventQuery(CUevent hEvent);
  */
 CUresult cuEventSynchronize(CUevent hEvent);
 /**
+ * @disabled client
  * @routingkey EVENT hEvent
  * @param hEvent SEND_ONLY
  */

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -3044,24 +3044,6 @@ CUresult cuEventSynchronize(CUevent hEvent) {
   return return_value;
 }
 
-CUresult cuEventDestroy_v2(CUevent hEvent) {
-  lupine_route route = lupine_route_for_event(hEvent);
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUevent);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventDestroy_v2",
-                                                  &return_value, hEvent)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart,
                                CUevent hEnd) {
   lupine_route route = lupine_route_for_event(hStart);

--- a/events.cpp
+++ b/events.cpp
@@ -19,6 +19,15 @@ void lupine_event_note_recorded(lupine_event_table *table, CUevent event) {
   *victim = {event, seq, 0};
 }
 
+void lupine_event_note_destroyed(lupine_event_table *table, CUevent event) {
+  std::lock_guard<std::mutex> lock(table->mutex);
+  for (auto &slot : table->slots) {
+    if (slot.event == event) {
+      slot = {};
+    }
+  }
+}
+
 bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
                                uint64_t *recorded) {
   bool copies_pending = table->dtoh_issued.load(std::memory_order_relaxed) !=
@@ -94,8 +103,17 @@ static lupine_event_table &lupine_event_table_instance() {
   return table;
 }
 
+std::shared_mutex &lupine_event_lifecycle_mutex() {
+  static std::shared_mutex mutex;
+  return mutex;
+}
+
 void lupine_note_event_recorded(CUevent event) {
   lupine_event_note_recorded(&lupine_event_table_instance(), event);
+}
+
+void lupine_note_event_destroyed(CUevent event) {
+  lupine_event_note_destroyed(&lupine_event_table_instance(), event);
 }
 
 bool lupine_event_query_needed(CUevent event, uint64_t *recorded) {

--- a/events.h
+++ b/events.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <cstdint>
 #include <mutex>
+#include <shared_mutex>
 
 #define LUPINE_CUDA_COMPAT_TYPES_ONLY
 #include "cuda_compat.h"
@@ -41,6 +42,7 @@ struct lupine_event_table {
 typedef conn_t *(*lupine_event_conn_resolver)(CUevent event);
 
 void lupine_event_note_recorded(lupine_event_table *table, CUevent event);
+void lupine_event_note_destroyed(lupine_event_table *table, CUevent event);
 bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
                                uint64_t *recorded);
 uint32_t lupine_event_collect_query_prefetch(
@@ -56,6 +58,8 @@ void lupine_event_note_dtoh_drained(lupine_event_table *table,
                                     uint64_t drained);
 
 void lupine_note_event_recorded(CUevent event);
+void lupine_note_event_destroyed(CUevent event);
+std::shared_mutex &lupine_event_lifecycle_mutex();
 bool lupine_event_query_needed(CUevent event, uint64_t *recorded);
 uint32_t lupine_collect_event_query_prefetch(CUevent exclude, conn_t *conn,
                                              CUevent *events,

--- a/events_test.cpp
+++ b/events_test.cpp
@@ -168,6 +168,26 @@ bool test_query_results_cache_only_successes() {
   return true;
 }
 
+bool test_destroyed_event_is_removed_from_prefetch() {
+  lupine_event_table table;
+  CUevent events[kLupineEventQueryBatch];
+  uint64_t recorded[kLupineEventQueryBatch];
+  CUevent primary = fake_event(0);
+  CUevent destroyed = fake_event(1);
+  lupine_event_note_recorded(&table, primary);
+  lupine_event_note_recorded(&table, destroyed);
+  lupine_event_note_destroyed(&table, destroyed);
+
+  uint32_t count = lupine_event_collect_query_prefetch(
+      &table, nullptr, kConnA, resolve_all_to_a, events, recorded);
+  if (count != 1 || events[0] != primary ||
+      batch_contains(events, count, destroyed)) {
+    std::cerr << "FAIL: destroyed event remained in the prefetch batch\n";
+    return false;
+  }
+  return true;
+}
+
 bool test_pending_dtoh_suppresses_local_answer() {
   lupine_event_table table;
   CUevent event = fake_event(0);
@@ -200,6 +220,7 @@ int main() {
       !test_eviction_is_oldest_recorded() ||
       !test_prefetch_batch_excludes_and_filters() ||
       !test_query_results_cache_only_successes() ||
+      !test_destroyed_event_is_removed_from_prefetch() ||
       !test_pending_dtoh_suppresses_local_answer()) {
     return 1;
   }

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3521,20 +3521,29 @@ int handle_manual_lupineEventQueryBatch(conn_t *conn) {
   uint32_t count = 0;
   if (rpc_read(conn, &count, sizeof(count)) < 0 || count == 0 ||
       count > LUPINE_EVENT_QUERY_BATCH_MAX) {
+    LUPINE_LOG_ERROR("cuEventQuery RPC failed while reading count: count="
+                     << count);
     return -1;
   }
   CUevent events[LUPINE_EVENT_QUERY_BATCH_MAX];
   if (rpc_read(conn, events, count * sizeof(*events)) < 0) {
+    LUPINE_LOG_ERROR("cuEventQuery RPC failed while reading events");
     return -1;
   }
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
+    LUPINE_LOG_ERROR("cuEventQuery RPC failed while finishing request");
     return -1;
   }
 
   CUresult results[LUPINE_EVENT_QUERY_BATCH_MAX];
   for (uint32_t i = 0; i < count; ++i) {
     results[i] = cuEventQuery(events[i]);
+    if (results[i] != CUDA_SUCCESS && results[i] != CUDA_ERROR_NOT_READY) {
+      LUPINE_LOG_ERROR("cuEventQuery failed on the server: result="
+                       << results[i] << " event=" << events[i]
+                       << " batch_index=" << i);
+    }
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||

--- a/routing.cpp
+++ b/routing.cpp
@@ -11,6 +11,7 @@
 #include "cache.h"
 #include "client_routing.h"
 #include "codegen/gen_api.h"
+#include "events.h"
 
 extern int rpc_open();
 extern int rpc_size();
@@ -614,6 +615,14 @@ extern "C" void lupine_forget_context_owner(CUcontext ctx) {
 extern "C" void lupine_forget_stream_owner(CUstream stream) {
   std::lock_guard<std::mutex> lock(lupine_routing_mutex());
   lupine_owners<CUstream>().erase(stream);
+}
+
+extern "C" void lupine_forget_event_owner(CUevent event) {
+  {
+    std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+    lupine_owners<CUevent>().erase(event);
+  }
+  lupine_note_event_destroyed(event);
 }
 
 template <typename Handle>

--- a/server.cpp
+++ b/server.cpp
@@ -77,6 +77,14 @@ lupine_reap_connection_children(std::unordered_set<pid_t> &children) {
     if (child <= 0) {
       break;
     }
+    if (WIFSIGNALED(status)) {
+      LUPINE_LOG_ERROR("Connection child "
+                       << child << " terminated by signal "
+                       << WTERMSIG(status));
+    } else if (!WIFEXITED(status) || WEXITSTATUS(status) != EXIT_SUCCESS) {
+      LUPINE_LOG_ERROR("Connection child "
+                       << child << " exited abnormally with status " << status);
+    }
     children.erase(child);
   }
   lupine_parent_child_exited = 0;


### PR DESCRIPTION
## Summary

- implement `cuEventDestroy_v2` manually so successful destruction removes routing ownership and cached query state
- serialize remote event queries and prefetch batches against event destruction
- add unit coverage and server diagnostics for invalid event batches and crashed connection children

## Context

Destroyed events remained in the query-prefetch table and could later be sent to the server, where querying the stale handle crashed the connection child. Removing the cached entry alone is insufficient when destruction races with an in-flight batch.

This is the event-lifecycle portion extracted from #513. PR #513 remains unchanged, and the original commit authorship is preserved. Related to #512.

## Validation

- CUDA 13.1 codegen is reproducible
- Release client and server builds pass
- focused `events_test`: 1/1 passed
- full CTest: 8 passed, 2 configured skips, 0 failed
- `nm` confirms both `cuEventDestroy` and `cuEventDestroy_v2` are exported
- `git diff --check` passes

The GPU/PyTorch destroy-query reproduction could not run locally because this environment has no NVIDIA runtime or usable PyTorch installation.
