### PR TITLE
Enforce backend separation and shim ABI in CI

### DIFF
--- a/.github/workflows/backend-separation.yml
+++ b/.github/workflows/backend-separation.yml
@@ -1,0 +1,90 @@
+name: Backend Separation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  core-only:
+    name: Core only (no accelerator SDK)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install CPU-only build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            libnghttp2-dev \
+            libssl-dev \
+            ninja-build
+
+      - name: Configure without CUDA or ROCm discovery
+        run: |
+          cmake -S . -B build/core-only -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=TRUE \
+            -DLUPINE_BUILD_CUDA=OFF \
+            -DLUPINE_BUILD_NVML=OFF \
+            -DLUPINE_BUILD_HIP=OFF \
+            -DLUPINE_BUILD_SERVER=OFF
+          ! grep -E '^(CUDAToolkit|CUDA_TOOLKIT|ROCM|ROCm)' \
+            build/core-only/CMakeCache.txt
+
+      - name: Build and test neutral components
+        run: |
+          cmake --build build/core-only --parallel
+          ctest --test-dir build/core-only --output-on-failure
+          test/check_neutral_build.sh build/core-only
+          test/check_rpc_ids.sh .
+
+  cuda-nvml:
+    name: CUDA + NVML boundaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Build CUDA development environment
+        run: |
+          docker build \
+            -f Dockerfile \
+            --target builder \
+            --build-arg CUDA_VERSION=13.1.0 \
+            --build-arg UBUNTU_VERSION=24.04 \
+            -t lupine-backend-separation \
+            .
+
+      - name: Build, test, and inspect final shims
+        run: |
+          docker run --rm --entrypoint bash \
+            lupine-backend-separation -lc '
+              set -euo pipefail
+              cmake -S /opt/lupine -B /opt/lupine/build-backend-separation -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs \
+                -DLUPINE_BUILD_CUDA=ON \
+                -DLUPINE_BUILD_NVML=ON \
+                -DLUPINE_BUILD_HIP=OFF \
+                -DLUPINE_BUILD_SERVER=ON
+              cmake --build /opt/lupine/build-backend-separation --parallel
+              ctest --test-dir /opt/lupine/build-backend-separation \
+                --output-on-failure
+              /opt/lupine/test/check_neutral_build.sh \
+                /opt/lupine/build-backend-separation
+              /opt/lupine/test/check_backend_abi.sh \
+                /opt/lupine/build-backend-separation
+            '

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -71,7 +71,11 @@ jobs:
             "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
             "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TARGET_TRIPLET" `
             "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" `
-            "-DCUDAToolkit_ROOT=$env:CUDA_PATH"
+            "-DCUDAToolkit_ROOT=$env:CUDA_PATH" `
+            -DLUPINE_BUILD_CUDA=ON `
+            -DLUPINE_BUILD_NVML=ON `
+            -DLUPINE_BUILD_HIP=OFF `
+            -DLUPINE_BUILD_SERVER=ON
 
       - name: Build
         run: cmake --build build/windows-server --config Release --target lupine_driver_server --parallel

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -32,3 +32,8 @@ jobs:
 
       - name: Verify generated files are current
         run: git diff --exit-code -- codegen
+
+      - name: Verify backend-specific generated boundaries
+        run: |
+          uv run codegen/codegen.py --verify-backend cuda
+          uv run codegen/codegen.py --verify-backend nvml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ set(LUPINE_SANITIZE "" CACHE STRING
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+if(NOT WIN32)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
 
 include(CTest)
 find_package(Threads REQUIRED)
@@ -358,6 +361,13 @@ if(BUILD_TESTING AND NOT WIN32)
     target_link_libraries(ipc_test PRIVATE lupine_ipc)
     lupine_apply_sanitizer(ipc_test)
 
+    add_test(NAME rpc_id_snapshot_test
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test/check_rpc_ids.sh
+                     ${CMAKE_CURRENT_SOURCE_DIR})
+    add_test(NAME neutral_build_test
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test/check_neutral_build.sh
+                     ${CMAKE_CURRENT_BINARY_DIR})
+
     add_library(test_lupinecr_provider SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/test/test_checkpoint_provider.c)
     target_include_directories(test_lupinecr_provider PRIVATE
@@ -427,6 +437,20 @@ if(BUILD_TESTING AND NOT WIN32)
         add_test(NAME nvml_ecc_exports
             COMMAND bash -c
                 "nm -D \"$<TARGET_FILE:lupine_nvml_client>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:lupine_nvml_client>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:lupine_nvml_client>\" | grep -q nvmlDeviceGetMemoryErrorCounter && nm -D \"$<TARGET_FILE:lupine_nvml_client>\" | grep -q nvmlDeviceGetCudaComputeCapability")
+    endif()
+
+    if(TARGET lupine_cuda_client AND TARGET lupine_nvml_client)
+        add_executable(shim_isolation_test
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/shim_isolation_test.cpp)
+        target_link_libraries(shim_isolation_test PRIVATE ${CMAKE_DL_LIBS})
+        add_dependencies(shim_isolation_test
+            lupine_cuda_client lupine_nvml_client)
+        add_test(NAME shim_isolation_test COMMAND shim_isolation_test
+            $<TARGET_FILE:lupine_cuda_client>
+            $<TARGET_FILE:lupine_nvml_client>)
+        add_test(NAME backend_abi_test
+            COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test/check_backend_abi.sh
+                         ${CMAKE_CURRENT_BINARY_DIR})
     endif()
 endif()
 

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1,3 +1,4 @@
+#include "codegen/gen_rpc_ids.h"
 #include "lupine_log.h"
 #include "rpc.h"
 
@@ -34,6 +35,10 @@ struct has_owned_member<T, std::void_t<decltype(std::declval<T>().owned)>>
 
 static_assert(!has_owned_member<rpc_write_entry>::value,
               "RPC write entries must not own individual iovecs");
+static_assert(sizeof(int) == 4, "RPC integer fields must remain 32-bit");
+static_assert(sizeof(uint64_t) == 8, "RPC lane fields must remain 64-bit");
+static_assert(RPC_cuInit == 1234315198, "cuInit RPC ID changed");
+static_assert(RPC_nvmlInit_v2 == 2103095296, "nvmlInit_v2 RPC ID changed");
 
 struct h2_pair {
   conn_t client = {};
@@ -207,6 +212,42 @@ void test_client_to_server() {
   write_all(&pair.client, {message});
   reader.join();
   require(received == message, "client-to-server payload mismatch");
+}
+
+void test_rpc_request_wire_prefix() {
+  h2_pair pair = make_pair();
+  int request_id = 0;
+  uint64_t lane_id = 0;
+  int operation = 0;
+  uint32_t flags = 0;
+  std::thread reader([&] {
+    require(rpc_http2_read(&pair.server, &request_id, sizeof(request_id)) ==
+                static_cast<int>(sizeof(request_id)),
+            "request id wire field changed");
+    require(rpc_http2_read(&pair.server, &lane_id, sizeof(lane_id)) ==
+                static_cast<int>(sizeof(lane_id)),
+            "lane id wire field changed");
+    require(rpc_http2_read(&pair.server, &operation, sizeof(operation)) ==
+                static_cast<int>(sizeof(operation)),
+            "operation wire field changed");
+    require(rpc_http2_read(&pair.server, &flags, sizeof(flags)) ==
+                static_cast<int>(sizeof(flags)),
+            "request payload wire field changed");
+  });
+
+  const uint32_t expected_flags = 0x12345678;
+  require(rpc_write_start_request(&pair.client, RPC_cuInit) == 0,
+          "request prefix start failed");
+  require(rpc_write(&pair.client, &expected_flags, sizeof(expected_flags)) == 0,
+          "request prefix payload failed");
+  int written_id = rpc_write_end(&pair.client);
+  reader.join();
+
+  require(written_id == 2 && request_id == written_id,
+          "request id prefix changed");
+  require(lane_id != 0, "lane id prefix missing");
+  require(operation == RPC_cuInit, "operation prefix changed");
+  require(flags == expected_flags, "request payload ordering changed");
 }
 
 void test_server_receives_session_id() {
@@ -1033,6 +1074,7 @@ int main() {
   test_rpc_lz4_payload_round_trip();
   test_response_wait_sends_transport_heartbeat();
   test_client_to_server();
+  test_rpc_request_wire_prefix();
   test_server_receives_session_id();
   test_server_to_client_after_request_headers();
   test_head_probe_cuda_version_metadata();

--- a/test/check_backend_abi.sh
+++ b/test/check_backend_abi.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_dir="${1:?usage: check_backend_abi.sh BUILD_DIR}"
+
+exports() {
+  nm -D --defined-only -P "$1" | awk '{ print $1 }'
+}
+
+require_export() {
+  local library="$1"
+  local symbol="$2"
+  if ! exports "$library" | grep -Fx "$symbol" >/dev/null; then
+    echo "$library does not export $symbol" >&2
+    exit 1
+  fi
+}
+
+check_soname() {
+  local library="$1"
+  local soname="$2"
+  if ! readelf -d "$library" | grep -F "Library soname: [$soname]" \
+    >/dev/null; then
+    echo "$library does not retain SONAME $soname" >&2
+    exit 1
+  fi
+}
+
+check_no_internal_exports() {
+  local library="$1"
+  if exports "$library" | grep -E \
+    '^(rpc_|lupine_client_transport_|lupine_(cuda|nvml|hip)_server_|get_(cuda|nvml|hip)_handler)' \
+    >/dev/null; then
+    echo "$library exposes an internal RPC, transport, or registry symbol" >&2
+    exit 1
+  fi
+}
+
+check_export_allowlist() {
+  local library="$1"
+  local pattern="$2"
+  local unexpected
+  unexpected="$(exports "$library" | grep -Ev "$pattern" || true)"
+  if [[ -n "$unexpected" ]]; then
+    echo "$library exposes symbols outside its public ABI:" >&2
+    echo "$unexpected" >&2
+    exit 1
+  fi
+}
+
+check_export_snapshot() {
+  local library="$1"
+  local expected="$2"
+  local actual
+  actual="$(exports "$library" | sort -u | sha256sum | awk '{ print $1 }')"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "$library export set changed: expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+check_no_cuda_dependency() {
+  local library="$1"
+  if readelf -d "$library" | grep -E \
+    'Shared library: \[(libcuda\.so|libamdhip64\.so)' >/dev/null; then
+    echo "$library has an unexpected accelerator-shim dependency" >&2
+    exit 1
+  fi
+}
+
+cuda="$build_dir/libcuda.so.1"
+nvml="$build_dir/libnvidia-ml.so.1"
+test -f "$cuda"
+test -f "$nvml"
+
+check_soname "$cuda" libcuda.so.1
+check_soname "$nvml" libnvidia-ml.so.1
+require_export "$cuda" cuInit
+require_export "$cuda" dlsym
+require_export "$cuda" lupine_checkpoint_drain_cuda_calls
+require_export "$nvml" nvmlInit_v2
+require_export "$nvml" nvmlDeviceGetCount_v2
+check_no_internal_exports "$cuda"
+check_no_internal_exports "$nvml"
+check_export_allowlist "$cuda" \
+  '^(cu[A-Z][A-Za-z0-9_]*|dlsym|lupine_checkpoint_(drain_cuda_calls|resume_captures|resume_cuda_calls|wait_for_captures))$'
+check_export_allowlist "$nvml" '^nvml[A-Z][A-Za-z0-9_]*$'
+check_export_snapshot "$cuda" \
+  b5c738c0c66ff110671270fd3491a996e14b364a89f1c53720c1b9418102710e
+check_export_snapshot "$nvml" \
+  2a8fd4454aac4146d0e812fb1fc1600144f1c53bab0e99edf76fe12c0ee4507f
+check_no_cuda_dependency "$cuda"
+check_no_cuda_dependency "$nvml"
+
+if [[ -f "$build_dir/libamdhip64.so.1" ]]; then
+  hip="$build_dir/libamdhip64.so.1"
+  check_soname "$hip" libamdhip64.so.1
+  require_export "$hip" hipInit
+  require_export "$hip" hipGetDeviceCount
+  check_no_internal_exports "$hip"
+  check_export_allowlist "$hip" '^hip[A-Z][A-Za-z0-9_]*$'
+  check_no_cuda_dependency "$hip"
+fi

--- a/test/check_neutral_build.sh
+++ b/test/check_neutral_build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_dir="${1:?usage: check_neutral_build.sh BUILD_DIR}"
+compile_commands="$build_dir/compile_commands.json"
+core="$build_dir/liblupine_rpc_core.a"
+
+test -f "$compile_commands"
+test -f "$core"
+
+neutral_commands="$(mktemp)"
+trap 'rm -f "$neutral_commands"' EXIT
+command_line=""
+while IFS= read -r line; do
+  if [[ "$line" == *'"command":'* ]]; then
+    command_line="$line"
+  elif [[ "$line" =~ /(rpc|h2|compress|transport|rpc_server)\.cpp\" ]]; then
+    printf '%s\n' "$command_line" >>"$neutral_commands"
+  fi
+done <"$compile_commands"
+
+if grep -Eq '/usr/local/cuda|/opt/rocm|(^|[ /])nvcc([ /]|$)|hipcc' \
+  "$neutral_commands"; then
+  echo "neutral source received an accelerator include path or compiler" >&2
+  cat "$neutral_commands" >&2
+  exit 1
+fi
+
+if nm -u "$core" | grep -Eq \
+  '\b(CU[A-Za-z_]|cuda[A-Za-z_]|hip[A-Za-z_]|nvml[A-Za-z_])'; then
+  echo "neutral RPC core imports an accelerator symbol" >&2
+  exit 1
+fi

--- a/test/check_rpc_ids.sh
+++ b/test/check_rpc_ids.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+expected_file="$repo_root/test/rpc_ids.sha256"
+ids_file="$repo_root/codegen/gen_rpc_ids.h"
+
+expected="$(awk 'NR == 1 { print $1 }' "$expected_file")"
+actual="$(awk '/^#define (RPC_|LUPINE_RPC_)/ && \
+                    $2 !~ /^(RPC|LUPINE_RPC)_hip/ { print }' "$ids_file" \
+  | sha256sum | awk '{ print $1 }')"
+
+if [[ "$actual" != "$expected" ]]; then
+  echo "RPC ID snapshot changed: expected $expected, got $actual" >&2
+  echo "Review wire compatibility before updating test/rpc_ids.sha256." >&2
+  exit 1
+fi

--- a/test/rpc_ids.sha256
+++ b/test/rpc_ids.sha256
@@ -1,0 +1,1 @@
+85cabbecc9c2863427d61c465d7c24b486e21f2bf7f9b0840e671479585d0e31  codegen/gen_rpc_ids.h

--- a/test/shim_isolation_test.cpp
+++ b/test/shim_isolation_test.cpp
@@ -1,0 +1,46 @@
+#include <dlfcn.h>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void require(bool condition, const char *message) {
+  if (!condition) {
+    std::cerr << message << std::endl;
+    std::exit(1);
+  }
+}
+
+void require_hidden(void *library, const char *symbol) {
+  dlerror();
+  require(dlsym(library, symbol) == nullptr, symbol);
+  (void)dlerror();
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  require(argc == 3, "usage: shim_isolation_test LIBCUDA LIBNVML");
+  void *cuda = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+  require(cuda != nullptr, dlerror());
+  void *nvml = dlopen(argv[2], RTLD_NOW | RTLD_LOCAL);
+  require(nvml != nullptr, dlerror());
+
+  require(dlsym(cuda, "cuInit") != nullptr, "CUDA entry point unavailable");
+  require(dlsym(nvml, "nvmlInit_v2") != nullptr,
+          "NVML entry point unavailable");
+
+  for (const char *symbol :
+       {"rpc_dispatch", "rpc_set_lifecycle_hooks",
+        "lupine_client_transport_open",
+        "lupine_client_transport_connection"}) {
+    require_hidden(cuda, symbol);
+    require_hidden(nvml, symbol);
+  }
+
+  require(dlclose(nvml) == 0, "NVML shim close failed");
+  require(dlclose(cuda) == 0, "CUDA shim close failed");
+  std::cout << "shim_isolation_test: PASS" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Refs #533

This seventh PR in the backend-separation stack makes the new boundaries continuously testable.

- adds a host-only job that installs no CUDA/ROCm packages, performs a clean core configure, and rejects accelerator discovery
- adds a clean CUDA/NVML component build job against final shared libraries
- keeps the unified Windows server matrix and makes its enabled components explicit
- verifies generated CUDA and NVML boundaries independently
- rejects CUDA/ROCm include paths or compilers in neutral compile commands
- rejects accelerator imports from `lupine_rpc_core`
- snapshots all existing non-HIP RPC IDs and representative request-prefix field order/widths
- enforces exact CUDA/NVML dynamic export sets, SONAMEs, allowlists, and no shim-to-shim dependency
- loads CUDA and NVML shims together and verifies RPC, transport, and registry symbols remain private
- leaves HIP-only and all-backend jobs ready for the final #487/#534 layer

Stack:
1. #535
2. #536
3. #537
4. #538
5. #539
6. #540
7. this PR

Validation:
- core-only CTest: 10/10 passed
- full CTest: 16/16 passed (2 environment-dependent tests skipped)
- ABI, neutral-build, RPC-ID, generated-boundary, shell syntax, YAML parse, and `git diff --check` checks pass locally

## Complete PR chain

#535 → #536 → #537 → #538 → #539 → #540 → #541 → #542