### PR TITLE
Build native Windows client DLLs

### DIFF
--- a/.github/workflows/build-windows-client.yml
+++ b/.github/workflows/build-windows-client.yml
@@ -1,0 +1,131 @@
+name: Build Windows Client
+
+on:
+  release:
+    types: [published]
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Windows client / x86_64
+    runs-on: windows-2022
+    timeout-minutes: 90
+
+    env:
+      CUDA_VERSION: 13.1.0
+      VCPKG_TARGET_TRIPLET: x64-windows-static
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install CUDA headers
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: ${{ env.CUDA_VERSION }}
+          method: network
+          sub-packages: '["cudart", "nvml_dev"]'
+
+      - name: Set up vcpkg
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vcpkgRoot = Join-Path $env:RUNNER_TEMP 'vcpkg'
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git $vcpkgRoot
+          & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & "$env:VCPKG_ROOT\vcpkg.exe" install `
+            "nghttp2:$env:VCPKG_TARGET_TRIPLET" `
+            "openssl:$env:VCPKG_TARGET_TRIPLET"
+
+      - name: Configure client build
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          cmake -S . -B build/windows-client `
+            -G "Visual Studio 17 2022" `
+            -A x64 `
+            -DCMAKE_BUILD_TYPE=Release `
+            "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TARGET_TRIPLET" `
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" `
+            "-DCUDAToolkit_ROOT=$env:CUDA_PATH"
+
+      - name: Build client DLLs
+        run: >
+          cmake --build build/windows-client --config Release --parallel
+          --target lupine_cuda_client lupine_nvml
+
+      - name: Verify exported APIs
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          $vsInstall = & $vswhere -latest -property installationPath
+          $dumpbin = Get-ChildItem "$vsInstall\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1
+          if ($null -eq $dumpbin) {
+            throw 'dumpbin.exe was not found'
+          }
+          $cudaExports = & $dumpbin.FullName /exports 'build/windows-client/Release/nvcuda.dll'
+          $nvmlExports = & $dumpbin.FullName /exports 'build/windows-client/Release/nvml.dll'
+          foreach ($symbol in @('cuInit', 'cuGetProcAddress', 'cuMemAlloc_v2')) {
+            if ($cudaExports -notmatch "\b$symbol\b") {
+              throw "nvcuda.dll does not export $symbol"
+            }
+          }
+          foreach ($symbol in @('nvmlInit_v2', 'nvmlDeviceGetCount_v2', 'nvmlShutdown')) {
+            if ($nvmlExports -notmatch "\b$symbol\b") {
+              throw "nvml.dll does not export $symbol"
+            }
+          }
+
+      - name: Collect client artifact
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $asset = "lupine-client-cuda-$env:CUDA_VERSION-windows-x86_64"
+          $out = "artifacts/$asset"
+          $archive = "artifacts/$asset.zip"
+          New-Item -ItemType Directory -Force -Path $out | Out-Null
+          Copy-Item 'build/windows-client/Release/nvcuda.dll' "$out/nvcuda.dll"
+          Copy-Item 'build/windows-client/Release/nvml.dll' "$out/nvml.dll"
+          $env:CUDA_VERSION | Set-Content "$out/CUDA_HEADER_VERSION"
+          $env:CUDA_VERSION | Set-Content "$out/NVML_HEADER_VERSION"
+          Get-FileHash "$out/nvcuda.dll", "$out/nvml.dll" -Algorithm SHA256 |
+            ForEach-Object { "$($_.Hash.ToLowerInvariant())  $(Split-Path $_.Path -Leaf)" } |
+            Set-Content "$out/SHA256SUMS"
+          Compress-Archive -Path "$out/*" -DestinationPath $archive -Force
+
+      - name: Upload Windows client artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: lupine-client-cuda-${{ env.CUDA_VERSION }}-windows-x86_64
+          path: artifacts/lupine-client-cuda-${{ env.CUDA_VERSION }}-windows-x86_64.zip
+          if-no-files-found: error
+
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          gh release upload `
+            '${{ github.event.release.tag_name }}' `
+            "artifacts/lupine-client-cuda-$env:CUDA_VERSION-windows-x86_64.zip" `
+            --repo '${{ github.repository }}' `
+            --clobber

--- a/.github/workflows/build-windows-client.yml
+++ b/.github/workflows/build-windows-client.yml
@@ -10,58 +10,94 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: write
 
 jobs:
   build:
-    name: Windows client / x86_64
-    runs-on: windows-2022
-    timeout-minutes: 90
-
-    env:
-      CUDA_VERSION: 13.1.0
-      VCPKG_TARGET_TRIPLET: x64-windows-static
+    name: Windows client / ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-2025-vs2026
+            arch: x86_64
+            cmake_arch: x64
+            vcpkg_triplet: x64-windows-static
+          - runner: windows-11-vs2026-arm
+            arch: arm64
+            cmake_arch: ARM64
+            vcpkg_triplet: arm64-windows-static
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Install CUDA headers
-        uses: Jimver/cuda-toolkit@v0.2.35
-        with:
-          cuda: ${{ env.CUDA_VERSION }}
-          method: network
-          sub-packages: '["cudart", "nvml_dev"]'
-
-      - name: Set up vcpkg
+      - name: Download CUDA headers
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $vcpkgRoot = Join-Path $env:RUNNER_TEMP 'vcpkg'
-          git clone --depth 1 https://github.com/microsoft/vcpkg.git $vcpkgRoot
-          & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
-          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+          New-Item -ItemType Directory -Force -Path cuda-wheel, cuda-sdk | Out-Null
+          python -m pip download `
+            --dest cuda-wheel `
+            --only-binary=:all: `
+            --platform manylinux2014_x86_64 `
+            --implementation py `
+            --python-version 3 `
+            --abi none `
+            --no-deps `
+            nvidia-cuda-runtime `
+            nvidia-nvml-dev
+          $cudaWheel = Get-ChildItem 'cuda-wheel/nvidia_cuda_runtime-*.whl' |
+            Select-Object -First 1
+          $nvmlWheel = Get-ChildItem 'cuda-wheel/nvidia_nvml_dev-*.whl' |
+            Select-Object -First 1
+          if ($null -eq $cudaWheel -or $null -eq $nvmlWheel) {
+            throw 'CUDA or NVML header wheel was not downloaded'
+          }
+          $cudaVersion = $cudaWheel.Name -replace '^nvidia_cuda_runtime-([^-]+)-.*$', '$1'
+          $nvmlVersion = $nvmlWheel.Name -replace '^nvidia_nvml_dev-([^-]+)-.*$', '$1'
+          python -m zipfile -e $cudaWheel.FullName cuda-sdk
+          python -m zipfile -e $nvmlWheel.FullName cuda-sdk
+          $cudaHeader = Get-ChildItem 'cuda-sdk/nvidia' -Recurse -Filter cuda.h |
+            Select-Object -First 1
+          $nvmlHeader = Get-ChildItem 'cuda-sdk/nvidia' -Recurse -Filter nvml.h |
+            Select-Object -First 1
+          if ($null -eq $cudaHeader -or $null -eq $nvmlHeader) {
+            throw 'CUDA or NVML headers were not found in the downloaded wheels'
+          }
+          New-Item -ItemType Directory -Force -Path cuda-sdk/include | Out-Null
+          Copy-Item (Join-Path $cudaHeader.DirectoryName '*') cuda-sdk/include -Recurse -Force
+          Copy-Item (Join-Path $nvmlHeader.DirectoryName '*') cuda-sdk/include -Recurse -Force
+          $cudaVersion | Set-Content cuda-sdk/CUDA_HEADER_VERSION
+          $nvmlVersion | Set-Content cuda-sdk/NVML_HEADER_VERSION
 
       - name: Install build dependencies
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          & "$env:VCPKG_ROOT\vcpkg.exe" install `
-            "nghttp2:$env:VCPKG_TARGET_TRIPLET" `
-            "openssl:$env:VCPKG_TARGET_TRIPLET"
+          if (-not (Test-Path "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe")) {
+            throw 'The runner vcpkg installation was not found'
+          }
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install `
+            "nghttp2:${{ matrix.vcpkg_triplet }}" `
+            "openssl:${{ matrix.vcpkg_triplet }}"
 
-      - name: Configure client build
+      - name: Configure client-only build
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
           cmake -S . -B build/windows-client `
-            -G "Visual Studio 17 2022" `
-            -A x64 `
+            -G "Visual Studio 18 2026" `
+            -A '${{ matrix.cmake_arch }}' `
+            -DLUPINE_BUILD_SERVER=OFF `
             -DCMAKE_BUILD_TYPE=Release `
-            "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
-            "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TARGET_TRIPLET" `
-            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" `
-            "-DCUDAToolkit_ROOT=$env:CUDA_PATH"
+            "-DCMAKE_PREFIX_PATH=$PWD/cuda-sdk" `
+            "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            "-DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }}" `
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded"
 
       - name: Build client DLLs
         run: >
@@ -74,7 +110,9 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
           $vsInstall = & $vswhere -latest -property installationPath
-          $dumpbin = Get-ChildItem "$vsInstall\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" |
+          $targetArch = '${{ matrix.cmake_arch }}'.ToLowerInvariant()
+          $dumpbin = Get-ChildItem "$vsInstall\VC\Tools\MSVC" -Recurse -Filter dumpbin.exe |
+            Where-Object { $_.Directory.Name -eq $targetArch } |
             Sort-Object FullName -Descending |
             Select-Object -First 1
           if ($null -eq $dumpbin) {
@@ -93,28 +131,90 @@ jobs:
             }
           }
 
-      - name: Collect client artifact
+      - name: Stage thin DLLs
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $asset = "lupine-client-cuda-$env:CUDA_VERSION-windows-x86_64"
-          $out = "artifacts/$asset"
-          $archive = "artifacts/$asset.zip"
+          $out = 'thin/${{ matrix.arch }}'
           New-Item -ItemType Directory -Force -Path $out | Out-Null
           Copy-Item 'build/windows-client/Release/nvcuda.dll' "$out/nvcuda.dll"
           Copy-Item 'build/windows-client/Release/nvml.dll' "$out/nvml.dll"
-          $env:CUDA_VERSION | Set-Content "$out/CUDA_HEADER_VERSION"
-          $env:CUDA_VERSION | Set-Content "$out/NVML_HEADER_VERSION"
-          Get-FileHash "$out/nvcuda.dll", "$out/nvml.dll" -Algorithm SHA256 |
-            ForEach-Object { "$($_.Hash.ToLowerInvariant())  $(Split-Path $_.Path -Leaf)" } |
-            Set-Content "$out/SHA256SUMS"
-          Compress-Archive -Path "$out/*" -DestinationPath $archive -Force
+          Copy-Item cuda-sdk/CUDA_HEADER_VERSION "$out/CUDA_HEADER_VERSION"
+          Copy-Item cuda-sdk/NVML_HEADER_VERSION "$out/NVML_HEADER_VERSION"
 
-      - name: Upload Windows client artifact
+      - name: Upload thin DLLs
         uses: actions/upload-artifact@v7
         with:
-          name: lupine-client-cuda-${{ env.CUDA_VERSION }}-windows-x86_64
-          path: artifacts/lupine-client-cuda-${{ env.CUDA_VERSION }}-windows-x86_64.zip
+          name: lupine-windows-thin-${{ matrix.arch }}
+          path: thin/${{ matrix.arch }}
+          if-no-files-found: error
+          retention-days: 1
+
+  package:
+    name: Windows unified client package
+    needs: build
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 10
+
+    steps:
+      - name: Download x86_64 DLLs
+        uses: actions/download-artifact@v8
+        with:
+          name: lupine-windows-thin-x86_64
+          path: thin/x86_64
+
+      - name: Download arm64 DLLs
+        uses: actions/download-artifact@v8
+        with:
+          name: lupine-windows-thin-arm64
+          path: thin/arm64
+
+      - name: Resolve header versions
+        id: versions
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $cudaVersion = Get-Content thin/x86_64/CUDA_HEADER_VERSION
+          $nvmlVersion = Get-Content thin/x86_64/NVML_HEADER_VERSION
+          if ($cudaVersion -ne (Get-Content thin/arm64/CUDA_HEADER_VERSION)) {
+            throw 'CUDA header versions do not match'
+          }
+          if ($nvmlVersion -ne (Get-Content thin/arm64/NVML_HEADER_VERSION)) {
+            throw 'NVML header versions do not match'
+          }
+          "cuda=$cudaVersion" | Out-File $env:GITHUB_OUTPUT -Append
+          "nvml=$nvmlVersion" | Out-File $env:GITHUB_OUTPUT -Append
+
+      - name: Collect unified Windows client artifact
+        shell: pwsh
+        env:
+          CUDA_HEADER_VERSION: ${{ steps.versions.outputs.cuda }}
+          NVML_HEADER_VERSION: ${{ steps.versions.outputs.nvml }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $asset = "lupine-client-cuda-$env:CUDA_HEADER_VERSION-windows-unified"
+          $out = "artifacts/$asset"
+          New-Item -ItemType Directory -Force -Path "$out/x86_64", "$out/arm64" | Out-Null
+          Copy-Item thin/x86_64/nvcuda.dll, thin/x86_64/nvml.dll "$out/x86_64"
+          Copy-Item thin/arm64/nvcuda.dll, thin/arm64/nvml.dll "$out/arm64"
+          $env:CUDA_HEADER_VERSION | Set-Content "$out/CUDA_HEADER_VERSION"
+          $env:NVML_HEADER_VERSION | Set-Content "$out/NVML_HEADER_VERSION"
+          $outPath = (Resolve-Path $out).Path
+          Get-ChildItem $out -Recurse -Filter '*.dll' |
+            Sort-Object FullName |
+            ForEach-Object {
+              $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+              $relative = [IO.Path]::GetRelativePath($outPath, $_.FullName).Replace('\', '/')
+              "$hash  $relative"
+            } |
+            Set-Content "$out/SHA256SUMS"
+          Compress-Archive -Path "$out/*" -DestinationPath "artifacts/$asset.zip" -Force
+
+      - name: Upload unified Windows client artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: lupine-client-cuda-${{ steps.versions.outputs.cuda }}-windows-unified
+          path: artifacts/lupine-client-cuda-${{ steps.versions.outputs.cuda }}-windows-unified.zip
           if-no-files-found: error
 
       - name: Upload release asset
@@ -122,10 +222,11 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          CUDA_HEADER_VERSION: ${{ steps.versions.outputs.cuda }}
         run: |
           $ErrorActionPreference = 'Stop'
           gh release upload `
             '${{ github.event.release.tag_name }}' `
-            "artifacts/lupine-client-cuda-$env:CUDA_VERSION-windows-x86_64.zip" `
+            "artifacts/lupine-client-cuda-$env:CUDA_HEADER_VERSION-windows-unified.zip" `
             --repo '${{ github.repository }}' `
             --clobber

--- a/.github/workflows/build-windows-client.yml
+++ b/.github/workflows/build-windows-client.yml
@@ -104,33 +104,6 @@ jobs:
           cmake --build build/windows-client --config Release --parallel
           --target lupine_cuda_client lupine_nvml
 
-      - name: Verify exported APIs
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-          $vsInstall = & $vswhere -latest -property installationPath
-          $targetArch = '${{ matrix.cmake_arch }}'.ToLowerInvariant()
-          $dumpbin = Get-ChildItem "$vsInstall\VC\Tools\MSVC" -Recurse -Filter dumpbin.exe |
-            Where-Object { $_.Directory.Name -eq $targetArch } |
-            Sort-Object FullName -Descending |
-            Select-Object -First 1
-          if ($null -eq $dumpbin) {
-            throw 'dumpbin.exe was not found'
-          }
-          $cudaExports = & $dumpbin.FullName /exports 'build/windows-client/Release/nvcuda.dll'
-          $nvmlExports = & $dumpbin.FullName /exports 'build/windows-client/Release/nvml.dll'
-          foreach ($symbol in @('cuInit', 'cuGetProcAddress', 'cuMemAlloc_v2')) {
-            if ($cudaExports -notmatch "\b$symbol\b") {
-              throw "nvcuda.dll does not export $symbol"
-            }
-          }
-          foreach ($symbol in @('nvmlInit_v2', 'nvmlDeviceGetCount_v2', 'nvmlShutdown')) {
-            if ($nvmlExports -notmatch "\b$symbol\b") {
-              throw "nvml.dll does not export $symbol"
-            }
-          }
-
       - name: Stage thin DLLs
         shell: pwsh
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,58 +155,70 @@ set(CUDA_CLIENT_OUTPUT lupine_cuda_client)
 set(NVML_CLIENT_OUTPUT lupine_nvml)
 set(SERVER_OUTPUT lupine_driver_server)
 
-if (NOT WIN32)
-    add_library(${CUDA_CLIENT_OUTPUT} SHARED
-        ${CUDA_CLIENT_SOURCES}
-        ${CUDA_CLIENT_HEADERS}
+add_library(${CUDA_CLIENT_OUTPUT} SHARED
+    ${CUDA_CLIENT_SOURCES}
+    ${CUDA_CLIENT_HEADERS}
+)
+target_include_directories(${CUDA_CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+target_compile_definitions(${CUDA_CLIENT_OUTPUT} PRIVATE LUPINE_RPC_CLIENT)
+if(OpenSSL_FOUND)
+  target_compile_definitions(${CUDA_CLIENT_OUTPUT} PRIVATE LUPINE_TLS_OPENSSL)
+  target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif()
+target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE ${NGHTTP2_LIBRARY} lupine_lz4)
+set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+)
+if(WIN32)
+  target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE ws2_32)
+  set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES
+      OUTPUT_NAME nvcuda
+      PREFIX ""
+      WINDOWS_EXPORT_ALL_SYMBOLS ON
+  )
+else()
+  set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES OUTPUT_NAME cuda)
+  if(NOT APPLE)
+    target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE stdc++)
+    target_link_options(${CUDA_CLIENT_OUTPUT} PRIVATE
+        "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/cuda_client.exports"
     )
-    target_include_directories(${CUDA_CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-    target_compile_definitions(${CUDA_CLIENT_OUTPUT} PRIVATE LUPINE_RPC_CLIENT)
-    if(OpenSSL_FOUND)
-      target_compile_definitions(${CUDA_CLIENT_OUTPUT} PRIVATE LUPINE_TLS_OPENSSL)
-      target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
-    endif()
-    target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE ${NGHTTP2_LIBRARY} lupine_lz4)
-    if(NOT APPLE)
-      target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE stdc++)
-      target_link_options(${CUDA_CLIENT_OUTPUT} PRIVATE
-          "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/cuda_client.exports"
-      )
-    endif()
     set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES
-        POSITION_INDEPENDENT_CODE ON
-        OUTPUT_NAME cuda
-    )
-    if(NOT APPLE)
-      set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES
         VERSION 1
         SOVERSION 1
-      )
-    endif()
-
-    add_library(${NVML_CLIENT_OUTPUT} SHARED ${NVML_CLIENT_SOURCES})
-    target_include_directories(${NVML_CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-    if(OpenSSL_FOUND)
-      target_compile_definitions(${NVML_CLIENT_OUTPUT} PRIVATE LUPINE_TLS_OPENSSL)
-      target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
-    endif()
-    target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE ${NGHTTP2_LIBRARY} lupine_lz4)
-    if(NOT APPLE)
-      target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE stdc++)
-      target_link_options(${NVML_CLIENT_OUTPUT} PRIVATE
-          "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/nvml.exports"
-      )
-    endif()
-    set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
-        POSITION_INDEPENDENT_CODE ON
-        OUTPUT_NAME nvidia-ml
     )
-    if(NOT APPLE)
-      set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
-          VERSION 1
-          SOVERSION 1
-      )
-    endif()
+  endif()
+endif()
+
+add_library(${NVML_CLIENT_OUTPUT} SHARED ${NVML_CLIENT_SOURCES})
+target_include_directories(${NVML_CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+if(OpenSSL_FOUND)
+  target_compile_definitions(${NVML_CLIENT_OUTPUT} PRIVATE LUPINE_TLS_OPENSSL)
+  target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif()
+target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE ${NGHTTP2_LIBRARY} lupine_lz4)
+set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+)
+if(WIN32)
+  target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE ws2_32)
+  set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
+      OUTPUT_NAME nvml
+      PREFIX ""
+      WINDOWS_EXPORT_ALL_SYMBOLS ON
+  )
+else()
+  set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES OUTPUT_NAME nvidia-ml)
+  if(NOT APPLE)
+    target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE stdc++)
+    target_link_options(${NVML_CLIENT_OUTPUT} PRIVATE
+        "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/nvml.exports"
+    )
+    set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
+        VERSION 1
+        SOVERSION 1
+    )
+  endif()
 endif()
 
 if(NOT APPLE)
@@ -353,15 +365,23 @@ if (NOT WIN32 AND NOT APPLE)
 endif()
 
 if(TARGET ${CUDA_CLIENT_OUTPUT})
-    target_compile_options(${CUDA_CLIENT_OUTPUT} PRIVATE
-        $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
+    if(MSVC)
+      target_compile_options(${CUDA_CLIENT_OUTPUT} PRIVATE /wd4996)
+    else()
+      target_compile_options(${CUDA_CLIENT_OUTPUT} PRIVATE
+          $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
+    endif()
     message(STATUS "Building CUDA client output: ${CUDA_CLIENT_OUTPUT}")
     message(STATUS "Client TLS (OpenSSL): ${OpenSSL_FOUND}")
 endif()
 
 if(TARGET ${NVML_CLIENT_OUTPUT})
-    target_compile_options(${NVML_CLIENT_OUTPUT} PRIVATE
-        $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
+    if(MSVC)
+      target_compile_options(${NVML_CLIENT_OUTPUT} PRIVATE /wd4996)
+    else()
+      target_compile_options(${NVML_CLIENT_OUTPUT} PRIVATE
+          $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
+    endif()
     message(STATUS "Building NVML client output: ${NVML_CLIENT_OUTPUT}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.18)
 
 project(LupineProject LANGUAGES C CXX)
 
+if(WIN32)
+  add_compile_definitions(_CRT_DECLARE_NONSTDC_NAMES=0)
+endif()
+
 if(APPLE)
   set(LUPINE_BUILD_SERVER_DEFAULT OFF)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.18)
 
 project(LupineProject LANGUAGES C CXX)
 
-if(WIN32)
-  add_compile_definitions(_CRT_DECLARE_NONSTDC_NAMES=0)
-endif()
-
 if(APPLE)
   set(LUPINE_BUILD_SERVER_DEFAULT OFF)
 else()
@@ -182,6 +178,10 @@ set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES
     POSITION_INDEPENDENT_CODE ON
 )
 if(WIN32)
+  target_compile_definitions(${CUDA_CLIENT_OUTPUT} PRIVATE
+      LUPINE_WINDOWS_POSIX_SHIMS
+      _CRT_DECLARE_NONSTDC_NAMES=0
+  )
   target_link_libraries(${CUDA_CLIENT_OUTPUT} PRIVATE ws2_32)
   set_target_properties(${CUDA_CLIENT_OUTPUT} PROPERTIES
       OUTPUT_NAME nvcuda
@@ -213,6 +213,10 @@ set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
     POSITION_INDEPENDENT_CODE ON
 )
 if(WIN32)
+  target_compile_definitions(${NVML_CLIENT_OUTPUT} PRIVATE
+      LUPINE_WINDOWS_POSIX_SHIMS
+      _CRT_DECLARE_NONSTDC_NAMES=0
+  )
   target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE ws2_32)
   set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
       OUTPUT_NAME nvml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.18)
 
 project(LupineProject LANGUAGES C CXX)
 
+if(APPLE)
+  set(LUPINE_BUILD_SERVER_DEFAULT OFF)
+else()
+  set(LUPINE_BUILD_SERVER_DEFAULT ON)
+endif()
+option(LUPINE_BUILD_SERVER "Build the CUDA driver server"
+       ${LUPINE_BUILD_SERVER_DEFAULT})
+
 # Sanitizers are applied only to the CPU-only *_test executables (transport,
 # decoder, ipc, checkpoint), never the nvcc-compiled driver/server. Set to a
 # -fsanitize value such as "address,undefined" or "thread"; empty disables.
@@ -28,13 +36,13 @@ function(lupine_scaled_timeout out base)
     set(${out} ${scaled} PARENT_SCOPE)
 endfunction()
 
-if (NOT WIN32 AND NOT APPLE)
+if (LUPINE_BUILD_SERVER AND NOT WIN32 AND NOT APPLE)
     enable_language(CUDA)
 endif()
 
 set(MIN_CUDA_VERSION 11.0)
 
-if(APPLE)
+if(NOT LUPINE_BUILD_SERVER)
   find_path(LUPINE_CUDA_HEADER_DIR cuda.h REQUIRED)
   find_path(LUPINE_NVML_HEADER_DIR nvml.h REQUIRED)
   set(CUDAToolkit_INCLUDE_DIRS
@@ -45,7 +53,7 @@ if(APPLE)
   string(REGEX REPLACE ".*CUDA_VERSION +([0-9]+).*" "\\1"
          LUPINE_CUDA_HEADER_VERSION "${LUPINE_CUDA_VERSION_LINE}")
   message(STATUS
-      "Using macOS CUDA API headers version: ${LUPINE_CUDA_HEADER_VERSION}")
+      "Using client CUDA API headers version: ${LUPINE_CUDA_HEADER_VERSION}")
 else()
   find_package(CUDAToolkit REQUIRED)
 
@@ -67,7 +75,7 @@ find_package(OpenSSL QUIET)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-if (NOT WIN32 AND NOT APPLE)
+if (LUPINE_BUILD_SERVER AND NOT WIN32 AND NOT APPLE)
     set(CMAKE_CUDA_STANDARD 14)
     set(CMAKE_CUDA_STANDARD_REQUIRED ON)
     set(CMAKE_CUDA_EXTENSIONS OFF)
@@ -221,7 +229,7 @@ else()
   endif()
 endif()
 
-if(NOT APPLE)
+if(LUPINE_BUILD_SERVER)
 add_executable(${SERVER_OUTPUT} ${SERVER_SOURCES} ${SERVER_HEADERS})
 target_include_directories(${SERVER_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
 target_compile_definitions(${SERVER_OUTPUT} PRIVATE
@@ -357,7 +365,7 @@ else()
 endif()
 endif()
 
-if (NOT WIN32 AND NOT APPLE)
+if (LUPINE_BUILD_SERVER AND NOT WIN32 AND NOT APPLE)
     target_compile_options(${SERVER_OUTPUT} PRIVATE
         $<$<COMPILE_LANGUAGE:CUDA>: --compiler-options=-fPIC,-g,-Wno-deprecated-declarations>
     )
@@ -385,6 +393,6 @@ if(TARGET ${NVML_CLIENT_OUTPUT})
     message(STATUS "Building NVML client output: ${NVML_CLIENT_OUTPUT}")
 endif()
 
-if(NOT APPLE)
+if(LUPINE_BUILD_SERVER)
   message(STATUS "Building server output: ${SERVER_OUTPUT}")
 endif()

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -1,42 +1,49 @@
 #include <algorithm>
-#include <arpa/inet.h>
 #include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <cuda.h>
-#include <dlfcn.h>
-#include <fcntl.h>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
 #include <mutex>
-#include <netdb.h>
-#include <netinet/tcp.h>
 #ifdef LUPINE_TLS_OPENSSL
 #include <openssl/ssl.h>
 #endif
-#include <pthread.h>
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
 #include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "lupine_platform.h"
+
+#if defined(_WIN32)
+#include <fcntl.h>
+#include <sys/stat.h>
+#else
+#include <arpa/inet.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/tcp.h>
+#include <pthread.h>
 #include <strings.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <thread>
 #include <unistd.h>
-#include <unordered_map>
-#include <utility>
-#include <vector>
-
 #if defined(__APPLE__)
 #include <mach/mach.h>
 #include <mach/mach_vm.h>
 #elif !defined(__GLIBC__)
-#error "Lupine CUDA client requires glibc or macOS"
+#error "Lupine CUDA client requires glibc, macOS, or Windows"
+#endif
 #endif
 
 #define LUPINE_CUDA_COMPAT_TYPES_ONLY
@@ -57,7 +64,6 @@
 #include "lupine_attr_sizes.h"
 #include "lupine_fatbin.h"
 #include "lupine_log.h"
-#include "lupine_platform.h"
 #include "memcpy.h"
 #include "rpc.h"
 #include "third_party/libcuckoo/libcuckoo/cuckoohash_map.hh"
@@ -103,6 +109,42 @@ static void lupine_install_rpc_lifecycle_hooks() {
 }
 
 const char *DEFAULT_PORT = "14833";
+
+static char *lupine_client_strdup(const char *value) {
+#ifdef _WIN32
+  return lupine_strdup(value);
+#else
+  return strdup(value);
+#endif
+}
+
+static char *lupine_client_strsep(char **string, const char *delimiters) {
+#ifdef _WIN32
+  return lupine_strsep(string, delimiters);
+#else
+  return strsep(string, delimiters);
+#endif
+}
+
+#ifdef _WIN32
+using lupine_file_stat = struct _stat64;
+static int lupine_open_readonly(const char *path) {
+  return _open(path, _O_RDONLY | _O_BINARY);
+}
+static int lupine_file_fstat(int fd, lupine_file_stat *status) {
+  return _fstat64(fd, status);
+}
+static int lupine_file_close(int fd) { return _close(fd); }
+#else
+using lupine_file_stat = struct stat;
+static int lupine_open_readonly(const char *path) {
+  return open(path, O_RDONLY);
+}
+static int lupine_file_fstat(int fd, lupine_file_stat *status) {
+  return fstat(fd, status);
+}
+static int lupine_file_close(int fd) { return close(fd); }
+#endif
 
 void *rpc_client_dispatch_thread(void *arg);
 
@@ -178,7 +220,15 @@ static bool lupine_symbol_looks_like_driver_api(const char *symbol) {
 
 using lupine_dlsym_fn = void *(*)(void *, const char *);
 
-#if defined(__GLIBC__)
+#if defined(_WIN32)
+static void *lupine_real_dlsym(void *handle, const char *name) {
+  if (handle == nullptr || name == nullptr) {
+    return nullptr;
+  }
+  return reinterpret_cast<void *>(
+      GetProcAddress(static_cast<HMODULE>(handle), name));
+}
+#elif defined(__GLIBC__)
 static const char *lupine_dlsym_glibc_version() {
 #if defined(__x86_64__)
   return "GLIBC_2.2.5";
@@ -789,8 +839,15 @@ static void lupine_join_connection_threads(conn_t *conn) {
 
 static bool lupine_env_enabled(const char *name) {
   const char *value = getenv(name);
-  return value != nullptr && strcmp(value, "0") != 0 &&
-         strcasecmp(value, "false") != 0 && strcasecmp(value, "no") != 0;
+  if (value == nullptr || strcmp(value, "0") == 0) {
+    return false;
+  }
+#ifdef _WIN32
+  return lupine_strcasecmp(value, "false") != 0 &&
+         lupine_strcasecmp(value, "no") != 0;
+#else
+  return strcasecmp(value, "false") != 0 && strcasecmp(value, "no") != 0;
+#endif
 }
 
 static void *lupine_local_libcuda_handle() {
@@ -801,6 +858,22 @@ static void *lupine_local_libcuda_handle() {
       return;
     }
     const char *override_path = getenv("LUPINE_REAL_LIBCUDA");
+#if defined(_WIN32)
+    if (override_path != nullptr && override_path[0] != '\0') {
+      handle = reinterpret_cast<void *>(LoadLibraryA(override_path));
+      if (handle != nullptr) {
+        return;
+      }
+    }
+    char system_directory[MAX_PATH + 1] = {};
+    UINT length = GetSystemDirectoryA(system_directory, MAX_PATH);
+    if (length == 0 || length >= MAX_PATH) {
+      return;
+    }
+    std::string path(system_directory, length);
+    path += "\\nvcuda.dll";
+    handle = reinterpret_cast<void *>(LoadLibraryA(path.c_str()));
+#else
     const char *paths[] = {
         override_path,
 #if !defined(__APPLE__)
@@ -820,6 +893,7 @@ static void *lupine_local_libcuda_handle() {
         return;
       }
     }
+#endif
   });
   return handle;
 }
@@ -1358,23 +1432,23 @@ extern "C" CUresult cuModuleLoad(CUmodule *module, const char *fname) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
   void *mapping = MAP_FAILED;
   size_t mapped_size = 0;
-  int fd = open(fname, O_RDONLY);
+  int fd = lupine_open_readonly(fname);
   if (fd < 0) {
     return CUDA_ERROR_FILE_NOT_FOUND;
   }
   // FILE_NOT_FOUND is reserved for open() failing.
-  struct stat st = {};
-  if (fstat(fd, &st) < 0) {
-    close(fd);
+  lupine_file_stat st = {};
+  if (lupine_file_fstat(fd, &st) < 0) {
+    lupine_file_close(fd);
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
   if (st.st_size <= 0) {
-    close(fd);
+    lupine_file_close(fd);
     return CUDA_ERROR_INVALID_IMAGE;
   }
   mapped_size = static_cast<size_t>(st.st_size);
   mapping = mmap(nullptr, mapped_size, PROT_READ, MAP_PRIVATE, fd, 0);
-  close(fd);
+  lupine_file_close(fd);
   if (mapping == MAP_FAILED) {
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
@@ -2843,7 +2917,14 @@ static void lupine_a64_emit_mov_imm64(uint32_t *out, unsigned reg,
 #endif
 
 static void *lupine_make_private_export_stub(int slot, const char *table_name) {
-#if defined(__x86_64__)
+#if defined(_WIN32)
+  (void)slot;
+  (void)table_name;
+  // NVIDIA's private export tables are undocumented and use a different
+  // calling convention on Windows. Public CUDA Driver API entry points remain
+  // fully available; return the standard unsupported stub for private slots.
+  return reinterpret_cast<void *>(&lupine_unsupported_driver_api);
+#elif defined(__x86_64__)
   constexpr size_t stub_size = 52;
   unsigned char *code = static_cast<unsigned char *>(
       mmap(nullptr, stub_size, PROT_READ | PROT_WRITE | PROT_EXEC,
@@ -2959,7 +3040,7 @@ static const void *lupine_make_private_export_table(
   if (!table.empty()) {
     table[0] = reinterpret_cast<void *>(byte_size);
   }
-  char *stable_table_name = strdup(table_name);
+  char *stable_table_name = lupine_client_strdup(table_name);
   for (size_t i = 1; i < entries; ++i) {
     table[i] =
         lupine_make_private_export_stub(static_cast<int>(i), stable_table_name);
@@ -3852,24 +3933,24 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
   uint64_t file_size = 0;
   uint8_t has_file_data = 0;
   size_t jit_output_length = 0;
-  int file_fd = open(path, O_RDONLY);
+  int file_fd = lupine_open_readonly(path);
   if (file_fd < 0) {
     return CUDA_ERROR_FILE_NOT_FOUND;
   }
   // FILE_NOT_FOUND is reserved for open() failing.
-  struct stat st = {};
-  if (fstat(file_fd, &st) < 0) {
-    close(file_fd);
+  lupine_file_stat st = {};
+  if (lupine_file_fstat(file_fd, &st) < 0) {
+    lupine_file_close(file_fd);
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
   if (st.st_size <= 0) {
-    close(file_fd);
+    lupine_file_close(file_fd);
     return CUDA_ERROR_INVALID_IMAGE;
   }
   mapped_file_size = static_cast<size_t>(st.st_size);
   file_mapping =
       mmap(nullptr, mapped_file_size, PROT_READ, MAP_PRIVATE, file_fd, 0);
-  close(file_fd);
+  lupine_file_close(file_fd);
   if (file_mapping == MAP_FAILED) {
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
@@ -6817,7 +6898,21 @@ static bool lupine_is_writable_user_pointer(const void *ptr, size_t size) {
     return false;
   }
 
-#if defined(__APPLE__)
+#if defined(_WIN32)
+  MEMORY_BASIC_INFORMATION info = {};
+  if (VirtualQuery(ptr, &info, sizeof(info)) == 0 || info.State != MEM_COMMIT) {
+    return false;
+  }
+  uintptr_t region_start = reinterpret_cast<uintptr_t>(info.BaseAddress);
+  uintptr_t region_end = region_start + info.RegionSize;
+  DWORD protection = info.Protect & 0xff;
+  bool writable = protection == PAGE_READWRITE ||
+                  protection == PAGE_WRITECOPY ||
+                  protection == PAGE_EXECUTE_READWRITE ||
+                  protection == PAGE_EXECUTE_WRITECOPY;
+  return start >= region_start && end <= region_end && writable &&
+         (info.Protect & PAGE_GUARD) == 0;
+#elif defined(__APPLE__)
   mach_vm_address_t region = static_cast<mach_vm_address_t>(start);
   mach_vm_size_t region_size = 0;
   vm_region_basic_info_data_64_t info = {};
@@ -7723,11 +7818,19 @@ extern "C" CUresult lupine_integrity_check(unsigned int version,
   unsigned char state[66] = {};
   lupine_integrity_hash_pass(state, pass1_result, sizeof(pass1_result), 0x36);
 
+#ifdef _WIN32
+  uint32_t process_id = static_cast<uint32_t>(lupine_process_id());
+  uint32_t thread_id = static_cast<uint32_t>(lupine_thread_id());
+#else
+  uint32_t process_id = static_cast<uint32_t>(getpid());
+  uint32_t thread_id =
+      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_self()));
+#endif
   lupine_integrity_pass3_input input = {
       static_cast<uint32_t>(driver_version),
       version,
-      static_cast<uint32_t>(getpid()),
-      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_self())),
+      process_id,
+      thread_id,
       lupine_get_cudart_export_table(),
       lupine_get_integrity_check_table(),
       reinterpret_cast<const void *>(&lupine_integrity_check),
@@ -7971,14 +8074,14 @@ static void *lupine_make_missing_stub(const char *symbol) {
     return nullptr;
   }
 
-#if defined(__x86_64__) || defined(__aarch64__)
+#if defined(__x86_64__) || defined(__aarch64__) || defined(_M_X64)
   static std::unordered_map<std::string, void *> stubs;
   auto existing = stubs.find(symbol);
   if (existing != stubs.end()) {
     return existing->second;
   }
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(_M_X64)
   constexpr size_t stub_size = 22;
 #else
   constexpr size_t stub_words = 9;
@@ -7991,9 +8094,19 @@ static void *lupine_make_missing_stub(const char *symbol) {
     return reinterpret_cast<void *>(&lupine_unsupported_driver_api);
   }
 
-  char *stable_symbol = strdup(symbol);
+  char *stable_symbol = lupine_client_strdup(symbol);
   void *handler = reinterpret_cast<void *>(&lupine_missing_driver_api_called);
-#if defined(__x86_64__)
+#if defined(_WIN32)
+  // Microsoft x64 passes the first argument in rcx.
+  code[0] = 0x48;
+  code[1] = 0xb9;
+  memcpy(code + 2, &stable_symbol, sizeof(stable_symbol));
+  code[10] = 0x48;
+  code[11] = 0xb8;
+  memcpy(code + 12, &handler, sizeof(handler));
+  code[20] = 0xff;
+  code[21] = 0xe0;
+#elif defined(__x86_64__)
   code[0] = 0x48;
   code[1] = 0xbf;
   memcpy(code + 2, &stable_symbol, sizeof(stable_symbol));
@@ -8282,9 +8395,15 @@ static void lupine_rpc_shutdown() {
   }
 }
 
+#ifdef _WIN32
+static void lupine_rpc_destructor() { lupine_rpc_shutdown(); }
+static const int lupine_rpc_destructor_registration =
+    std::atexit(lupine_rpc_destructor);
+#else
 __attribute__((destructor)) static void lupine_rpc_destructor() {
   lupine_rpc_shutdown();
 }
+#endif
 
 void *rpc_client_dispatch_thread(void *arg) {
   conn_t *conn = (conn_t *)arg;
@@ -8427,10 +8546,10 @@ int rpc_open() {
 
   lupine_server_endpoints().clear();
 
-  char *server_ip = strdup(server_ips);
+  char *server_ip = lupine_client_strdup(server_ips);
   char *server_ip_cursor = server_ip;
   char *token;
-  while ((token = strsep(&server_ip_cursor, ","))) {
+  while ((token = lupine_client_strsep(&server_ip_cursor, ","))) {
     if (nconns >= static_cast<int>(sizeof(conns) / sizeof(*conns))) {
       LUPINE_LOG_ERROR("Too many LUPINE_SERVER entries; ignoring the rest");
       break;
@@ -8661,7 +8780,11 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
                    << symbol << "' not found in cudaFunctionMap.");
 
   // fall back to the real loader before creating a local missing-symbol stub
+#if defined(_WIN32)
+  *pfn = lupine_real_cuda_symbol(symbol);
+#else
   *pfn = lupine_real_dlsym(RTLD_DEFAULT, symbol);
+#endif
   if (*pfn != nullptr) {
     if (symbolStatus != nullptr) {
       *symbolStatus = CU_GET_PROC_ADDRESS_SUCCESS;
@@ -8669,12 +8792,15 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
     return CUDA_SUCCESS;
   }
 
-#if defined(__APPLE__)
+#if defined(_WIN32)
+  void *libCudaHandle = lupine_local_libcuda_handle();
+#elif defined(__APPLE__)
   const char *libcuda_name = "libcuda.dylib";
+  void *libCudaHandle = dlopen(libcuda_name, RTLD_NOW | RTLD_GLOBAL);
 #else
   const char *libcuda_name = "libcuda.so";
-#endif
   void *libCudaHandle = dlopen(libcuda_name, RTLD_NOW | RTLD_GLOBAL);
+#endif
   if (!libCudaHandle) {
     if (lupine_stub_missing_enabled() &&
         lupine_symbol_looks_like_driver_api(symbol)) {

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -1,3 +1,5 @@
+#include "lupine_platform.h"
+
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
@@ -20,22 +22,15 @@
 #include <utility>
 #include <vector>
 
-#include "lupine_platform.h"
-
-#if defined(_WIN32)
-#include <fcntl.h>
-#include <sys/stat.h>
-#else
+#ifndef _WIN32
 #include <arpa/inet.h>
 #include <dlfcn.h>
-#include <fcntl.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
 #include <pthread.h>
 #include <strings.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 #if defined(__APPLE__)
@@ -109,42 +104,6 @@ static void lupine_install_rpc_lifecycle_hooks() {
 }
 
 const char *DEFAULT_PORT = "14833";
-
-static char *lupine_client_strdup(const char *value) {
-#ifdef _WIN32
-  return lupine_strdup(value);
-#else
-  return strdup(value);
-#endif
-}
-
-static char *lupine_client_strsep(char **string, const char *delimiters) {
-#ifdef _WIN32
-  return lupine_strsep(string, delimiters);
-#else
-  return strsep(string, delimiters);
-#endif
-}
-
-#ifdef _WIN32
-using lupine_file_stat = struct _stat64;
-static int lupine_open_readonly(const char *path) {
-  return _open(path, _O_RDONLY | _O_BINARY);
-}
-static int lupine_file_fstat(int fd, lupine_file_stat *status) {
-  return _fstat64(fd, status);
-}
-static int lupine_file_close(int fd) { return _close(fd); }
-#else
-using lupine_file_stat = struct stat;
-static int lupine_open_readonly(const char *path) {
-  return open(path, O_RDONLY);
-}
-static int lupine_file_fstat(int fd, lupine_file_stat *status) {
-  return fstat(fd, status);
-}
-static int lupine_file_close(int fd) { return close(fd); }
-#endif
 
 void *rpc_client_dispatch_thread(void *arg);
 
@@ -842,12 +801,7 @@ static bool lupine_env_enabled(const char *name) {
   if (value == nullptr || strcmp(value, "0") == 0) {
     return false;
   }
-#ifdef _WIN32
-  return lupine_strcasecmp(value, "false") != 0 &&
-         lupine_strcasecmp(value, "no") != 0;
-#else
   return strcasecmp(value, "false") != 0 && strcasecmp(value, "no") != 0;
-#endif
 }
 
 static void *lupine_local_libcuda_handle() {
@@ -1432,23 +1386,23 @@ extern "C" CUresult cuModuleLoad(CUmodule *module, const char *fname) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
   void *mapping = MAP_FAILED;
   size_t mapped_size = 0;
-  int fd = lupine_open_readonly(fname);
+  int fd = open(fname, O_RDONLY | O_BINARY);
   if (fd < 0) {
     return CUDA_ERROR_FILE_NOT_FOUND;
   }
   // FILE_NOT_FOUND is reserved for open() failing.
   lupine_file_stat st = {};
-  if (lupine_file_fstat(fd, &st) < 0) {
-    lupine_file_close(fd);
+  if (fstat(fd, &st) < 0) {
+    close(fd);
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
   if (st.st_size <= 0) {
-    lupine_file_close(fd);
+    close(fd);
     return CUDA_ERROR_INVALID_IMAGE;
   }
   mapped_size = static_cast<size_t>(st.st_size);
   mapping = mmap(nullptr, mapped_size, PROT_READ, MAP_PRIVATE, fd, 0);
-  lupine_file_close(fd);
+  close(fd);
   if (mapping == MAP_FAILED) {
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
@@ -3040,7 +2994,7 @@ static const void *lupine_make_private_export_table(
   if (!table.empty()) {
     table[0] = reinterpret_cast<void *>(byte_size);
   }
-  char *stable_table_name = lupine_client_strdup(table_name);
+  char *stable_table_name = strdup(table_name);
   for (size_t i = 1; i < entries; ++i) {
     table[i] =
         lupine_make_private_export_stub(static_cast<int>(i), stable_table_name);
@@ -3933,24 +3887,24 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
   uint64_t file_size = 0;
   uint8_t has_file_data = 0;
   size_t jit_output_length = 0;
-  int file_fd = lupine_open_readonly(path);
+  int file_fd = open(path, O_RDONLY | O_BINARY);
   if (file_fd < 0) {
     return CUDA_ERROR_FILE_NOT_FOUND;
   }
   // FILE_NOT_FOUND is reserved for open() failing.
   lupine_file_stat st = {};
-  if (lupine_file_fstat(file_fd, &st) < 0) {
-    lupine_file_close(file_fd);
+  if (fstat(file_fd, &st) < 0) {
+    close(file_fd);
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
   if (st.st_size <= 0) {
-    lupine_file_close(file_fd);
+    close(file_fd);
     return CUDA_ERROR_INVALID_IMAGE;
   }
   mapped_file_size = static_cast<size_t>(st.st_size);
   file_mapping =
       mmap(nullptr, mapped_file_size, PROT_READ, MAP_PRIVATE, file_fd, 0);
-  lupine_file_close(file_fd);
+  close(file_fd);
   if (file_mapping == MAP_FAILED) {
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
@@ -8094,7 +8048,7 @@ static void *lupine_make_missing_stub(const char *symbol) {
     return reinterpret_cast<void *>(&lupine_unsupported_driver_api);
   }
 
-  char *stable_symbol = lupine_client_strdup(symbol);
+  char *stable_symbol = strdup(symbol);
   void *handler = reinterpret_cast<void *>(&lupine_missing_driver_api_called);
 #if defined(_WIN32)
   // Microsoft x64 passes the first argument in rcx.
@@ -8546,10 +8500,10 @@ int rpc_open() {
 
   lupine_server_endpoints().clear();
 
-  char *server_ip = lupine_client_strdup(server_ips);
+  char *server_ip = strdup(server_ips);
   char *server_ip_cursor = server_ip;
   char *token;
-  while ((token = lupine_client_strsep(&server_ip_cursor, ","))) {
+  while ((token = strsep(&server_ip_cursor, ","))) {
     if (nconns >= static_cast<int>(sizeof(conns) / sizeof(*conns))) {
       LUPINE_LOG_ERROR("Too many LUPINE_SERVER entries; ignoring the rest");
       break;

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -1782,6 +1782,9 @@ static CUfunction lupine_resolve_host_function(CUfunction function) {
     }
   }
 
+#if defined(_WIN32)
+  return function;
+#else
   Dl_info info = {};
   if (dladdr(reinterpret_cast<void *>(function), &info) == 0) {
     return function;
@@ -1826,6 +1829,7 @@ static CUfunction lupine_resolve_host_function(CUfunction function) {
                                          << " loaded modules");
 
   return function;
+#endif
 }
 
 static CUfunction lupine_translate_private_function(CUfunction function) {

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -116,6 +116,7 @@ struct Elf64_Sym {
 #include <vector>
 
 using ssize_t = SSIZE_T;
+using off_t = __int64;
 using socklen_t = int;
 using lupine_socket_t = SOCKET;
 

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -116,7 +116,6 @@ struct Elf64_Sym {
 #include <vector>
 
 using ssize_t = SSIZE_T;
-using off_t = __int64;
 using socklen_t = int;
 using lupine_socket_t = SOCKET;
 
@@ -224,6 +223,8 @@ inline int pthread_once(pthread_once_t *once, void (*init)()) {
 inline DWORD lupine_thread_id() { return GetCurrentThreadId(); }
 inline DWORD lupine_process_id() { return GetCurrentProcessId(); }
 
+#ifdef LUPINE_WINDOWS_POSIX_SHIMS
+using off_t = __int64;
 using lupine_file_stat = struct _stat64;
 
 inline int open(const char *path, int flags) { return _open(path, flags); }
@@ -263,6 +264,7 @@ inline char *strsep(char **string, const char *delimiters) {
 #endif
 #ifndef O_BINARY
 #define O_BINARY _O_BINARY
+#endif
 #endif
 
 // Minimal POSIX virtual-memory compatibility for the client shim. Anonymous

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -89,6 +89,14 @@ struct Elf64_Sym {
 #define NOMINMAX
 #endif
 
+// clang-format off: Windows extension headers require winsock2.h first.
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <mswsock.h>
+#include <mstcpip.h>
+#include <windows.h>
+// clang-format on
+
 #include <BaseTsd.h>
 #include <algorithm>
 #include <atomic>
@@ -98,19 +106,14 @@ struct Elf64_Sym {
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <io.h>
 #include <mutex>
 #include <new>
+#include <sys/stat.h>
 #include <thread>
 #include <type_traits>
 #include <vector>
-// clang-format off: Windows extension headers require winsock2.h first.
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <mswsock.h>
-#include <mstcpip.h>
-#include <windows.h>
-// clang-format on
 
 using ssize_t = SSIZE_T;
 using socklen_t = int;
@@ -220,15 +223,23 @@ inline int pthread_once(pthread_once_t *once, void (*init)()) {
 inline DWORD lupine_thread_id() { return GetCurrentThreadId(); }
 inline DWORD lupine_process_id() { return GetCurrentProcessId(); }
 
-inline char *lupine_strdup(const char *value) {
-  return value == nullptr ? nullptr : _strdup(value);
-}
+using lupine_file_stat = struct _stat64;
 
-inline int lupine_strcasecmp(const char *first, const char *second) {
+inline int open(const char *path, int flags) { return _open(path, flags); }
+inline int open(const char *path, int flags, int mode) {
+  return _open(path, flags, mode);
+}
+inline int fstat(int fd, lupine_file_stat *status) {
+  return _fstat64(fd, status);
+}
+inline int close(int fd) { return _close(fd); }
+
+inline char *strdup(const char *value) { return _strdup(value); }
+inline int strcasecmp(const char *first, const char *second) {
   return _stricmp(first, second);
 }
 
-inline char *lupine_strsep(char **string, const char *delimiters) {
+inline char *strsep(char **string, const char *delimiters) {
   if (string == nullptr || *string == nullptr) {
     return nullptr;
   }
@@ -245,6 +256,13 @@ inline char *lupine_strsep(char **string, const char *delimiters) {
   *string = nullptr;
   return token;
 }
+
+#ifndef O_RDONLY
+#define O_RDONLY _O_RDONLY
+#endif
+#ifndef O_BINARY
+#define O_BINARY _O_BINARY
+#endif
 
 // Minimal POSIX virtual-memory compatibility for the client shim. Anonymous
 // mappings use VirtualAlloc; file mappings use CreateFileMapping. munmap
@@ -617,10 +635,16 @@ inline int lupine_fd_truncate(int fd, long length) {
 #include <poll.h>
 #include <pthread.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/uio.h>
 #include <unistd.h>
 
 using lupine_socket_t = int;
+using lupine_file_stat = struct stat;
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
 
 #define LUPINE_INVALID_SOCKET (-1)
 #define LUPINE_STDOUT_FD STDOUT_FILENO

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -91,19 +91,25 @@ struct Elf64_Sym {
 
 #include <BaseTsd.h>
 #include <algorithm>
+#include <atomic>
 #include <climits>
 #include <condition_variable>
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <io.h>
 #include <mutex>
+#include <new>
 #include <thread>
+#include <type_traits>
 #include <vector>
 // clang-format off: Windows extension headers require winsock2.h first.
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <mswsock.h>
 #include <mstcpip.h>
+#include <windows.h>
 // clang-format on
 
 using ssize_t = SSIZE_T;
@@ -115,56 +121,74 @@ struct iovec {
   size_t iov_len;
 };
 
-struct pthread_mutex_t {
-  std::mutex mutex;
-};
+using pthread_mutex_t = SRWLOCK;
+using pthread_cond_t = CONDITION_VARIABLE;
+using pthread_t = HANDLE;
+using pthread_once_t = INIT_ONCE;
+using pid_t = int;
 
-struct pthread_cond_t {
-  std::condition_variable_any cond;
-};
-
-using pthread_t = std::thread *;
-
-#define PTHREAD_MUTEX_INITIALIZER                                              \
-  {}
-#define PTHREAD_COND_INITIALIZER                                               \
-  {}
+#define PTHREAD_MUTEX_INITIALIZER SRWLOCK_INIT
+#define PTHREAD_COND_INITIALIZER CONDITION_VARIABLE_INIT
+#define PTHREAD_ONCE_INIT INIT_ONCE_STATIC_INIT
 #define LUPINE_INVALID_SOCKET INVALID_SOCKET
 #define LUPINE_STDOUT_FD _fileno(stdout)
 
-inline int pthread_mutex_init(pthread_mutex_t *, void *) { return 0; }
+inline int pthread_mutex_init(pthread_mutex_t *mutex, void *) {
+  InitializeSRWLock(mutex);
+  return 0;
+}
 inline int pthread_mutex_destroy(pthread_mutex_t *) { return 0; }
 
 inline int pthread_mutex_lock(pthread_mutex_t *mutex) {
-  mutex->mutex.lock();
+  AcquireSRWLockExclusive(mutex);
   return 0;
 }
 
 inline int pthread_mutex_unlock(pthread_mutex_t *mutex) {
-  mutex->mutex.unlock();
+  ReleaseSRWLockExclusive(mutex);
   return 0;
 }
 
-inline int pthread_cond_init(pthread_cond_t *, void *) { return 0; }
+inline int pthread_cond_init(pthread_cond_t *cond, void *) {
+  InitializeConditionVariable(cond);
+  return 0;
+}
 inline int pthread_cond_destroy(pthread_cond_t *) { return 0; }
 
 inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
-  std::unique_lock<std::mutex> lock(mutex->mutex, std::adopt_lock);
-  cond->cond.wait(lock);
-  lock.release();
-  return 0;
+  return SleepConditionVariableSRW(cond, mutex, INFINITE, 0) ? 0 : -1;
 }
 
 inline int pthread_cond_broadcast(pthread_cond_t *cond) {
-  cond->cond.notify_all();
+  WakeAllConditionVariable(cond);
+  return 0;
+}
+
+struct lupine_windows_thread_start {
+  void *(*start)(void *);
+  void *arg;
+};
+
+inline DWORD WINAPI lupine_windows_thread_main(void *opaque) {
+  auto *thread_start = static_cast<lupine_windows_thread_start *>(opaque);
+  void *(*start)(void *) = thread_start->start;
+  void *arg = thread_start->arg;
+  delete thread_start;
+  start(arg);
   return 0;
 }
 
 inline int pthread_create(pthread_t *thread, void *, void *(*start)(void *),
                           void *arg) {
-  try {
-    *thread = new std::thread([start, arg]() { start(arg); });
-  } catch (...) {
+  auto *thread_start =
+      new (std::nothrow) lupine_windows_thread_start{start, arg};
+  if (thread_start == nullptr) {
+    return -1;
+  }
+  *thread = CreateThread(nullptr, 0, lupine_windows_thread_main, thread_start,
+                         0, nullptr);
+  if (*thread == nullptr) {
+    delete thread_start;
     return -1;
   }
   return 0;
@@ -172,11 +196,353 @@ inline int pthread_create(pthread_t *thread, void *, void *(*start)(void *),
 
 inline int pthread_join(pthread_t thread, void **) {
   if (thread != nullptr) {
-    thread->join();
-    delete thread;
+    if (WaitForSingleObject(thread, INFINITE) != WAIT_OBJECT_0) {
+      return -1;
+    }
+    CloseHandle(thread);
   }
   return 0;
 }
+
+inline BOOL CALLBACK lupine_windows_once_callback(PINIT_ONCE, PVOID parameter,
+                                                  PVOID *) {
+  reinterpret_cast<void (*)()>(parameter)();
+  return TRUE;
+}
+
+inline int pthread_once(pthread_once_t *once, void (*init)()) {
+  return InitOnceExecuteOnce(once, lupine_windows_once_callback,
+                             reinterpret_cast<void *>(init), nullptr)
+             ? 0
+             : -1;
+}
+
+inline DWORD lupine_thread_id() { return GetCurrentThreadId(); }
+inline DWORD lupine_process_id() { return GetCurrentProcessId(); }
+
+inline char *lupine_strdup(const char *value) {
+  return value == nullptr ? nullptr : _strdup(value);
+}
+
+inline int lupine_strcasecmp(const char *first, const char *second) {
+  return _stricmp(first, second);
+}
+
+inline char *lupine_strsep(char **string, const char *delimiters) {
+  if (string == nullptr || *string == nullptr) {
+    return nullptr;
+  }
+  char *token = *string;
+  char *cursor = token;
+  while (*cursor != '\0') {
+    if (std::strchr(delimiters, *cursor) != nullptr) {
+      *cursor = '\0';
+      *string = cursor + 1;
+      return token;
+    }
+    ++cursor;
+  }
+  *string = nullptr;
+  return token;
+}
+
+// Minimal POSIX virtual-memory compatibility for the client shim. Anonymous
+// mappings use VirtualAlloc; file mappings use CreateFileMapping. munmap
+// distinguishes the two through VirtualQuery so the call sites can retain
+// their existing ownership model.
+#define PROT_NONE 0x0
+#define PROT_READ 0x1
+#define PROT_WRITE 0x2
+#define PROT_EXEC 0x4
+#define MAP_PRIVATE 0x02
+#define MAP_ANONYMOUS 0x20
+#define MAP_FIXED_NOREPLACE 0x100000
+#define MAP_FAILED reinterpret_cast<void *>(static_cast<intptr_t>(-1))
+
+inline DWORD lupine_windows_page_protection(int prot) {
+  if ((prot & PROT_EXEC) != 0) {
+    return (prot & PROT_WRITE) != 0 ? PAGE_EXECUTE_READWRITE
+                                    : PAGE_EXECUTE_READ;
+  }
+  if ((prot & PROT_WRITE) != 0) {
+    return PAGE_READWRITE;
+  }
+  if ((prot & PROT_READ) != 0) {
+    return PAGE_READONLY;
+  }
+  return PAGE_NOACCESS;
+}
+
+inline void *mmap(void *address, size_t length, int prot, int flags, int fd,
+                  long long offset) {
+  if (length == 0) {
+    return MAP_FAILED;
+  }
+  if ((flags & MAP_ANONYMOUS) != 0) {
+    void *mapping = VirtualAlloc(address, length, MEM_RESERVE | MEM_COMMIT,
+                                 lupine_windows_page_protection(prot));
+    return mapping == nullptr ? MAP_FAILED : mapping;
+  }
+  intptr_t os_handle = _get_osfhandle(fd);
+  if (os_handle == -1) {
+    return MAP_FAILED;
+  }
+  DWORD protect = (prot & PROT_WRITE) != 0 ? PAGE_READWRITE : PAGE_READONLY;
+  HANDLE file_mapping = CreateFileMappingA(reinterpret_cast<HANDLE>(os_handle),
+                                           nullptr, protect, 0, 0, nullptr);
+  if (file_mapping == nullptr) {
+    return MAP_FAILED;
+  }
+  DWORD access = (prot & PROT_WRITE) != 0 ? FILE_MAP_WRITE : FILE_MAP_READ;
+  ULARGE_INTEGER view_offset = {};
+  view_offset.QuadPart = static_cast<unsigned long long>(offset);
+  void *mapping = MapViewOfFile(file_mapping, access, view_offset.HighPart,
+                                view_offset.LowPart, length);
+  CloseHandle(file_mapping);
+  return mapping == nullptr ? MAP_FAILED : mapping;
+}
+
+inline int munmap(void *address, size_t) {
+  if (address == nullptr || address == MAP_FAILED) {
+    return -1;
+  }
+  MEMORY_BASIC_INFORMATION info = {};
+  if (VirtualQuery(address, &info, sizeof(info)) == 0) {
+    return -1;
+  }
+  if (info.Type == MEM_MAPPED || info.Type == MEM_IMAGE) {
+    return UnmapViewOfFile(address) ? 0 : -1;
+  }
+  return VirtualFree(info.AllocationBase, 0, MEM_RELEASE) ? 0 : -1;
+}
+
+inline int mprotect(void *address, size_t length, int prot) {
+  DWORD previous = 0;
+  return VirtualProtect(address, length, lupine_windows_page_protection(prot),
+                        &previous)
+             ? 0
+             : -1;
+}
+
+inline int mincore(void *address, size_t, unsigned char *residency) {
+  MEMORY_BASIC_INFORMATION info = {};
+  if (VirtualQuery(address, &info, sizeof(info)) == 0 ||
+      info.State != MEM_COMMIT) {
+    return -1;
+  }
+  if (residency != nullptr) {
+    *residency = 1;
+  }
+  return 0;
+}
+
+// Windows access violations are the native equivalent of the SIGSEGV dirty
+// tracking hook used on Unix. These definitions provide only the subset of
+// sigaction/sigaltstack consumed by memcpy.cpp.
+struct siginfo_t {
+  void *si_addr;
+};
+
+using lupine_signal_handler_t = void (*)(int);
+struct sigaction {
+  void (*sa_sigaction)(int, siginfo_t *, void *);
+  lupine_signal_handler_t sa_handler;
+  int sa_flags;
+  int sa_mask;
+};
+
+struct stack_t {
+  void *ss_sp;
+  size_t ss_size;
+  int ss_flags;
+};
+
+#define SA_SIGINFO 0x1
+#define SA_NODEFER 0x2
+#define SA_ONSTACK 0x4
+
+inline sigaction lupine_windows_sigsegv_action = {};
+inline PVOID lupine_windows_exception_handler_handle = nullptr;
+
+inline LONG CALLBACK
+lupine_windows_exception_handler(EXCEPTION_POINTERS *exception) {
+  if (exception == nullptr || exception->ExceptionRecord == nullptr ||
+      exception->ExceptionRecord->ExceptionCode != EXCEPTION_ACCESS_VIOLATION ||
+      lupine_windows_sigsegv_action.sa_sigaction == nullptr) {
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+  siginfo_t info = {reinterpret_cast<void *>(
+      exception->ExceptionRecord->ExceptionInformation[1])};
+  lupine_windows_sigsegv_action.sa_sigaction(SIGSEGV, &info, exception);
+  return EXCEPTION_CONTINUE_EXECUTION;
+}
+
+inline int sigaction(int signal, const struct sigaction *action,
+                     struct sigaction *previous) {
+  if (signal != SIGSEGV) {
+    return -1;
+  }
+  if (previous != nullptr) {
+    *previous = lupine_windows_sigsegv_action;
+  }
+  if (action != nullptr) {
+    lupine_windows_sigsegv_action = *action;
+    if (lupine_windows_exception_handler_handle == nullptr &&
+        action->sa_sigaction != nullptr) {
+      lupine_windows_exception_handler_handle =
+          AddVectoredExceptionHandler(1, lupine_windows_exception_handler);
+      if (lupine_windows_exception_handler_handle == nullptr) {
+        return -1;
+      }
+    }
+  }
+  return 0;
+}
+
+inline int sigemptyset(int *set) {
+  if (set != nullptr) {
+    *set = 0;
+  }
+  return 0;
+}
+
+inline int sigaltstack(const stack_t *, stack_t *) { return 0; }
+
+inline long sysconf(int) {
+  SYSTEM_INFO info = {};
+  GetSystemInfo(&info);
+  return static_cast<long>(info.dwPageSize);
+}
+
+#define _SC_PAGESIZE 30
+
+inline int sched_yield() {
+  SwitchToThread();
+  return 0;
+}
+
+#if defined(_MSC_VER) && !defined(__clang__)
+// MSVC does not expose GCC's __atomic_* builtins. The client state fields are
+// deliberately plain scalars because they are shared with signal/exception
+// handlers; use the equivalent std::atomic operations at those call sites.
+#ifndef __ATOMIC_RELAXED
+#define __ATOMIC_RELAXED 0
+#define __ATOMIC_CONSUME 1
+#define __ATOMIC_ACQUIRE 2
+#define __ATOMIC_RELEASE 3
+#define __ATOMIC_ACQ_REL 4
+#define __ATOMIC_SEQ_CST 5
+#endif
+
+inline std::memory_order lupine_atomic_order(int order) {
+  switch (order) {
+  case __ATOMIC_RELAXED:
+    return std::memory_order_relaxed;
+  case __ATOMIC_ACQUIRE:
+  case __ATOMIC_CONSUME:
+    return std::memory_order_acquire;
+  case __ATOMIC_RELEASE:
+    return std::memory_order_release;
+  case __ATOMIC_ACQ_REL:
+    return std::memory_order_acq_rel;
+  default:
+    return std::memory_order_seq_cst;
+  }
+}
+
+inline std::memory_order lupine_atomic_failure_order(int order) {
+  if (order == __ATOMIC_ACQ_REL || order == __ATOMIC_ACQUIRE ||
+      order == __ATOMIC_CONSUME) {
+    return std::memory_order_acquire;
+  }
+  if (order == __ATOMIC_SEQ_CST) {
+    return std::memory_order_seq_cst;
+  }
+  return std::memory_order_relaxed;
+}
+
+template <typename T> struct lupine_atomic_identity {
+  using type = T;
+};
+
+template <typename T>
+inline std::atomic<T> *lupine_atomic_pointer(volatile T *value) {
+  static_assert(std::is_trivially_copyable<T>::value,
+                "atomic compatibility requires a scalar type");
+  return reinterpret_cast<std::atomic<T> *>(const_cast<T *>(value));
+}
+
+template <typename T>
+inline const std::atomic<T> *lupine_atomic_pointer(const volatile T *value) {
+  static_assert(std::is_trivially_copyable<T>::value,
+                "atomic compatibility requires a scalar type");
+  return reinterpret_cast<const std::atomic<T> *>(const_cast<const T *>(value));
+}
+
+template <typename T>
+inline T lupine_atomic_load_n(const volatile T *value, int order) {
+  return lupine_atomic_pointer(value)->load(lupine_atomic_order(order));
+}
+
+template <typename T>
+inline void
+lupine_atomic_store_n(volatile T *value,
+                      typename lupine_atomic_identity<T>::type desired,
+                      int order) {
+  lupine_atomic_pointer(value)->store(desired, lupine_atomic_order(order));
+}
+
+template <typename T>
+inline T
+lupine_atomic_exchange_n(volatile T *value,
+                         typename lupine_atomic_identity<T>::type desired,
+                         int order) {
+  return lupine_atomic_pointer(value)->exchange(desired,
+                                                lupine_atomic_order(order));
+}
+
+template <typename T>
+inline T
+lupine_atomic_add_fetch(volatile T *value,
+                        typename lupine_atomic_identity<T>::type amount,
+                        int order) {
+  return lupine_atomic_pointer(value)->fetch_add(amount,
+                                                 lupine_atomic_order(order)) +
+         amount;
+}
+
+template <typename T>
+inline T
+lupine_atomic_sub_fetch(volatile T *value,
+                        typename lupine_atomic_identity<T>::type amount,
+                        int order) {
+  return lupine_atomic_pointer(value)->fetch_sub(amount,
+                                                 lupine_atomic_order(order)) -
+         amount;
+}
+
+template <typename T>
+inline bool lupine_atomic_compare_exchange_n(
+    volatile T *value, T *expected,
+    typename lupine_atomic_identity<T>::type desired, bool weak,
+    int success_order, int failure_order) {
+  if (weak) {
+    return lupine_atomic_pointer(value)->compare_exchange_weak(
+        *expected, desired, lupine_atomic_order(success_order),
+        lupine_atomic_failure_order(failure_order));
+  }
+  return lupine_atomic_pointer(value)->compare_exchange_strong(
+      *expected, desired, lupine_atomic_order(success_order),
+      lupine_atomic_failure_order(failure_order));
+}
+
+#define __atomic_load_n lupine_atomic_load_n
+#define __atomic_store_n lupine_atomic_store_n
+#define __atomic_exchange_n lupine_atomic_exchange_n
+#define __atomic_add_fetch lupine_atomic_add_fetch
+#define __atomic_sub_fetch lupine_atomic_sub_fetch
+#define __atomic_compare_exchange_n lupine_atomic_compare_exchange_n
+#endif
 
 inline int lupine_socket_init() {
   static int result = []() {

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -1,3 +1,5 @@
+#include "lupine_platform.h"
+
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -23,7 +25,6 @@
 #include "codegen/gen_api.h"
 #include "lupine_attr_sizes.h"
 #include "lupine_log.h"
-#include "lupine_platform.h"
 #include "memcpy.h"
 #include "third_party/libcuckoo/libcuckoo/cuckoohash_map.hh"
 

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <map>
 #include <mutex>
+#ifndef _WIN32
 #include <sched.h>
 #include <signal.h>
 #include <sys/mman.h>
@@ -13,6 +14,7 @@
 #endif
 #include <sys/uio.h>
 #include <unistd.h>
+#endif
 #include <vector>
 
 #include <cuda.h>
@@ -21,6 +23,7 @@
 #include "codegen/gen_api.h"
 #include "lupine_attr_sizes.h"
 #include "lupine_log.h"
+#include "lupine_platform.h"
 #include "memcpy.h"
 #include "third_party/libcuckoo/libcuckoo/cuckoohash_map.hh"
 
@@ -168,7 +171,9 @@ static size_t lupine_page_size() {
 }
 
 static pid_t lupine_gettid() {
-#if defined(__APPLE__)
+#if defined(_WIN32)
+  return static_cast<pid_t>(lupine_thread_id());
+#elif defined(__APPLE__)
   return static_cast<pid_t>(pthread_mach_thread_np(pthread_self()));
 #else
   return static_cast<pid_t>(syscall(SYS_gettid));

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -1,14 +1,16 @@
-#include <arpa/inet.h>
 #include <cuda.h>
-#include <netdb.h>
-#include <netinet/tcp.h>
 #include <nvml.h>
 #ifdef LUPINE_TLS_OPENSSL
 #include <openssl/ssl.h>
 #endif
+#ifndef _WIN32
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/tcp.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#endif
 
 #include <algorithm>
 #include <atomic>
@@ -59,6 +61,22 @@ std::vector<lupine_nvml_remote_device> devices;
 std::vector<std::string> conn_labels;
 bool devices_ready = false;
 
+char *client_strdup(const char *value) {
+#ifdef _WIN32
+  return lupine_strdup(value);
+#else
+  return strdup(value);
+#endif
+}
+
+char *client_strsep(char **string, const char *delimiters) {
+#ifdef _WIN32
+  return lupine_strsep(string, delimiters);
+#else
+  return strsep(string, delimiters);
+#endif
+}
+
 // Real NVML reference counts init/shutdown; this shim connects lazily, so
 // without a counter it could never report UNINITIALIZED.
 std::atomic<int> init_refcount{0};
@@ -108,7 +126,7 @@ int open_connection() {
     return -1;
   }
 
-  char *servers = strdup(servers_env);
+  char *servers = client_strdup(servers_env);
   if (servers == nullptr) {
     pthread_mutex_unlock(&conn_mutex);
     return -1;
@@ -116,7 +134,7 @@ int open_connection() {
 
   char *cursor = servers;
   char *token = nullptr;
-  while ((token = strsep(&cursor, ",")) != nullptr) {
+  while ((token = client_strsep(&cursor, ",")) != nullptr) {
     if (token[0] == '\0') {
       continue;
     }
@@ -154,12 +172,13 @@ int open_connection() {
       continue;
     }
 
-    int sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-    if (sockfd >= 0) {
+    lupine_socket_t sockfd =
+        socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (sockfd != LUPINE_INVALID_SOCKET) {
       lupine_socket_apply_transport_options(sockfd);
       if (connect(sockfd, res->ai_addr, res->ai_addrlen) == 0) {
         if (nconns >= static_cast<int>(sizeof(conns) / sizeof(*conns))) {
-          close(sockfd);
+          lupine_socket_close(sockfd);
           freeaddrinfo(res);
           break;
         }
@@ -187,13 +206,14 @@ int open_connection() {
           }();
           SSL *ssl = tls_ctx != nullptr ? SSL_new(tls_ctx) : nullptr;
           if (ssl == nullptr || SSL_set_tlsext_host_name(ssl, host) != 1 ||
-              SSL_set1_host(ssl, host) != 1 || SSL_set_fd(ssl, sockfd) != 1 ||
+              SSL_set1_host(ssl, host) != 1 ||
+              SSL_set_fd(ssl, static_cast<int>(sockfd)) != 1 ||
               SSL_connect(ssl) != 1) {
             if (ssl != nullptr) {
               SSL_free(ssl);
             }
             LUPINE_LOG_ERROR("TLS handshake with " << host << " failed");
-            close(sockfd);
+            lupine_socket_close(sockfd);
             freeaddrinfo(res);
             continue;
           }
@@ -203,7 +223,7 @@ int open_connection() {
                            << host << ":" << port
                            << " uses https:// but this client was built "
                               "without TLS support");
-          close(sockfd);
+          lupine_socket_close(sockfd);
           freeaddrinfo(res);
           continue;
 #endif
@@ -221,7 +241,7 @@ int open_connection() {
             c->tls_session = nullptr;
           }
 #endif
-          close(sockfd);
+          lupine_socket_close(sockfd);
           freeaddrinfo(res);
           continue;
         }
@@ -231,7 +251,7 @@ int open_connection() {
         freeaddrinfo(res);
         continue;
       }
-      close(sockfd);
+      lupine_socket_close(sockfd);
     }
     freeaddrinfo(res);
   }

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -1,3 +1,5 @@
+#include "lupine_platform.h"
+
 #include <cuda.h>
 #include <nvml.h>
 #ifdef LUPINE_TLS_OPENSSL
@@ -61,22 +63,6 @@ std::vector<lupine_nvml_remote_device> devices;
 std::vector<std::string> conn_labels;
 bool devices_ready = false;
 
-char *client_strdup(const char *value) {
-#ifdef _WIN32
-  return lupine_strdup(value);
-#else
-  return strdup(value);
-#endif
-}
-
-char *client_strsep(char **string, const char *delimiters) {
-#ifdef _WIN32
-  return lupine_strsep(string, delimiters);
-#else
-  return strsep(string, delimiters);
-#endif
-}
-
 // Real NVML reference counts init/shutdown; this shim connects lazily, so
 // without a counter it could never report UNINITIALIZED.
 std::atomic<int> init_refcount{0};
@@ -126,7 +112,7 @@ int open_connection() {
     return -1;
   }
 
-  char *servers = client_strdup(servers_env);
+  char *servers = strdup(servers_env);
   if (servers == nullptr) {
     pthread_mutex_unlock(&conn_mutex);
     return -1;
@@ -134,7 +120,7 @@ int open_connection() {
 
   char *cursor = servers;
   char *token = nullptr;
-  while ((token = client_strsep(&cursor, ",")) != nullptr) {
+  while ((token = strsep(&cursor, ",")) != nullptr) {
     if (token[0] == '\0') {
       continue;
     }


### PR DESCRIPTION
## What changed

- build the CUDA and NVML client shims on Windows as the canonical `nvcuda.dll` and `nvml.dll`
- add native Windows support for the client loader, file and virtual-memory mappings, dirty-page fault handling, API stubs, and RPC synchronization primitives
- build native x86_64 and ARM64 DLLs on the VS2026 `windows-2025-vs2026` and `windows-11-vs2026-arm` runners
- use CUDA/NVML header wheels and each runner's preinstalled vcpkg instead of installing the CUDA Toolkit or bootstrapping vcpkg
- publish one `windows-unified` archive containing architecture-specific DLL pairs, header-version metadata, and SHA-256 checksums
- preserve the existing Windows server, Linux client/server, and macOS client outputs

## Why

The client shims do not link NVIDIA libraries, so they can provide the same remote CUDA/NVML forwarding behavior on Windows. Windows applications expect the canonical driver library names `nvcuda.dll` and `nvml.dll`.

## Artifact layout

Windows PE/COFF does not support a fat binary equivalent to a macOS universal Mach-O file, so the unified release archive contains both native variants:

```text
x86_64/nvcuda.dll
x86_64/nvml.dll
arm64/nvcuda.dll
arm64/nvml.dll
CUDA_HEADER_VERSION
NVML_HEADER_VERSION
SHA256SUMS
```

Published releases receive `lupine-client-cuda-<header-version>-windows-unified.zip`.

## Validation

- VS2026 x86_64 client build: passed
- VS2026 ARM64 client build: passed
- unified Windows package job: passed
- downloaded artifact contains native x86-64 and AArch64 PE32+ DLLs; all four SHA-256 checksums pass
- client-only Release build of `lupine_cuda_client` and `lupine_nvml`
- full Linux Release build and CTest suite: 10/10 passed (two expected server signal-test skips)
- workflow YAML and matrix validation
- clang-format diff check and `git diff --check`
