### PR TITLE
client: survive fork() instead of destroying the parent's session

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -66,6 +66,67 @@ conn_t conns[16];
 int nconns = 0;
 static bool lupine_rpc_shutting_down = false;
 
+// Set in a child that inherited a live connection across fork(). CUDA state
+// cannot survive a fork: locally the driver enforces that by poisoning the
+// child's context, and the shim has to reproduce it, because here the child's
+// inherited descriptor still addresses the PARENT's session. Left unhandled,
+// a child's ordinary teardown (cuLibraryUnload, cuDevicePrimaryCtxRelease) is
+// forwarded onto the parent's context and destroys it, and the destructor
+// below then shutdown()s the shared socket out from under the parent -- which
+// keeps running, now holding a dead session and a released context.
+static bool lupine_forked_child = false;
+
+#ifndef _WIN32
+static void lupine_rpc_atfork_prepare() { pthread_mutex_lock(&conn_mutex); }
+
+static void lupine_rpc_atfork_parent() { pthread_mutex_unlock(&conn_mutex); }
+
+// Runs in the child, which owns only the forking thread: every dispatch and
+// read thread is gone, and whatever mutexes they held are locked forever. So
+// abandon the inherited transport rather than unwind it.
+//
+// close(), never shutdown(): the descriptor is shared with the parent, and
+// close() drops only this process's reference while shutdown() would take down
+// the TCP connection both processes are using. Nothing here allocates or
+// frees -- conn_t is trivially destructible by design, so zeroing it is a
+// plain store -- which keeps the handler safe even if another thread held the
+// allocator lock at fork() time. The write_queue/http2/tls_session blocks are
+// deliberately leaked into the child's private image for the same reason; a
+// poisoned child issues no further RPCs.
+static void lupine_rpc_atfork_child() {
+  bool inherited = nconns > 0;
+  for (int i = 0; i < nconns; ++i) {
+    if (!conns[i].closed && conns[i].connfd != LUPINE_INVALID_SOCKET) {
+      close(conns[i].connfd);
+    }
+    conns[i] = {};
+    conns[i].connfd = LUPINE_INVALID_SOCKET;
+    // Routing may still hold pointers into this table; `closed` is what every
+    // read and write path checks first, so the stale entries stay inert.
+    conns[i].closed = 1;
+  }
+  nconns = 0;
+  lupine_rpc_shutting_down = false;
+  if (inherited) {
+    lupine_forked_child = true;
+  }
+  pthread_mutex_unlock(&conn_mutex);
+}
+
+static pthread_once_t lupine_rpc_fork_once = PTHREAD_ONCE_INIT;
+
+static void lupine_rpc_install_fork_handlers() {
+  pthread_atfork(lupine_rpc_atfork_prepare, lupine_rpc_atfork_parent,
+                 lupine_rpc_atfork_child);
+}
+#endif
+
+static void lupine_rpc_register_fork_handlers() {
+#ifndef _WIN32
+  pthread_once(&lupine_rpc_fork_once, lupine_rpc_install_fork_handlers);
+#endif
+}
+
 void rpc_destroy_thread_lane(uint64_t lane_id) {
   conn_t *active_conns[sizeof(conns) / sizeof(conns[0])];
   int count = 0;
@@ -8404,8 +8465,19 @@ close_connection:
 }
 
 int rpc_open() {
+  lupine_rpc_register_fork_handlers();
+
   if (pthread_mutex_lock(&conn_mutex) < 0)
     return -1;
+
+  // A process that forked after CUDA was initialized cannot use CUDA, exactly
+  // as with a local driver. Dialing a fresh connection here would be worse
+  // than failing: the child would get a second, empty context in which its
+  // teardown appears to succeed, hiding the fault instead of reporting it.
+  if (lupine_forked_child) {
+    pthread_mutex_unlock(&conn_mutex);
+    return -1;
+  }
 
   if (nconns > 0) {
     if (pthread_mutex_unlock(&conn_mutex) < 0)

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -280,6 +280,23 @@ inline int lupine_socket_apply_transport_options(lupine_socket_t fd) {
   return 0;
 }
 
+// lupine_socket_type_with_cloexec returns the type argument for socket(),
+// requesting close-on-exec atomically where the platform supports it.
+//
+// An RPC socket must not survive exec(). The client's connection table lives
+// in memory that exec() replaces, so the new image has no record of the
+// inherited descriptor: it can neither use it nor close it, yet it holds the
+// server-side connection open for as long as the exec'd process lives. Setting
+// the flag in socket() rather than with a follow-up fcntl() closes the window
+// where a concurrent fork+exec could copy the descriptor first.
+inline int lupine_socket_type_with_cloexec(int socktype) {
+#ifdef SOCK_CLOEXEC
+  return socktype | SOCK_CLOEXEC;
+#else
+  return socktype;
+#endif
+}
+
 // lupine_socket_connect_with_timeout connects `fd` to `addr`, waiting up to
 // `timeout_ms` milliseconds. A non-positive timeout performs a plain blocking
 // connect (the historical behavior). A bounded timeout prevents a

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -92,9 +92,65 @@ void *rpc_client_dispatch_thread(void *p) {
   return nullptr;
 }
 
+// Set by the fork handler; consumed by open_connection() below. The handler
+// itself must not touch the device/label vectors, because releasing their
+// storage means calling the allocator, which a child of a multi-threaded
+// parent may not do. Deferring that to the next call under the mutex keeps
+// the handler allocation-free without leaving the tables desynchronized.
+bool fork_reset_pending = false;
+
+#ifndef _WIN32
+void atfork_prepare() { pthread_mutex_lock(&conn_mutex); }
+
+void atfork_parent() { pthread_mutex_unlock(&conn_mutex); }
+
+// Abandon the connections inherited from the parent. close(), never
+// shutdown(): the descriptor is shared, so shutdown() would tear down the
+// connection the parent is still using. Unlike CUDA there is nothing to
+// poison -- NVML keeps no per-process device state that a fork invalidates --
+// so the child is simply left disconnected and may dial again on its own.
+void atfork_child() {
+  for (int i = 0; i < nconns; ++i) {
+    if (!conns[i].closed && conns[i].connfd != LUPINE_INVALID_SOCKET) {
+      close(conns[i].connfd);
+    }
+    conns[i] = {};
+    conns[i].connfd = LUPINE_INVALID_SOCKET;
+    conns[i].closed = 1;
+  }
+  nconns = 0;
+  connected = false;
+  devices_ready = false;
+  fork_reset_pending = true;
+  pthread_mutex_unlock(&conn_mutex);
+}
+
+pthread_once_t fork_once = PTHREAD_ONCE_INIT;
+
+void install_fork_handlers() {
+  pthread_atfork(atfork_prepare, atfork_parent, atfork_child);
+}
+#endif
+
+void register_fork_handlers() {
+#ifndef _WIN32
+  pthread_once(&fork_once, install_fork_handlers);
+#endif
+}
+
 int open_connection() {
+  register_fork_handlers();
+
   if (pthread_mutex_lock(&conn_mutex) < 0) {
     return -1;
+  }
+  if (fork_reset_pending) {
+    // Inherited entries described the parent's connections, which this process
+    // no longer has; dialing on top of them would desynchronize the label and
+    // device indices from conns[].
+    devices.clear();
+    conn_labels.clear();
+    fork_reset_pending = false;
   }
   if (connected) {
     pthread_mutex_unlock(&conn_mutex);
@@ -154,7 +210,9 @@ int open_connection() {
       continue;
     }
 
-    int sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    int sockfd = socket(res->ai_family,
+                        lupine_socket_type_with_cloexec(res->ai_socktype),
+                        res->ai_protocol);
     if (sockfd >= 0) {
       lupine_socket_apply_transport_options(sockfd);
       if (connect(sockfd, res->ai_addr, res->ai_addrlen) == 0) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -44,7 +44,9 @@ lupine_socket_t lupine_tcp_connect(const char *host, const char *port) {
     } else {
       for (addrinfo *ai = res; ai != nullptr; ai = ai->ai_next) {
         lupine_socket_t sockfd =
-            socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+            socket(ai->ai_family,
+                   lupine_socket_type_with_cloexec(ai->ai_socktype),
+                   ai->ai_protocol);
         if (sockfd == LUPINE_INVALID_SOCKET) {
           continue;
         }


### PR DESCRIPTION
A child process that inherits a connected client currently destroys the parent's GPU session on its way out. Observed in production: a training run finished, a child exited, and the server logged

  handling op 537528411   (cuLibraryUnload) x4
  handling op 1487179514  (cuDevicePrimaryCtxRelease_v2)
  RPC dispatch failed; closing client.   x2

after which every call in the still-running parent returned CUDA_ERROR_DEVICE_UNAVAILABLE.

Two things go wrong, both because the shim has no fork handling:

  - The child's own CUDA teardown is written to the socket it inherited, which addresses the PARENT's session, so the parent's primary context is released out from under it.
  - The ELF destructor then calls shutdown(SHUT_RDWR) on that shared descriptor. shutdown() is not refcounted across the parent's and child's copies, so it tears down the TCP connection the parent is still using -- one line per connection, hence two: the CUDA table in client.cpp and the independent NVML table in nvml_client.cpp.

None of this can happen with a local driver, which poisons CUDA in a forked child; replacing libcuda replaced that protection too.

Register pthread_atfork handlers for both connection tables. The child abandons the inherited transport rather than unwinding it -- every dispatch and read thread is gone and their mutexes are locked forever -- closing the descriptors with close(), which drops only this process's reference, and zeroing the table. The handler allocates and frees nothing (conn_t is trivially destructible, and NVML's vector cleanup is deferred to the next open_connection() under the mutex), so it stays safe when another thread held the allocator lock at fork() time.

CUDA is then latched off in the child, matching the driver's local semantics: re-dialing would hand the child an empty second context in which its teardown appears to succeed, hiding the fault. NVML is not latched -- it keeps no per-process device state a fork invalidates -- so a child may simply connect again. A process that forks BEFORE initializing is untouched and connects normally, as it does locally.

Also request SOCK_CLOEXEC when dialing. exec() replaces the connection table, so an inherited descriptor is one the new image can neither use nor close, while it holds the server-side connection open.