### PR TITLE
Componentize the build by RPC core and backend

### DIFF
--- a/.github/workflows/build-lambda-client.yml
+++ b/.github/workflows/build-lambda-client.yml
@@ -122,7 +122,7 @@ jobs:
                 -DCMAKE_BUILD_TYPE=Release \
                 -DCMAKE_LIBRARY_PATH="${CUDA_HOME}/lib64/stubs"
 
-          RUN cmake --build /opt/lupine-src/build --parallel --target lupine_cuda_client lupine_nvml
+          RUN cmake --build /opt/lupine-src/build --parallel --target lupine_cuda_client lupine_nvml_client
 
           RUN mkdir -p /opt/lib /opt/bin /opt/share/lupine \
               && cp /opt/lupine-src/build/libcuda.so.1 /opt/lib/libcuda.so.1 \

--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -551,7 +551,7 @@ jobs:
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
               cmake --build "$LUPINE_BUILD_DIR" --parallel \
-                --target lupine_cuda_client lupine_nvml lupine_driver_server
+                --target lupine_cuda_client lupine_nvml_client lupine_driver_server
               ln -sf libcuda.so.1 "$LUPINE_BUILD_DIR/libcuda.so"
               ln -sf libnvidia-ml.so.1 "$LUPINE_BUILD_DIR/libnvidia-ml.so"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,22 +2,100 @@ cmake_minimum_required(VERSION 3.18)
 
 project(LupineProject LANGUAGES C CXX)
 
+option(LUPINE_BUILD_CUDA "Build the CUDA client and server backend" ON)
+option(LUPINE_BUILD_NVML "Build the NVML client and server backend" ON)
+option(LUPINE_BUILD_HIP "Build the HIP client and server backend when present" ON)
 if(APPLE)
-  set(LUPINE_BUILD_SERVER_DEFAULT OFF)
+    set(LUPINE_BUILD_SERVER_DEFAULT OFF)
 else()
-  set(LUPINE_BUILD_SERVER_DEFAULT ON)
+    set(LUPINE_BUILD_SERVER_DEFAULT ON)
 endif()
-option(LUPINE_BUILD_SERVER "Build the CUDA driver server"
+option(LUPINE_BUILD_SERVER "Build the RPC server"
        ${LUPINE_BUILD_SERVER_DEFAULT})
 
-# Sanitizers are applied only to the CPU-only *_test executables (transport,
-# decoder, ipc, checkpoint), never the nvcc-compiled driver/server. Set to a
+# Sanitizers are applied only to the CPU-only *_test executables. Set to a
 # -fsanitize value such as "address,undefined" or "thread"; empty disables.
 set(LUPINE_SANITIZE "" CACHE STRING
     "Sanitizer for CPU test targets (e.g. address,undefined or thread)")
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(CTest)
+find_package(Threads REQUIRED)
+find_path(NGHTTP2_INCLUDE_DIR nghttp2/nghttp2.h REQUIRED)
+find_library(NGHTTP2_LIBRARY nghttp2 REQUIRED)
+find_package(OpenSSL QUIET)
+
+set(MIN_CUDA_VERSION 11.0)
+if(LUPINE_BUILD_CUDA OR LUPINE_BUILD_NVML)
+    if(LUPINE_BUILD_SERVER AND LUPINE_BUILD_CUDA)
+        find_package(CUDAToolkit REQUIRED)
+        if(NOT CUDAToolkit_VERSION)
+            message(FATAL_ERROR
+                "CUDA Toolkit is required for the CUDA server backend.")
+        endif()
+        if(CUDAToolkit_VERSION VERSION_LESS MIN_CUDA_VERSION)
+            message(FATAL_ERROR
+                "CUDA Toolkit must be >= ${MIN_CUDA_VERSION}; found ${CUDAToolkit_VERSION}")
+        endif()
+        message(STATUS "Found CUDA Toolkit version: ${CUDAToolkit_VERSION}")
+    else()
+        find_path(LUPINE_CUDA_HEADER_DIR cuda.h
+            HINTS
+                ${CUDAToolkit_ROOT}/include
+                $ENV{CUDA_HOME}/include
+                $ENV{CUDA_PATH}/include
+                /usr/local/cuda/include
+            REQUIRED)
+        list(APPEND CUDAToolkit_INCLUDE_DIRS ${LUPINE_CUDA_HEADER_DIR})
+        if(LUPINE_BUILD_NVML)
+            find_path(LUPINE_NVML_HEADER_DIR nvml.h
+                HINTS
+                    ${CUDAToolkit_ROOT}/include
+                    $ENV{CUDA_HOME}/include
+                    $ENV{CUDA_PATH}/include
+                    /usr/local/cuda/include
+                REQUIRED)
+            list(APPEND CUDAToolkit_INCLUDE_DIRS ${LUPINE_NVML_HEADER_DIR})
+        endif()
+        file(STRINGS "${LUPINE_CUDA_HEADER_DIR}/cuda.h"
+             LUPINE_CUDA_VERSION_LINE
+             REGEX "^#define CUDA_VERSION +[0-9]+$")
+        string(REGEX REPLACE ".*CUDA_VERSION +([0-9]+).*" "\\1"
+               LUPINE_CUDA_HEADER_VERSION "${LUPINE_CUDA_VERSION_LINE}")
+        message(STATUS
+            "Using client CUDA API headers version: ${LUPINE_CUDA_HEADER_VERSION}")
+    endif()
+endif()
+
+if(LUPINE_BUILD_SERVER AND NOT (LUPINE_BUILD_CUDA OR LUPINE_BUILD_NVML))
+    message(FATAL_ERROR
+        "LUPINE_BUILD_SERVER requires at least one available backend")
+endif()
+
+# HIP implementation sources arrive in the final #487 rebase. Keeping the
+# option default-on here makes that backend part of the normal build as soon as
+# those sources are present, rather than introducing a hidden opt-in later.
+if(LUPINE_BUILD_HIP)
+    message(STATUS "HIP backend requested; implementation is supplied by PR #487")
+endif()
+
+function(lupine_internal_target target)
+    set_target_properties(${target} PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+    )
+    target_include_directories(${target} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/codegen
+    )
+endfunction()
+
 function(lupine_apply_sanitizer target)
-    if (LUPINE_SANITIZE)
+    if(LUPINE_SANITIZE)
         target_compile_options(${target} PRIVATE
             -fsanitize=${LUPINE_SANITIZE} -fno-omit-frame-pointer
             -fno-sanitize-recover=all -g)
@@ -25,8 +103,7 @@ function(lupine_apply_sanitizer target)
     endif()
 endfunction()
 
-# Instrumented builds run several times slower, so give ctest more headroom.
-if (LUPINE_SANITIZE)
+if(LUPINE_SANITIZE)
     set(LUPINE_TEST_TIMEOUT_SCALE 8)
 else()
     set(LUPINE_TEST_TIMEOUT_SCALE 1)
@@ -36,376 +113,332 @@ function(lupine_scaled_timeout out base)
     set(${out} ${scaled} PARENT_SCOPE)
 endfunction()
 
-if (LUPINE_BUILD_SERVER AND NOT WIN32 AND NOT APPLE)
-    enable_language(CUDA)
-endif()
-
-set(MIN_CUDA_VERSION 11.0)
-
-if(NOT LUPINE_BUILD_SERVER)
-  find_path(LUPINE_CUDA_HEADER_DIR cuda.h REQUIRED)
-  find_path(LUPINE_NVML_HEADER_DIR nvml.h REQUIRED)
-  set(CUDAToolkit_INCLUDE_DIRS
-      "${LUPINE_CUDA_HEADER_DIR}"
-      "${LUPINE_NVML_HEADER_DIR}")
-  file(STRINGS "${LUPINE_CUDA_HEADER_DIR}/cuda.h" LUPINE_CUDA_VERSION_LINE
-       REGEX "^#define CUDA_VERSION +[0-9]+$")
-  string(REGEX REPLACE ".*CUDA_VERSION +([0-9]+).*" "\\1"
-         LUPINE_CUDA_HEADER_VERSION "${LUPINE_CUDA_VERSION_LINE}")
-  message(STATUS
-      "Using client CUDA API headers version: ${LUPINE_CUDA_HEADER_VERSION}")
-else()
-  find_package(CUDAToolkit REQUIRED)
-
-  if (NOT CUDAToolkit_VERSION)
-      message(FATAL_ERROR "CUDA Toolkit is required but not found.")
-  endif()
-
-  if (CUDAToolkit_VERSION VERSION_LESS MIN_CUDA_VERSION)
-      message(FATAL_ERROR "CUDA Toolkit version must be >= ${MIN_CUDA_VERSION}. Found: ${CUDAToolkit_VERSION}")
-  endif()
-
-  message(STATUS "Found CUDA Toolkit version: ${CUDAToolkit_VERSION}")
-endif()
-find_path(NGHTTP2_INCLUDE_DIR nghttp2/nghttp2.h REQUIRED)
-find_library(NGHTTP2_LIBRARY nghttp2 REQUIRED)
-# The server stays plaintext (front it with a TLS proxy); only the client links OpenSSL.
-find_package(OpenSSL QUIET)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-if (LUPINE_BUILD_SERVER AND NOT WIN32 AND NOT APPLE)
-    set(CMAKE_CUDA_STANDARD 14)
-    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-    set(CMAKE_CUDA_EXTENSIONS OFF)
-endif()
-
-include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/codegen
-    ${CUDAToolkit_INCLUDE_DIRS}
-    ${NGHTTP2_INCLUDE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/lz4/lib
-)
-
-# LZ4 is vendored as a git subtree (third_party/lz4, BSD-2-Clause) so builds do
-# not depend on a system liblz4. It is built as a plain C static library to keep
-# it out of the CUDA source handling below.
-add_library(lupine_lz4 STATIC ${CMAKE_CURRENT_SOURCE_DIR}/third_party/lz4/lib/lz4.c)
+# Vendored LZ4 keeps the neutral core independent of host package versions.
+add_library(lupine_lz4 STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/lz4/lib/lz4.c)
 set_target_properties(lupine_lz4 PROPERTIES POSITION_INDEPENDENT_CODE ON)
-# Unoptimized LZ4 compresses slower than the wire, turning compression into a
-# slowdown, so keep it optimized even when no CMAKE_BUILD_TYPE is set.
+target_include_directories(lupine_lz4 PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/lz4/lib)
 if(NOT MSVC AND NOT CMAKE_BUILD_TYPE)
-  target_compile_options(lupine_lz4 PRIVATE -O2)
+    target_compile_options(lupine_lz4 PRIVATE -O2)
 endif()
 
-set(CUDA_CLIENT_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/transport.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
+# Accelerator-neutral wire protocol, HTTP/2, compression, and platform IPC.
+add_library(lupine_rpc_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipc.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cuda_client.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/events.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/routing.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/copy_pipeline.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_cuda_client.cpp
-)
-
-set(SERVER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/server_checkpoint.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/server.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rpc_server.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cuda_server.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/copy_pipeline.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/nvml_server.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipc.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_cuda_server.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/codegen/registry.cpp
 )
-
-set(NVML_CLIENT_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/transport.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/nvml_client.cpp
-)
-
-set(CUDA_CLIENT_HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/cache.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/client_routing.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/transport.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipc.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_cuda_client.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/copy_pipeline.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/cuda_profiler_compat.h
-)
-
-set(SERVER_HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint_provider.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lupine_platform.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/cuda_server.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/copy_pipeline.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/nvml_server.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipc.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/rpc.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/rpc_server.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/server_checkpoint.h
-)
-
-set(CUDA_CLIENT_OUTPUT lupine_cuda_client)
-set(NVML_CLIENT_OUTPUT lupine_nvml)
-set(SERVER_OUTPUT lupine_driver_server)
-
-add_library(${CUDA_CLIENT_OUTPUT} SHARED
-    ${CUDA_CLIENT_SOURCES}
-    ${CUDA_CLIENT_HEADERS}
-)
-target_include_directories(${CUDA_CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-target_compile_definitions(${CUDA_CLIENT_OUTPUT} PRIVATE LUPINE_RPC_CLIENT)
+lupine_internal_target(lupine_rpc_core)
+target_include_directories(lupine_rpc_core
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE ${NGHTTP2_INCLUDE_DIR})
+target_link_libraries(lupine_rpc_core PUBLIC
+    Threads::Threads ${NGHTTP2_LIBRARY} lupine_lz4)
 if(OpenSSL_FOUND)
-  target_compile_definitions(${CUDA_CLIENT_OUTPUT} PRIVATE LUPINE_TLS_OPENSSL)
-  target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    target_compile_definitions(lupine_rpc_core PRIVATE LUPINE_TLS_OPENSSL)
+    target_link_libraries(lupine_rpc_core PUBLIC OpenSSL::SSL OpenSSL::Crypto)
 endif()
-target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE ${NGHTTP2_LIBRARY} lupine_lz4)
-set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-)
 if(WIN32)
-  target_compile_definitions(${CUDA_CLIENT_OUTPUT} PRIVATE
-      LUPINE_WINDOWS_POSIX_SHIMS
-      _CRT_DECLARE_NONSTDC_NAMES=0
-  )
-  target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE ws2_32)
-  set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES
-      OUTPUT_NAME nvcuda
-      PREFIX ""
-      WINDOWS_EXPORT_ALL_SYMBOLS ON
-  )
-else()
-  set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES OUTPUT_NAME cuda)
-  if(NOT APPLE)
-    target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE stdc++)
-    target_link_options(${CUDA_CLIENT_OUTPUT} PRIVATE
-        "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/cuda_client.exports"
-    )
-    set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES
-        VERSION 1
-        SOVERSION 1
-    )
-  endif()
+    target_link_libraries(lupine_rpc_core PUBLIC ws2_32)
 endif()
 
-add_library(${NVML_CLIENT_OUTPUT} SHARED ${NVML_CLIENT_SOURCES})
-target_include_directories(${NVML_CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+add_library(lupine_client_transport STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/transport.cpp)
+lupine_internal_target(lupine_client_transport)
+target_include_directories(lupine_client_transport PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(lupine_client_transport PUBLIC lupine_rpc_core)
 if(OpenSSL_FOUND)
-  target_compile_definitions(${NVML_CLIENT_OUTPUT} PRIVATE LUPINE_TLS_OPENSSL)
-  target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    target_compile_definitions(lupine_client_transport PRIVATE
+        LUPINE_TLS_OPENSSL)
+    target_link_libraries(lupine_client_transport PUBLIC
+        OpenSSL::SSL OpenSSL::Crypto)
 endif()
-target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE ${NGHTTP2_LIBRARY} lupine_lz4)
-set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-)
-if(WIN32)
-  target_compile_definitions(${NVML_CLIENT_OUTPUT} PRIVATE
-      LUPINE_WINDOWS_POSIX_SHIMS
-      _CRT_DECLARE_NONSTDC_NAMES=0
-  )
-  target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE ws2_32)
-  set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
-      OUTPUT_NAME nvml
-      PREFIX ""
-      WINDOWS_EXPORT_ALL_SYMBOLS ON
-  )
-else()
-  set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES OUTPUT_NAME nvidia-ml)
-  if(NOT APPLE)
-    target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE stdc++)
-    target_link_options(${NVML_CLIENT_OUTPUT} PRIVATE
-        "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/nvml.exports"
+
+add_library(lupine_ipc STATIC ${CMAKE_CURRENT_SOURCE_DIR}/ipc.cpp)
+lupine_internal_target(lupine_ipc)
+target_include_directories(lupine_ipc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(lupine_ipc PUBLIC Threads::Threads)
+
+add_library(lupine_server_core STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/rpc_server.cpp)
+lupine_internal_target(lupine_server_core)
+target_include_directories(lupine_server_core PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(lupine_server_core PUBLIC lupine_rpc_core)
+
+if(LUPINE_BUILD_CUDA)
+    add_library(lupine_cuda_checkpoint STATIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp)
+    set_target_properties(lupine_cuda_checkpoint PROPERTIES
+        POSITION_INDEPENDENT_CODE ON)
+    target_include_directories(lupine_cuda_checkpoint PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(lupine_cuda_checkpoint PUBLIC Threads::Threads)
+endif()
+
+if(LUPINE_BUILD_CUDA)
+    add_library(lupine_cuda_client SHARED
+        ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/cuda_client.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/events.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/routing.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/copy_pipeline.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_cuda_client.cpp
     )
-    set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
-        VERSION 1
-        SOVERSION 1
-    )
-  endif()
+    target_include_directories(lupine_cuda_client PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/codegen
+        ${CUDAToolkit_INCLUDE_DIRS})
+    target_compile_definitions(lupine_cuda_client PRIVATE LUPINE_RPC_CLIENT)
+    target_link_libraries(lupine_cuda_client PRIVATE
+        lupine_client_transport lupine_cuda_checkpoint lupine_ipc
+        ${CMAKE_DL_LIBS})
+    set_target_properties(lupine_cuda_client PROPERTIES
+        POSITION_INDEPENDENT_CODE ON)
+    if(WIN32)
+        target_compile_definitions(lupine_cuda_client PRIVATE
+            LUPINE_WINDOWS_POSIX_SHIMS
+            _CRT_DECLARE_NONSTDC_NAMES=0)
+        target_compile_options(lupine_cuda_client PRIVATE /wd4996)
+        set_target_properties(lupine_cuda_client PROPERTIES
+            OUTPUT_NAME nvcuda
+            PREFIX ""
+            WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    else()
+        target_compile_options(lupine_cuda_client PRIVATE
+            -Wno-deprecated-declarations)
+        set_target_properties(lupine_cuda_client PROPERTIES OUTPUT_NAME cuda)
+        if(NOT APPLE)
+            target_link_libraries(lupine_cuda_client PRIVATE stdc++)
+            target_link_options(lupine_cuda_client PRIVATE
+                "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/cuda_client.exports")
+            set_target_properties(lupine_cuda_client PROPERTIES
+                VERSION 1
+                SOVERSION 1)
+        endif()
+    endif()
+endif()
+
+if(LUPINE_BUILD_NVML)
+    add_library(lupine_nvml_client SHARED
+        ${CMAKE_CURRENT_SOURCE_DIR}/nvml_client.cpp)
+    target_include_directories(lupine_nvml_client PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/codegen
+        ${CUDAToolkit_INCLUDE_DIRS})
+    target_link_libraries(lupine_nvml_client PRIVATE lupine_client_transport)
+    set_target_properties(lupine_nvml_client PROPERTIES
+        POSITION_INDEPENDENT_CODE ON)
+    if(WIN32)
+        target_compile_definitions(lupine_nvml_client PRIVATE
+            LUPINE_WINDOWS_POSIX_SHIMS
+            _CRT_DECLARE_NONSTDC_NAMES=0)
+        target_compile_options(lupine_nvml_client PRIVATE /wd4996)
+        set_target_properties(lupine_nvml_client PROPERTIES
+            OUTPUT_NAME nvml
+            PREFIX ""
+            WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    else()
+        target_compile_options(lupine_nvml_client PRIVATE
+            -Wno-deprecated-declarations)
+        set_target_properties(lupine_nvml_client PROPERTIES
+            OUTPUT_NAME nvidia-ml)
+        if(NOT APPLE)
+            target_link_libraries(lupine_nvml_client PRIVATE stdc++)
+            target_link_options(lupine_nvml_client PRIVATE
+                "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/nvml.exports")
+            set_target_properties(lupine_nvml_client PROPERTIES
+                VERSION 1
+                SOVERSION 1)
+        endif()
+    endif()
+    add_custom_target(lupine_nvml DEPENDS lupine_nvml_client)
 endif()
 
 if(LUPINE_BUILD_SERVER)
-add_executable(${SERVER_OUTPUT} ${SERVER_SOURCES} ${SERVER_HEADERS})
-target_include_directories(${SERVER_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-target_compile_definitions(${SERVER_OUTPUT} PRIVATE
-    LUPINE_RPC_SERVER
-    LUPINE_CUDA_VERSION="${CUDAToolkit_VERSION}"
-)
-target_link_libraries(${SERVER_OUTPUT} PRIVATE CUDA::cuda_driver ${NGHTTP2_LIBRARY} lupine_lz4)
+    if(LUPINE_BUILD_CUDA)
+        add_library(lupine_cuda_server STATIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/server_checkpoint.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/cuda_server.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/copy_pipeline.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_cuda_server.cpp
+        )
+        lupine_internal_target(lupine_cuda_server)
+        target_include_directories(lupine_cuda_server PRIVATE
+            ${CUDAToolkit_INCLUDE_DIRS})
+        target_compile_definitions(lupine_cuda_server PRIVATE
+            LUPINE_RPC_SERVER)
+        if(MSVC)
+            target_compile_options(lupine_cuda_server PRIVATE /wd4996)
+        else()
+            target_compile_options(lupine_cuda_server PRIVATE
+                -Wno-deprecated-declarations)
+        endif()
+        target_link_libraries(lupine_cuda_server PRIVATE
+            lupine_server_core lupine_cuda_checkpoint lupine_ipc
+            CUDA::cuda_driver)
+    endif()
 
-if (WIN32)
-    target_link_libraries(${SERVER_OUTPUT} PRIVATE ws2_32)
-else()
-    target_link_libraries(${SERVER_OUTPUT} PRIVATE dl)
+    if(LUPINE_BUILD_NVML)
+        add_library(lupine_nvml_server STATIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/nvml_server.cpp)
+        lupine_internal_target(lupine_nvml_server)
+        target_include_directories(lupine_nvml_server PRIVATE
+            ${CUDAToolkit_INCLUDE_DIRS})
+        target_link_libraries(lupine_nvml_server PRIVATE lupine_server_core)
+    endif()
 
-    set(H2_TEST_SOURCES
-        ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
-    )
-    add_executable(h2_test ${H2_TEST_SOURCES})
-    target_compile_definitions(h2_test PRIVATE
-        LUPINE_CUDA_VERSION="${CUDAToolkit_VERSION}"
-    )
-    target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
+    add_executable(lupine_driver_server
+        ${CMAKE_CURRENT_SOURCE_DIR}/server.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/codegen/registry.cpp)
+    target_include_directories(lupine_driver_server PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/codegen
+        ${CUDAToolkit_INCLUDE_DIRS})
+    target_link_libraries(lupine_driver_server PRIVATE
+        lupine_server_core lupine_ipc ${CMAKE_DL_LIBS})
+    if(LUPINE_BUILD_CUDA)
+        target_compile_definitions(lupine_driver_server PRIVATE
+            LUPINE_BUILD_CUDA_BACKEND
+            LUPINE_RPC_SERVER
+            LUPINE_BACKEND_VERSION="${CUDAToolkit_VERSION}")
+        target_link_libraries(lupine_driver_server PRIVATE lupine_cuda_server)
+    endif()
+    if(LUPINE_BUILD_NVML)
+        target_compile_definitions(lupine_driver_server PRIVATE
+            LUPINE_BUILD_NVML_BACKEND)
+        target_link_libraries(lupine_driver_server PRIVATE lupine_nvml_server)
+    endif()
+endif()
+
+if(BUILD_TESTING AND NOT WIN32)
+    add_executable(h2_test ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp)
+    target_include_directories(h2_test PRIVATE ${NGHTTP2_INCLUDE_DIR})
+    if(CUDAToolkit_VERSION)
+        target_compile_definitions(h2_test PRIVATE
+            LUPINE_CUDA_VERSION="${CUDAToolkit_VERSION}")
+    else()
+        target_compile_definitions(h2_test PRIVATE
+            LUPINE_CUDA_VERSION="core-only-test")
+    endif()
+    target_link_libraries(h2_test PRIVATE lupine_rpc_core)
     lupine_apply_sanitizer(h2_test)
 
-    add_executable(h2_unknown_cuda_version_test ${H2_TEST_SOURCES})
+    add_executable(h2_unknown_cuda_version_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp)
+    target_include_directories(h2_unknown_cuda_version_test PRIVATE
+        ${NGHTTP2_INCLUDE_DIR})
     target_compile_definitions(h2_unknown_cuda_version_test PRIVATE
-        LUPINE_H2_UNKNOWN_CUDA_VERSION_TEST
-    )
-    target_link_libraries(h2_unknown_cuda_version_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
+        LUPINE_H2_UNKNOWN_CUDA_VERSION_TEST)
+    target_link_libraries(h2_unknown_cuda_version_test PRIVATE lupine_rpc_core)
     lupine_apply_sanitizer(h2_unknown_cuda_version_test)
-
-    enable_testing()
-    add_test(NAME h2_test COMMAND h2_test)
-    lupine_scaled_timeout(h2_timeout 30)
-    set_tests_properties(h2_test PROPERTIES TIMEOUT ${h2_timeout})
-    add_test(NAME h2_unknown_cuda_version_test COMMAND h2_unknown_cuda_version_test)
-    lupine_scaled_timeout(h2u_timeout 10)
-    set_tests_properties(h2_unknown_cuda_version_test PROPERTIES TIMEOUT ${h2u_timeout})
 
     add_executable(checkpoint_test
         ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint_test.cpp
-    )
-    target_link_libraries(checkpoint_test PRIVATE pthread)
+        ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint_test.cpp)
+    target_include_directories(checkpoint_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(checkpoint_test PRIVATE Threads::Threads)
     lupine_apply_sanitizer(checkpoint_test)
-    add_test(NAME checkpoint_test COMMAND checkpoint_test)
-    lupine_scaled_timeout(ckpt_timeout 10)
-    set_tests_properties(checkpoint_test PROPERTIES TIMEOUT ${ckpt_timeout})
 
-    add_executable(events_test
-        ${CMAKE_CURRENT_SOURCE_DIR}/events.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/events_test.cpp
-    )
-    target_link_libraries(events_test PRIVATE pthread)
-    lupine_apply_sanitizer(events_test)
-    add_test(NAME events_test COMMAND events_test)
-    lupine_scaled_timeout(events_timeout 10)
-    set_tests_properties(events_test PROPERTIES TIMEOUT ${events_timeout})
+    if(LUPINE_BUILD_CUDA)
+        add_executable(events_test
+            ${CMAKE_CURRENT_SOURCE_DIR}/events.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/events_test.cpp)
+        target_include_directories(events_test PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR} ${CUDAToolkit_INCLUDE_DIRS})
+        target_link_libraries(events_test PRIVATE Threads::Threads)
+        lupine_apply_sanitizer(events_test)
+    endif()
 
-    add_executable(ipc_test
-        ${CMAKE_CURRENT_SOURCE_DIR}/ipc.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/ipc_test.cpp
-    )
-    target_link_libraries(ipc_test PRIVATE pthread)
+    add_executable(ipc_test ${CMAKE_CURRENT_SOURCE_DIR}/ipc_test.cpp)
+    target_link_libraries(ipc_test PRIVATE lupine_ipc)
     lupine_apply_sanitizer(ipc_test)
-    add_test(NAME ipc_test COMMAND ipc_test)
-    lupine_scaled_timeout(ipc_timeout 10)
-    set_tests_properties(ipc_test PROPERTIES TIMEOUT ${ipc_timeout})
 
     add_library(test_lupinecr_provider SHARED
-        ${CMAKE_CURRENT_SOURCE_DIR}/test/test_checkpoint_provider.c
-    )
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/test_checkpoint_provider.c)
+    target_include_directories(test_lupinecr_provider PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR})
     set_target_properties(test_lupinecr_provider PROPERTIES
         PREFIX ""
-        OUTPUT_NAME "test-lupinecr-provider"
-    )
+        OUTPUT_NAME "test-lupinecr-provider")
 
     add_executable(server_checkpoint_test
         ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/server_checkpoint.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_checkpoint.cpp
-    )
-    target_link_libraries(server_checkpoint_test PRIVATE dl pthread)
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_checkpoint.cpp)
+    target_include_directories(server_checkpoint_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(server_checkpoint_test PRIVATE
+        ${CMAKE_DL_LIBS} Threads::Threads)
     lupine_apply_sanitizer(server_checkpoint_test)
-    add_test(
-        NAME server_checkpoint_test
-        COMMAND server_checkpoint_test $<TARGET_FILE:test_lupinecr_provider> present
-    )
-    lupine_scaled_timeout(sckpt_timeout 10)
-    set_tests_properties(server_checkpoint_test PROPERTIES TIMEOUT ${sckpt_timeout})
-    add_test(
-        NAME server_checkpoint_missing_provider_test
+
+    add_test(NAME h2_test COMMAND h2_test)
+    lupine_scaled_timeout(h2_timeout 30)
+    set_tests_properties(h2_test PROPERTIES TIMEOUT ${h2_timeout})
+    add_test(NAME h2_unknown_cuda_version_test
+        COMMAND h2_unknown_cuda_version_test)
+    lupine_scaled_timeout(h2u_timeout 10)
+    set_tests_properties(h2_unknown_cuda_version_test PROPERTIES
+        TIMEOUT ${h2u_timeout})
+    add_test(NAME checkpoint_test COMMAND checkpoint_test)
+    lupine_scaled_timeout(ckpt_timeout 10)
+    set_tests_properties(checkpoint_test PROPERTIES TIMEOUT ${ckpt_timeout})
+    if(TARGET events_test)
+        add_test(NAME events_test COMMAND events_test)
+        lupine_scaled_timeout(events_timeout 10)
+        set_tests_properties(events_test PROPERTIES TIMEOUT ${events_timeout})
+    endif()
+    add_test(NAME ipc_test COMMAND ipc_test)
+    lupine_scaled_timeout(ipc_timeout 10)
+    set_tests_properties(ipc_test PROPERTIES TIMEOUT ${ipc_timeout})
+    add_test(NAME server_checkpoint_test
         COMMAND server_checkpoint_test
-                ${CMAKE_CURRENT_BINARY_DIR}/missing-liblupinecr.so missing
-    )
-    set_tests_properties(server_checkpoint_missing_provider_test
-                         PROPERTIES TIMEOUT ${sckpt_timeout})
+                $<TARGET_FILE:test_lupinecr_provider> present)
+    lupine_scaled_timeout(sckpt_timeout 10)
+    set_tests_properties(server_checkpoint_test PROPERTIES
+        TIMEOUT ${sckpt_timeout})
+    add_test(NAME server_checkpoint_missing_provider_test
+        COMMAND server_checkpoint_test
+                ${CMAKE_CURRENT_BINARY_DIR}/missing-liblupinecr.so missing)
+    set_tests_properties(server_checkpoint_missing_provider_test PROPERTIES
+        TIMEOUT ${sckpt_timeout})
 
-    add_executable(server_sigterm_test
-        ${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_sigterm.cpp
-    )
-    target_link_libraries(server_sigterm_test PRIVATE pthread)
-    add_test(
-        NAME server_sigterm_test
-        COMMAND server_sigterm_test $<TARGET_FILE:${SERVER_OUTPUT}>
-    )
-    set_tests_properties(server_sigterm_test PROPERTIES
-        TIMEOUT 10
-        SKIP_RETURN_CODE 77
-    )
-    add_test(
-        NAME server_sigterm_provider_test
-        COMMAND server_sigterm_test
-                $<TARGET_FILE:${SERVER_OUTPUT}>
-                $<TARGET_FILE:test_lupinecr_provider>
-    )
-    set_tests_properties(server_sigterm_provider_test PROPERTIES
-        TIMEOUT 10
-        SKIP_RETURN_CODE 77
-    )
-    if(TARGET ${NVML_CLIENT_OUTPUT})
-      add_test(
-          NAME nvml_ecc_exports
-          COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetCudaComputeCapability"
-      )
+    if(TARGET lupine_driver_server AND LUPINE_BUILD_CUDA)
+        add_executable(server_sigterm_test
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_sigterm.cpp)
+        target_link_libraries(server_sigterm_test PRIVATE Threads::Threads)
+        add_test(NAME server_sigterm_test
+            COMMAND server_sigterm_test $<TARGET_FILE:lupine_driver_server>)
+        set_tests_properties(server_sigterm_test PROPERTIES
+            TIMEOUT 10 SKIP_RETURN_CODE 77)
+        add_test(NAME server_sigterm_provider_test
+            COMMAND server_sigterm_test
+                    $<TARGET_FILE:lupine_driver_server>
+                    $<TARGET_FILE:test_lupinecr_provider>)
+        set_tests_properties(server_sigterm_provider_test PROPERTIES
+            TIMEOUT 10 SKIP_RETURN_CODE 77)
     endif()
-    set_source_files_properties(
-        ${SERVER_SOURCES}
-        PROPERTIES LANGUAGE CUDA
-    )
-endif()
-endif()
 
-if (LUPINE_BUILD_SERVER AND NOT WIN32 AND NOT APPLE)
-    target_compile_options(${SERVER_OUTPUT} PRIVATE
-        $<$<COMPILE_LANGUAGE:CUDA>: --compiler-options=-fPIC,-g,-Wno-deprecated-declarations>
-    )
-
-endif()
-
-if(TARGET ${CUDA_CLIENT_OUTPUT})
-    if(MSVC)
-      target_compile_options(${CUDA_CLIENT_OUTPUT} PRIVATE /wd4996)
-    else()
-      target_compile_options(${CUDA_CLIENT_OUTPUT} PRIVATE
-          $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
+    if(TARGET lupine_nvml_client)
+        add_test(NAME nvml_ecc_exports
+            COMMAND bash -c
+                "nm -D \"$<TARGET_FILE:lupine_nvml_client>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:lupine_nvml_client>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:lupine_nvml_client>\" | grep -q nvmlDeviceGetMemoryErrorCounter && nm -D \"$<TARGET_FILE:lupine_nvml_client>\" | grep -q nvmlDeviceGetCudaComputeCapability")
     endif()
-    message(STATUS "Building CUDA client output: ${CUDA_CLIENT_OUTPUT}")
-    message(STATUS "Client TLS (OpenSSL): ${OpenSSL_FOUND}")
 endif()
 
-if(TARGET ${NVML_CLIENT_OUTPUT})
-    if(MSVC)
-      target_compile_options(${NVML_CLIENT_OUTPUT} PRIVATE /wd4996)
-    else()
-      target_compile_options(${NVML_CLIENT_OUTPUT} PRIVATE
-          $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
-    endif()
-    message(STATUS "Building NVML client output: ${NVML_CLIENT_OUTPUT}")
+message(STATUS "RPC core target: lupine_rpc_core")
+message(STATUS "Client TLS (OpenSSL): ${OpenSSL_FOUND}")
+if(TARGET lupine_cuda_client)
+    message(STATUS "Building CUDA client: lupine_cuda_client (libcuda.so.1)")
 endif()
-
-if(LUPINE_BUILD_SERVER)
-  message(STATUS "Building server output: ${SERVER_OUTPUT}")
+if(TARGET lupine_nvml_client)
+    message(STATUS
+        "Building NVML client: lupine_nvml_client (libnvidia-ml.so.1)")
+endif()
+if(TARGET lupine_driver_server)
+    message(STATUS "Building server: lupine_driver_server")
 endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN cmake -S /opt/lupine -B /opt/lupine/build \
 
 FROM builder AS client-build
 
-RUN cmake --build /opt/lupine/build --parallel --target lupine_cuda_client lupine_nvml
+RUN cmake --build /opt/lupine/build --parallel --target lupine_cuda_client lupine_nvml_client
 
 RUN test -e /opt/lupine/build/libcuda.so.1 \
     && test -e /opt/lupine/build/libnvidia-ml.so.1 \

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -200,33 +200,49 @@ PRIVATE_RPC_FUNCTIONS = [
 REGISTRY_CPP_TEMPLATE = Template(
     r'''#include "rpc_server.h"
 
-#include "copy_pipeline.h"
-#include "cuda_server.h"
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+#include <cuda.h>
+#endif
 #include "gen_rpc_ids.h"
-#include "nvml_server.h"
 
 // clang-format off
-#define LUPINE_RPC_HANDLERS(HANDLER) \
-$registry_entries
+#define LUPINE_CUDA_RPC_HANDLERS(HANDLER) \
+$cuda_registry_entries
+#define LUPINE_NVML_RPC_HANDLERS(HANDLER) \
+$nvml_registry_entries
 // clang-format on
 
 #define LUPINE_DECLARE_HANDLER(operation, handler, backend)                    \
   int handler(conn_t *conn);
-LUPINE_RPC_HANDLERS(LUPINE_DECLARE_HANDLER)
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+LUPINE_CUDA_RPC_HANDLERS(LUPINE_DECLARE_HANDLER)
+$cuda_guarded_declarations
+#endif
+#ifdef LUPINE_BUILD_NVML_BACKEND
+LUPINE_NVML_RPC_HANDLERS(LUPINE_DECLARE_HANDLER)
+$nvml_guarded_declarations
+#endif
 #undef LUPINE_DECLARE_HANDLER
 
 const rpc_handler_registry &lupine_rpc_handlers() {
 #define LUPINE_REGISTER_HANDLER(operation, handler, backend)                    \
   {operation, {handler, backend}},
   static const rpc_handler_registry handlers = {
-      LUPINE_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
-$guarded_handlers
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+      LUPINE_CUDA_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
+$cuda_guarded_handlers
+#endif
+#ifdef LUPINE_BUILD_NVML_BACKEND
+      LUPINE_NVML_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
+$nvml_guarded_handlers
+#endif
   };
 #undef LUPINE_REGISTER_HANDLER
   return handlers;
 }
 
-#undef LUPINE_RPC_HANDLERS
+#undef LUPINE_CUDA_RPC_HANDLERS
+#undef LUPINE_NVML_RPC_HANDLERS
 '''
 )
 
@@ -1980,27 +1996,39 @@ def main():
             f"{binding.backend_symbol})"
         )
 
-    registry_entries = [
-        "  " + registry_entry(binding, "HANDLER")
-        for binding in bindings
-        if binding.guard is None
-    ]
-
-    guarded_handlers = []
+    registry_entries = {backend: [] for backend in SERVER_BACKENDS}
+    guarded_handlers = {backend: [] for backend in SERVER_BACKENDS}
+    guarded_declarations = {backend: [] for backend in SERVER_BACKENDS}
     for binding in bindings:
         if binding.guard is None:
-            continue
-        guarded_handlers.append(
-            f"#if {binding.guard}\n"
-            f"      {registry_entry(binding, 'LUPINE_REGISTER_HANDLER')}\n"
-            f'#endif'
-        )
+            registry_entries[binding.backend].append(
+                "  " + registry_entry(binding, "HANDLER")
+            )
+        else:
+            guarded_declarations[binding.backend].append(
+                f"#if {binding.guard}\n"
+                f"{registry_entry(binding, 'LUPINE_DECLARE_HANDLER')}\n"
+                f'#endif'
+            )
+            guarded_handlers[binding.backend].append(
+                f"#if {binding.guard}\n"
+                f"      {registry_entry(binding, 'LUPINE_REGISTER_HANDLER')}\n"
+                f'#endif'
+            )
 
     with open("registry.cpp", "w") as f:
         f.write(
             REGISTRY_CPP_TEMPLATE.substitute(
-                registry_entries=" \\\n".join(registry_entries),
-                guarded_handlers="\n".join(guarded_handlers),
+                cuda_registry_entries=" \\\n".join(registry_entries["CUDA"]),
+                nvml_registry_entries=" \\\n".join(registry_entries["NVML"]),
+                cuda_guarded_declarations="\n".join(
+                    guarded_declarations["CUDA"]
+                ),
+                nvml_guarded_declarations="\n".join(
+                    guarded_declarations["NVML"]
+                ),
+                cuda_guarded_handlers="\n".join(guarded_handlers["CUDA"]),
+                nvml_guarded_handlers="\n".join(guarded_handlers["NVML"]),
             )
         )
 

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -1,12 +1,12 @@
 #include "rpc_server.h"
 
-#include "copy_pipeline.h"
-#include "cuda_server.h"
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+#include <cuda.h>
+#endif
 #include "gen_rpc_ids.h"
-#include "nvml_server.h"
 
 // clang-format off
-#define LUPINE_RPC_HANDLERS(HANDLER) \
+#define LUPINE_CUDA_RPC_HANDLERS(HANDLER) \
   HANDLER(RPC_cuGetErrorString, handle_cuGetErrorString, rpc_backend::cuda) \
   HANDLER(RPC_cuGetErrorName, handle_cuGetErrorName, rpc_backend::cuda) \
   HANDLER(RPC_cuDevicePrimaryCtxRetain, handle_cuDevicePrimaryCtxRetain, rpc_backend::cuda) \
@@ -99,12 +99,6 @@
   HANDLER(LUPINE_RPC_cuStreamGetCaptureInfo_v3, handle_cuStreamGetCaptureInfo, rpc_backend::cuda) \
   HANDLER(LUPINE_RPC_lupineManagedHostFlush, handle_lupineManagedHostFlush, rpc_backend::cuda) \
   HANDLER(LUPINE_RPC_lupineDeviceSnapshot, handle_lupineDeviceSnapshot, rpc_backend::cuda) \
-  HANDLER(RPC_nvmlDeviceGetComputeRunningProcesses, handle_nvmlDeviceGetComputeRunningProcesses, rpc_backend::nvml) \
-  HANDLER(RPC_nvmlDeviceGetComputeRunningProcesses_v2, handle_nvmlDeviceGetComputeRunningProcesses_v2, rpc_backend::nvml) \
-  HANDLER(RPC_nvmlDeviceGetGraphicsRunningProcesses, handle_nvmlDeviceGetGraphicsRunningProcesses, rpc_backend::nvml) \
-  HANDLER(RPC_nvmlDeviceGetGraphicsRunningProcesses_v2, handle_nvmlDeviceGetGraphicsRunningProcesses_v2, rpc_backend::nvml) \
-  HANDLER(RPC_nvmlDeviceGetMPSComputeRunningProcesses, handle_nvmlDeviceGetMPSComputeRunningProcesses, rpc_backend::nvml) \
-  HANDLER(RPC_nvmlDeviceGetMPSComputeRunningProcesses_v2, handle_nvmlDeviceGetMPSComputeRunningProcesses_v2, rpc_backend::nvml) \
   HANDLER(RPC_cuInit, handle_cuInit, rpc_backend::cuda) \
   HANDLER(RPC_cuDriverGetVersion, handle_cuDriverGetVersion, rpc_backend::cuda) \
   HANDLER(RPC_cuDeviceGet, handle_cuDeviceGet, rpc_backend::cuda) \
@@ -380,7 +374,14 @@
   HANDLER(RPC_cuGraphicsResourceGetMappedPointer_v2, handle_cuGraphicsResourceGetMappedPointer_v2, rpc_backend::cuda) \
   HANDLER(RPC_cuGraphicsResourceSetMapFlags_v2, handle_cuGraphicsResourceSetMapFlags_v2, rpc_backend::cuda) \
   HANDLER(RPC_cuGraphicsMapResources, handle_cuGraphicsMapResources, rpc_backend::cuda) \
-  HANDLER(RPC_cuGraphicsUnmapResources, handle_cuGraphicsUnmapResources, rpc_backend::cuda) \
+  HANDLER(RPC_cuGraphicsUnmapResources, handle_cuGraphicsUnmapResources, rpc_backend::cuda)
+#define LUPINE_NVML_RPC_HANDLERS(HANDLER) \
+  HANDLER(RPC_nvmlDeviceGetComputeRunningProcesses, handle_nvmlDeviceGetComputeRunningProcesses, rpc_backend::nvml) \
+  HANDLER(RPC_nvmlDeviceGetComputeRunningProcesses_v2, handle_nvmlDeviceGetComputeRunningProcesses_v2, rpc_backend::nvml) \
+  HANDLER(RPC_nvmlDeviceGetGraphicsRunningProcesses, handle_nvmlDeviceGetGraphicsRunningProcesses, rpc_backend::nvml) \
+  HANDLER(RPC_nvmlDeviceGetGraphicsRunningProcesses_v2, handle_nvmlDeviceGetGraphicsRunningProcesses_v2, rpc_backend::nvml) \
+  HANDLER(RPC_nvmlDeviceGetMPSComputeRunningProcesses, handle_nvmlDeviceGetMPSComputeRunningProcesses, rpc_backend::nvml) \
+  HANDLER(RPC_nvmlDeviceGetMPSComputeRunningProcesses_v2, handle_nvmlDeviceGetMPSComputeRunningProcesses_v2, rpc_backend::nvml) \
   HANDLER(RPC_nvmlInit_v2, handle_nvmlInit_v2, rpc_backend::nvml) \
   HANDLER(RPC_nvmlInitWithFlags, handle_nvmlInitWithFlags, rpc_backend::nvml) \
   HANDLER(RPC_nvmlShutdown, handle_nvmlShutdown, rpc_backend::nvml) \
@@ -442,22 +443,39 @@
 
 #define LUPINE_DECLARE_HANDLER(operation, handler, backend)                    \
   int handler(conn_t *conn);
-LUPINE_RPC_HANDLERS(LUPINE_DECLARE_HANDLER)
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+LUPINE_CUDA_RPC_HANDLERS(LUPINE_DECLARE_HANDLER)
+#if CUDA_VERSION >= 12000
+LUPINE_DECLARE_HANDLER(RPC_cuTensorMapEncodeTiled,
+                       handle_cuTensorMapEncodeTiled, rpc_backend::cuda)
+#endif
+#endif
+#ifdef LUPINE_BUILD_NVML_BACKEND
+LUPINE_NVML_RPC_HANDLERS(LUPINE_DECLARE_HANDLER)
+
+#endif
 #undef LUPINE_DECLARE_HANDLER
 
 const rpc_handler_registry &lupine_rpc_handlers() {
 #define LUPINE_REGISTER_HANDLER(operation, handler, backend)                   \
   {operation, {handler, backend}},
   static const rpc_handler_registry handlers = {
-      LUPINE_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+      LUPINE_CUDA_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
 #if CUDA_VERSION >= 12000
           LUPINE_REGISTER_HANDLER(RPC_cuTensorMapEncodeTiled,
                                   handle_cuTensorMapEncodeTiled,
                                   rpc_backend::cuda)
+#endif
+#endif
+#ifdef LUPINE_BUILD_NVML_BACKEND
+              LUPINE_NVML_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
+
 #endif
   };
 #undef LUPINE_REGISTER_HANDLER
   return handlers;
 }
 
-#undef LUPINE_RPC_HANDLERS
+#undef LUPINE_CUDA_RPC_HANDLERS
+#undef LUPINE_NVML_RPC_HANDLERS

--- a/deploy/Dockerfile.pytorch-worker
+++ b/deploy/Dockerfile.pytorch-worker
@@ -26,7 +26,7 @@ COPY . /opt/lupine-src
 RUN cmake -S /opt/lupine-src -B /opt/lupine-src/build \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs \
-    && cmake --build /opt/lupine-src/build --parallel --target lupine_cuda_client lupine_nvml \
+    && cmake --build /opt/lupine-src/build --parallel --target lupine_cuda_client lupine_nvml_client \
     && mkdir -p /opt/lupine/lib \
     && cp /opt/lupine-src/build/libcuda.so.1 /opt/lupine/lib/libcuda.so.1 \
     && cp /opt/lupine-src/build/libnvidia-ml.so.1 /opt/lupine/lib/libnvidia-ml.so.1 \

--- a/h2.cpp
+++ b/h2.cpp
@@ -75,6 +75,7 @@ struct h2_transport {
   std::string request_method;
   std::string request_path;
   std::string peer_cuda_version;
+  std::string server_version;
   std::string session_id;
 };
 
@@ -429,11 +430,6 @@ constexpr char kLupineCompressHeader[] = "x-lupine-compress";
 constexpr char kLupineCompressLz4[] = "lz4";
 constexpr char kLupineCudaVersionHeader[] = "x-lupine-cuda-version";
 constexpr char kLupineSessionHeader[] = "x-lupine-session";
-#ifdef LUPINE_CUDA_VERSION
-constexpr char kLupineCudaVersion[] = LUPINE_CUDA_VERSION;
-#else
-constexpr char kLupineCudaVersion[] = "";
-#endif
 
 bool lupine_h2_debug_enabled() {
   const char *debug = getenv("LUPINE_DEBUG");
@@ -445,8 +441,9 @@ bool lupine_h2_debug_enabled() {
 
 int h2_submit_server_response(h2_transport *transport, bool end_stream) {
   std::vector<nghttp2_nv> headers = {h2_nv(":status", "200")};
-  if (kLupineCudaVersion[0] != '\0') {
-    headers.push_back(h2_nv(kLupineCudaVersionHeader, kLupineCudaVersion));
+  if (!transport->server_version.empty()) {
+    headers.push_back(
+        h2_nv(kLupineCudaVersionHeader, transport->server_version.c_str()));
   }
   uint8_t flags = end_stream ? NGHTTP2_FLAG_END_STREAM : NGHTTP2_FLAG_NONE;
   if (nghttp2_submit_headers(transport->session, flags, transport->stream_id,
@@ -681,11 +678,15 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
   return result;
 }
 
-int h2_init_direct(conn_t *conn, bool server, bool probe) {
+int h2_init_direct(conn_t *conn, bool server, bool probe,
+                   const rpc_http2_server_metadata *metadata = nullptr) {
   auto *transport = new h2_transport();
   transport->netfd = conn->connfd;
   transport->tls = conn->tls_session;
   transport->server = server;
+  if (metadata != nullptr && metadata->backend_version != nullptr) {
+    transport->server_version = metadata->backend_version;
+  }
 
   nghttp2_session_callbacks *callbacks = nullptr;
   if (nghttp2_session_callbacks_new(&callbacks) != 0) {
@@ -738,9 +739,9 @@ int h2_init_direct(conn_t *conn, bool server, bool probe) {
   };
   if (nghttp2_submit_settings(transport->session, NGHTTP2_FLAG_NONE, settings,
                               2) != 0 ||
-      nghttp2_session_set_local_window_size(transport->session,
-                                            NGHTTP2_FLAG_NONE, 0,
-                                            static_cast<int32_t>(window)) != 0) {
+      nghttp2_session_set_local_window_size(
+          transport->session, NGHTTP2_FLAG_NONE, 0,
+          static_cast<int32_t>(window)) != 0) {
     nghttp2_session_del(transport->session);
     delete transport;
     return -1;
@@ -1014,7 +1015,12 @@ const char *rpc_http2_client_probe(conn_t *conn) {
 }
 
 int rpc_http2_server_init(conn_t *conn) {
-  if (h2_init_direct(conn, true, false) < 0) {
+  return rpc_http2_server_init_with_metadata(conn, nullptr);
+}
+
+int rpc_http2_server_init_with_metadata(
+    conn_t *conn, const rpc_http2_server_metadata *metadata) {
+  if (h2_init_direct(conn, true, false, metadata) < 0) {
     return -1;
   }
   auto *transport = static_cast<h2_transport *>(conn->http2);

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -255,7 +255,13 @@ void test_head_probe_cuda_version_metadata() {
   const char *cuda_version = nullptr;
   std::thread probe(
       [&] { cuda_version = rpc_http2_client_probe(&pair.client); });
+#ifdef LUPINE_CUDA_VERSION
+  const rpc_http2_server_metadata metadata = {LUPINE_CUDA_VERSION};
+  int server_result =
+      rpc_http2_server_init_with_metadata(&pair.server, &metadata);
+#else
   int server_result = rpc_http2_server_init(&pair.server);
+#endif
   probe.join();
 
   require(server_result == 1, "HEAD / was not handled as a metadata request");

--- a/rpc.h
+++ b/rpc.h
@@ -141,6 +141,9 @@ extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
 extern int rpc_http2_client_init(conn_t *conn);
 extern void rpc_http2_client_start_heartbeat(conn_t *conn);
 extern void rpc_http2_destroy(conn_t *conn);
+struct rpc_http2_server_metadata {
+  const char *backend_version;
+};
 // Sends HEAD / and returns the backend-version response header, or nullptr
 // when the request fails or the server does not advertise a version.
 // The returned pointer remains valid until rpc_http2_destroy() or
@@ -149,6 +152,9 @@ extern const char *rpc_http2_client_probe(conn_t *conn);
 // Returns -1 on failure, 0 for an RPC connection, and a positive value when
 // the HTTP layer has already handled the request.
 extern int rpc_http2_server_init(conn_t *conn);
+extern int
+rpc_http2_server_init_with_metadata(conn_t *conn,
+                                    const rpc_http2_server_metadata *metadata);
 extern int rpc_http2_compress_lz4(conn_t *conn);
 // Returns the x-lupine-session request header after the server has consumed
 // the HTTP/2 request headers, or nullptr when no session was supplied.

--- a/rpc_server.cpp
+++ b/rpc_server.cpp
@@ -1,8 +1,5 @@
 #include "rpc_server.h"
 
-#include "checkpoint.h"
-#include "lupine_log.h"
-
 bool rpc_server_validate(const rpc_handler_registry &handlers) {
   for (const auto &entry : handlers) {
     if (entry.second.handler == nullptr) {
@@ -17,38 +14,4 @@ bool rpc_server_validate(const rpc_handler_registry &handlers) {
     }
   }
   return true;
-}
-
-int rpc_server_dispatch(const rpc_handler_registry &handlers, conn_t *conn,
-                        int op) {
-  LUPINE_TRACE_LOG("LUPINE server handling op " << op);
-  auto it = handlers.find(op);
-  if (it == handlers.end()) {
-    LUPINE_LOG_ERROR("No RPC handler for op " << op << "; closing client.");
-    return -1;
-  }
-  const rpc_handler &handler = it->second;
-  const char *backend_name;
-  int result;
-  switch (handler.backend) {
-  case rpc_backend::cuda: {
-    backend_name = "CUDA";
-    lupine_checkpoint::cuda_call_guard guard;
-    result = handler.handler(conn);
-    break;
-  }
-  case rpc_backend::nvml:
-    backend_name = "NVML";
-    result = handler.handler(conn);
-    break;
-  default:
-    LUPINE_LOG_ERROR("Invalid RPC backend for op " << op << ".");
-    return -1;
-  }
-  if (result >= 0) {
-    return 0;
-  }
-  LUPINE_LOG_ERROR("Error handling " << backend_name << " request for op " << op
-                                     << ".");
-  return -1;
 }

--- a/server.cpp
+++ b/server.cpp
@@ -23,12 +23,15 @@
 #include <vector>
 #endif
 
-#include "copy_pipeline.h"
 #include "ipc.h"
 #include "lupine_log.h"
 #include "rpc.h"
 #include "rpc_server.h"
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+#include "checkpoint.h"
+#include "copy_pipeline.h"
 #include "server_checkpoint.h"
+#endif
 
 #define DEFAULT_PORT 14833
 #define MAX_CLIENTS 10
@@ -99,29 +102,94 @@ struct lupine_lane {
   std::thread worker;
 };
 
+int rpc_server_dispatch(const rpc_handler_registry &handlers, conn_t *conn,
+                        int op) {
+  LUPINE_TRACE_LOG("LUPINE server handling op " << op);
+  auto it = handlers.find(op);
+  if (it == handlers.end()) {
+    LUPINE_LOG_ERROR("No RPC handler for op " << op << "; closing client.");
+    return -1;
+  }
+
+  const rpc_handler &handler = it->second;
+  const char *backend_name = nullptr;
+  int result = -1;
+  switch (handler.backend) {
+  case rpc_backend::cuda:
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+  {
+    backend_name = "CUDA";
+    lupine_checkpoint::cuda_call_guard guard;
+    result = handler.handler(conn);
+    break;
+  }
+#else
+    break;
+#endif
+  case rpc_backend::nvml:
+#ifdef LUPINE_BUILD_NVML_BACKEND
+    backend_name = "NVML";
+    result = handler.handler(conn);
+#endif
+    break;
+  }
+
+  if (result >= 0) {
+    return 0;
+  }
+  if (backend_name == nullptr) {
+    LUPINE_LOG_ERROR("RPC op " << op << " belongs to a disabled backend.");
+  } else {
+    LUPINE_LOG_ERROR("Error handling " << backend_name << " request for op "
+                                       << op << ".");
+  }
+  return -1;
+}
+
 int client_handler(lupine_socket_t connfd) {
   const rpc_handler_registry &handlers = lupine_rpc_handlers();
   conn_t conn = {};
   if (rpc_conn_init(&conn, connfd, 1) < 0) {
     LUPINE_LOG_ERROR("Error initializing connection synchronization.");
+#ifdef LUPINE_BUILD_CUDA_BACKEND
     return lupine_server_checkpoint_child_finish();
+#else
+    return 0;
+#endif
   }
 
-  int http2_init_result = rpc_http2_server_init(&conn);
+  const rpc_http2_server_metadata metadata = {
+#ifdef LUPINE_BACKEND_VERSION
+      LUPINE_BACKEND_VERSION,
+#else
+      nullptr,
+#endif
+  };
+  int http2_init_result = rpc_http2_server_init_with_metadata(&conn, &metadata);
   if (http2_init_result < 0) {
     LUPINE_LOG_ERROR("Error initializing HTTP/2 connection.");
     rpc_conn_destroy(&conn);
+#ifdef LUPINE_BUILD_CUDA_BACKEND
     return lupine_server_checkpoint_child_finish();
+#else
+    return 0;
+#endif
   }
   if (http2_init_result != 0) {
     rpc_conn_destroy(&conn);
+#ifdef LUPINE_BUILD_CUDA_BACKEND
     return lupine_server_checkpoint_child_finish();
+#else
+    return 0;
+#endif
   }
+#ifdef LUPINE_BUILD_CUDA_BACKEND
   if (!lupine_server_initialize_connection(&conn)) {
     LUPINE_LOG_ERROR("Error initializing per-connection CUDA state.");
     rpc_conn_destroy(&conn);
     return lupine_server_checkpoint_child_finish();
   }
+#endif
 
   LUPINE_LOG_DEBUG("Client connected.");
 
@@ -169,12 +237,14 @@ int client_handler(lupine_socket_t connfd) {
     int op = conn.read_op;
 
     if (!connection_ready) {
+#ifdef LUPINE_BUILD_CUDA_BACKEND
       if (!lupine_server_checkpoint_connection_ready(
               rpc_http2_session_id(&conn))) {
         pthread_mutex_unlock(&conn.read_mutex);
         LUPINE_LOG_ERROR("Failed to restore connection checkpoint.");
         break;
       }
+#endif
       connection_ready = true;
     }
 
@@ -266,9 +336,12 @@ int client_handler(lupine_socket_t connfd) {
     conn.rpc_thread = 0;
   }
 
-  // Finish checkpointing before releasing per-connection resources.
-  int checkpoint_result = lupine_server_checkpoint_child_finish();
+  int checkpoint_result = 0;
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+  // Finish checkpointing before releasing per-connection CUDA resources.
+  checkpoint_result = lupine_server_checkpoint_child_finish();
   lupine_server_cleanup_connection(&conn);
+#endif
   rpc_conn_destroy(&conn);
   return checkpoint_result;
 }
@@ -463,11 +536,13 @@ int main() {
       }
       close(broker_pair[0]);
       lupine_ipc_set_broker_fd(broker_pair[1]);
+#ifdef LUPINE_BUILD_CUDA_BACKEND
       if (!lupine_server_checkpoint_child_start(connfd)) {
         LUPINE_LOG_ERROR("Failed to initialize graceful child shutdown.");
         lupine_socket_close(connfd);
         exit(EXIT_FAILURE);
       }
+#endif
       (void)sigprocmask(SIG_SETMASK, &previous_mask, nullptr);
       int checkpoint_result = client_handler(connfd);
       exit(checkpoint_result == 0 ? EXIT_SUCCESS : EXIT_FAILURE);


### PR DESCRIPTION
Refs #532

This sixth PR in the backend-separation stack turns the source boundaries into actual build boundaries.

- adds PIC static components for the neutral RPC core, client transport, IPC, CUDA RPC/checkpoint, server core, and CUDA/NVML server backends
- adds default-on CUDA, NVML, HIP, and server component options (the HIP implementation is supplied by the final #487 rebase)
- discovers CUDAToolkit only when CUDA or NVML components are requested
- removes global include directories, CUDA language enablement, and blanket NVCC compilation of server `.cpp` files
- keeps CUDA/NVML SDK includes private to backend targets
- moves CUDA/NVML backend descriptors into their owning components
- passes server version metadata per HTTP/2 connection so one neutral core supports every final binary
- renames the logical NVML shim target to `lupine_nvml_client`, while retaining a compatibility build target and the `libnvidia-ml.so.1` artifact
- preserves `libcuda.so.1` and `lupine_driver_server`

Stack:
1. #535
2. #536
3. #537
4. #538
5. #539
6. this PR

Validation:
- clean host-only configure/build with CUDA, NVML, HIP, and server disabled; no CUDA discovery in configure output
- host-only CTest: 8/8 passed
- clean CUDA-only client/server build
- clean NVML-only client/server build
- clean all-component build
- full CTest: 12/12 passed (2 environment-dependent tests skipped)
- neutral compile commands contain no CUDA/ROCm include path and use C++, not NVCC
- `lupine_rpc_core` has no CUDA/HIP/NVML undefined symbols
- CUDA and NVML dynamic export sets exactly match the parent build
- shim SONAMEs remain `libcuda.so.1` and `libnvidia-ml.so.1`
- generated backend boundary verification and `git diff --check`

## Complete PR chain

#535 → #536 → #537 → #538 → #539 → #540 → #541 → #542