### PR TITLE
Flush dirty mapped pages automatically at request start

### DIFF
--- a/client_routing.h
+++ b/client_routing.h
@@ -62,6 +62,7 @@ extern "C" conn_t *lupine_rpc_conn_for_function(CUfunction function);
 extern "C" conn_t *lupine_rpc_conn_for_stream(CUstream stream);
 extern "C" conn_t *lupine_rpc_conn_for_event(CUevent event);
 extern "C" conn_t *lupine_rpc_conn_for_deviceptr(CUdeviceptr ptr);
+extern "C" int lupine_cuda_rpc_start(conn_t *conn, int op);
 
 extern "C" bool lupine_route_is_local(lupine_route route);
 // May return null for local/invalid routes; rpc_write_start_request absorbs

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -61,12 +61,12 @@ routes through the client-side cross-server copy helper.
 
 `@param <name> ... TRANSLATE_DEVICEPTR` makes the generated client wrapper
 translate a client-visible managed host alias to the server-visible
-`CUdeviceptr` before routing, local CUDA forwarding, or RPC serialization. If
-translation occurs, the wrapper first flushes all client-dirty managed pages.
+`CUdeviceptr` before routing, local CUDA forwarding, or RPC serialization.
+Client-dirty mapped pages are flushed centrally before each CUDA RPC request.
 `@routingfallback <kind> <param>` can be paired with stream routing for APIs
 that route by stream when a stream is supplied and by another object otherwise.
-`@synchronize [DEFERRED_DTOH] [STDOUT]` flushes client-dirty mapped host pages
-before dispatch and refreshes mapped host allocations after a successful call.
+`@synchronize [DEFERRED_DTOH] [STDOUT]` refreshes mapped host allocations after
+a successful call.
 The optional flags consume response fields emitted by a manual server handler
 before the generated wrapper reads the CUDA result.
 

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1539,7 +1539,6 @@ def main():
             'extern "C" void lupine_invalidate_kernel_attribute_cache();\n'
             'extern "C" void lupine_kernel_attribute_cache_erase(int route_id, CUkernel kernel, int attrib, int dev);\n'
             'extern "C" void lupine_invalidate_function_attribute_cache();\n'
-            'extern "C" CUresult lupine_flush_dirty_host_pages_to_server();\n\n'
             'extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);\n'
             'extern "C" int lupine_forward_remote_stdout(conn_t *conn);\n'
             'extern "C" CUresult lupine_sync_mapped_device_to_host();\n'
@@ -1565,36 +1564,12 @@ def main():
             )
             f.write("{\n")
 
-            if metadata.synchronize:
-                f.write(
-                    "    CUresult lupine_sync_result = "
-                    "lupine_flush_dirty_host_pages_to_server();\n"
-                    "    if (lupine_sync_result != CUDA_SUCCESS) {\n"
-                    "        return lupine_sync_result;\n"
-                    "    }\n"
-                )
-
             for translation in metadata.translate_deviceptrs:
                 name = translation.parameter.name
                 f.write(f"    CUdeviceptr {name}_rpc = {name};\n")
                 f.write(
-                    f"    bool {name}_is_managed_host = "
-                    f"lupine_translate_managed_host_ptr({name}, &{name}_rpc);\n"
+                    f"    lupine_translate_managed_host_ptr({name}, &{name}_rpc);\n"
                 )
-            if metadata.translate_deviceptrs:
-                translated_condition = " || ".join(
-                    f"{item.parameter.name}_is_managed_host"
-                    for item in metadata.translate_deviceptrs
-                )
-                f.write(f"    if ({translated_condition}) {{\n")
-                f.write(
-                    "        CUresult managed_result = "
-                    "lupine_flush_dirty_host_pages_to_server();\n"
-                )
-                f.write("        if (managed_result != CUDA_SUCCESS) {\n")
-                f.write("            return managed_result;\n")
-                f.write("        }\n")
-                f.write("    }\n")
 
             all_output = metadata.routing_parameter
             if metadata.routing_kind == "ALL":
@@ -1741,7 +1716,7 @@ def main():
                         )
                     )
 
-            # Reject invalid send buffers before rpc_write_start_request()
+            # Reject invalid send buffers before lupine_cuda_rpc_start()
             # acquires the connection's call/write locks. Conditions in the
             # builder below may skip optional writes, but only rpc_write* calls
             # themselves are allowed to fail the builder.
@@ -1754,7 +1729,7 @@ def main():
             if metadata.async_fire_forget:
                 error_return = error_const(function.return_type.format())
                 f.write(
-                    "    if (rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
+                    "    if (lupine_cuda_rpc_start(conn, RPC_{name}) < 0 ||\n".format(
                         name=function.name.format()
                     )
                 )
@@ -1777,7 +1752,7 @@ def main():
                 continue
 
             f.write(
-                "    if (rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
+                "    if (lupine_cuda_rpc_start(conn, RPC_{name}) < 0 ||\n".format(
                     name=function.name.format()
                 )
             )

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -78,8 +78,6 @@ extern "C" void lupine_kernel_attribute_cache_erase(int route_id,
                                                     CUkernel kernel, int attrib,
                                                     int dev);
 extern "C" void lupine_invalidate_function_attribute_cache();
-extern "C" CUresult lupine_flush_dirty_host_pages_to_server();
-
 extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);
 extern "C" int lupine_forward_remote_stdout(conn_t *conn);
 extern "C" CUresult lupine_sync_mapped_device_to_host();
@@ -100,7 +98,7 @@ CUresult cuDriverGetVersion(int *driverVersion) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDriverGetVersion) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, driverVersion, sizeof(int)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -126,7 +124,7 @@ CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetLuid) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetLuid) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       (8 != 0 && rpc_read(conn, luid, 8) < 0) ||
@@ -152,8 +150,7 @@ CUresult cuDeviceGetTexture1DLinearMaxWidth(size_t *maxWidthInElements,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetTexture1DLinearMaxWidth) <
-          0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetTexture1DLinearMaxWidth) < 0 ||
       rpc_write(conn, &format, sizeof(CUarray_format)) < 0 ||
       rpc_write(conn, &numChannels, sizeof(unsigned)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -176,7 +173,7 @@ CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceSetMemPool) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceSetMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -200,7 +197,7 @@ CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetMemPool) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pool, sizeof(CUmemoryPool)) < 0 ||
@@ -227,7 +224,7 @@ CUresult cuDeviceGetDefaultMemPool(CUmemoryPool *pool_out, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetDefaultMemPool) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetDefaultMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pool_out, sizeof(CUmemoryPool)) < 0 ||
@@ -253,7 +250,7 @@ CUresult cuDeviceGetExecAffinitySupport(int *pi, CUexecAffinityType type,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetExecAffinitySupport) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetExecAffinitySupport) < 0 ||
       rpc_write(conn, &type, sizeof(CUexecAffinityType)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 || rpc_read(conn, pi, sizeof(int)) < 0 ||
@@ -274,7 +271,7 @@ CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
       rpc_write(conn, &target, sizeof(CUflushGPUDirectRDMAWritesTarget)) < 0 ||
       rpc_write(conn, &scope, sizeof(CUflushGPUDirectRDMAWritesScope)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -295,7 +292,7 @@ CUresult cuDeviceGetProperties(CUdevprop *prop, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetProperties) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetProperties) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, prop, sizeof(CUdevprop)) < 0 ||
@@ -317,7 +314,7 @@ CUresult cuDeviceComputeCapability(int *major, int *minor, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceComputeCapability) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceComputeCapability) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, major, sizeof(int)) < 0 ||
@@ -346,7 +343,7 @@ CUresult cuCtxDestroy_v2(CUcontext ctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxDestroy_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxDestroy_v2) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -368,7 +365,7 @@ CUresult cuCtxGetFlags(unsigned int *flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxGetFlags) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetFlags) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, flags, sizeof(unsigned int)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -386,7 +383,7 @@ CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxGetId) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetId) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, ctxId, sizeof(unsigned long long)) < 0 ||
@@ -397,10 +394,6 @@ CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId) {
 }
 
 CUresult cuCtxSynchronize() {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   lupine_route route = lupine_route_for_current_context();
   CUresult return_value;
   using real_fn_t = CUresult (*)();
@@ -411,7 +404,7 @@ CUresult cuCtxSynchronize() {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxSynchronize) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSynchronize) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
       lupine_forward_remote_stdout(conn) < 0 ||
@@ -425,10 +418,6 @@ CUresult cuCtxSynchronize() {
 
 #if CUDA_VERSION >= 13000
 CUresult cuCtxSynchronize_v2(CUcontext ctx) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   lupine_route route = lupine_route_for_context(ctx);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUcontext);
@@ -439,7 +428,7 @@ CUresult cuCtxSynchronize_v2(CUcontext ctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxSynchronize_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSynchronize_v2) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -463,7 +452,7 @@ CUresult cuCtxSetLimit(CUlimit limit, size_t value) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxSetLimit) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSetLimit) < 0 ||
       rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
       rpc_write(conn, &value, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -482,7 +471,7 @@ CUresult cuCtxGetLimit(size_t *pvalue, CUlimit limit) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxGetLimit) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetLimit) < 0 ||
       rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pvalue, sizeof(size_t)) < 0 ||
@@ -501,7 +490,7 @@ CUresult cuCtxGetCacheConfig(CUfunc_cache *pconfig) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxGetCacheConfig) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetCacheConfig) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pconfig, sizeof(CUfunc_cache)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -519,7 +508,7 @@ CUresult cuCtxSetCacheConfig(CUfunc_cache config) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxSetCacheConfig) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSetCacheConfig) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -537,7 +526,7 @@ CUresult cuCtxGetApiVersion(CUcontext ctx, unsigned int *version) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxGetApiVersion) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetApiVersion) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, version, sizeof(unsigned int)) < 0 ||
@@ -556,7 +545,7 @@ CUresult cuCtxResetPersistingL2Cache() {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -574,7 +563,7 @@ CUresult cuCtxGetExecAffinity(CUexecAffinityParam *pExecAffinity,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxGetExecAffinity) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetExecAffinity) < 0 ||
       rpc_write(conn, &type, sizeof(CUexecAffinityType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pExecAffinity, sizeof(CUexecAffinityParam)) < 0 ||
@@ -593,7 +582,7 @@ CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxAttach) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxAttach) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pctx, sizeof(CUcontext)) < 0 ||
@@ -614,7 +603,7 @@ CUresult cuCtxDetach(CUcontext ctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxDetach) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxDetach) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -634,7 +623,7 @@ CUresult cuCtxGetSharedMemConfig(CUsharedconfig *pConfig) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pConfig, sizeof(CUsharedconfig)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -652,7 +641,7 @@ CUresult cuCtxSetSharedMemConfig(CUsharedconfig config) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
       rpc_write(conn, &config, sizeof(CUsharedconfig)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -672,7 +661,7 @@ CUresult cuModuleUnload(CUmodule hmod) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuModuleUnload) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuModuleUnload) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -692,7 +681,7 @@ CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode *mode) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuModuleGetLoadingMode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetLoadingMode) < 0 ||
       rpc_write(conn, mode, sizeof(CUmoduleLoadingMode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, mode, sizeof(CUmoduleLoadingMode)) < 0 ||
@@ -722,7 +711,7 @@ CUresult cuModuleGetGlobal_v2(CUdeviceptr *dptr, size_t *bytes, CUmodule hmod,
   CUdeviceptr *dptr_null_check;
   size_t *bytes_null_check;
   std::size_t name_len = std::strlen(name) + 1;
-  if (rpc_write_start_request(conn, RPC_cuModuleGetGlobal_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetGlobal_v2) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
@@ -753,7 +742,7 @@ CUresult cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod, const char *name) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
-  if (rpc_write_start_request(conn, RPC_cuModuleGetTexRef) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetTexRef) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -775,7 +764,7 @@ CUresult cuModuleGetSurfRef(CUsurfref *pSurfRef, CUmodule hmod,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
-  if (rpc_write_start_request(conn, RPC_cuModuleGetSurfRef) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetSurfRef) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -818,7 +807,7 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
     return CUDA_ERROR_INVALID_VALUE;
   if (numLibraryOptions * sizeof(void *) != 0 && libraryOptionValues == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuLibraryLoadFromFile) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryLoadFromFile) < 0 ||
       rpc_write(conn, &fileName_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, fileName, fileName_len) < 0 ||
       rpc_write(conn, &numJitOptions, sizeof(unsigned int)) < 0 ||
@@ -851,7 +840,7 @@ CUresult cuLibraryUnload(CUlibrary library) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryUnload) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -874,7 +863,7 @@ CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuLibraryGetModule) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetModule) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pMod, sizeof(CUmodule)) < 0 ||
@@ -907,7 +896,7 @@ CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
   CUdeviceptr *dptr_null_check;
   size_t *bytes_null_check;
   std::size_t name_len = std::strlen(name) + 1;
-  if (rpc_write_start_request(conn, RPC_cuLibraryGetGlobal) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetGlobal) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
@@ -948,7 +937,7 @@ CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
   CUdeviceptr *dptr_null_check;
   size_t *bytes_null_check;
   std::size_t name_len = std::strlen(name) + 1;
-  if (rpc_write_start_request(conn, RPC_cuLibraryGetManaged) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetManaged) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
@@ -981,7 +970,7 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t symbol_len = std::strlen(symbol) + 1;
-  if (rpc_write_start_request(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &symbol_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, symbol, symbol_len) < 0 ||
@@ -1009,7 +998,7 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuKernelSetAttribute) < 0 ||
       rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_write(conn, &val, sizeof(int)) < 0 ||
       rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
@@ -1036,7 +1025,7 @@ CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuKernelSetCacheConfig) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuKernelSetCacheConfig) < 0 ||
       rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -1056,7 +1045,7 @@ CUresult cuMemGetInfo_v2(size_t *free, size_t *total) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemGetInfo_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetInfo_v2) < 0 ||
       rpc_write(conn, free, sizeof(size_t)) < 0 ||
       rpc_write(conn, total, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1082,7 +1071,7 @@ CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemAlloc_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemAlloc_v2) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1122,7 +1111,7 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr *dptr, size_t *pPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemAllocPitch_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemAllocPitch_v2) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, pPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &WidthInBytes, sizeof(size_t)) < 0 ||
@@ -1159,7 +1148,7 @@ CUresult cuMemGetAddressRange_v2(CUdeviceptr *pbase, size_t *psize,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemGetAddressRange_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetAddressRange_v2) < 0 ||
       rpc_write(conn, pbase, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, psize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -1188,7 +1177,7 @@ CUresult cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId) {
         conn_t *conn = lupine_route_remote_conn(route);
         CUdevice *dev_null_check;
         std::size_t pciBusId_len = std::strlen(pciBusId) + 1;
-        if (rpc_write_start_request(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
+        if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
             rpc_write(conn, &dev, sizeof(CUdevice *)) < 0 ||
             rpc_write(conn, &pciBusId_len, sizeof(std::size_t)) < 0 ||
             rpc_write(conn, pciBusId, pciBusId_len) < 0 ||
@@ -1213,7 +1202,7 @@ CUresult cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetPCIBusId) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetPCIBusId) < 0 ||
       rpc_write(conn, &len, sizeof(int)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1234,7 +1223,7 @@ CUresult cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuIpcGetEventHandle) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuIpcGetEventHandle) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUipcEventHandle)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1254,7 +1243,7 @@ CUresult cuIpcOpenEventHandle(CUevent *phEvent, CUipcEventHandle handle) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuIpcOpenEventHandle) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuIpcOpenEventHandle) < 0 ||
       rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &handle, sizeof(CUipcEventHandle)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1274,7 +1263,7 @@ CUresult cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuIpcGetMemHandle) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuIpcGetMemHandle) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUipcMemHandle)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1296,7 +1285,7 @@ CUresult cuIpcOpenMemHandle_v2(CUdeviceptr *pdptr, CUipcMemHandle handle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
       rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &handle, sizeof(CUipcMemHandle)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -1317,7 +1306,7 @@ CUresult cuIpcCloseMemHandle(CUdeviceptr dptr) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuIpcCloseMemHandle) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuIpcCloseMemHandle) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -1343,7 +1332,7 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpyPeer) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyPeer) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstContext, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1358,19 +1347,8 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
 
 CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
                          size_t ByteCount) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, const void *, size_t);
@@ -1385,7 +1363,7 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
   if (ByteCount != 0 && srcHost == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   srcHost = lupine_mapped_host_read_source(srcHost, ByteCount);
-  if (rpc_write_start_request(conn, RPC_cuMemcpyHtoD_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyHtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
       rpc_write_payload(conn, srcHost, ByteCount) < 0 ||
@@ -1400,22 +1378,10 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
 
 CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                          size_t ByteCount) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   CUdeviceptr srcDevice_rpc = srcDevice;
-  bool srcDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(srcDevice, &srcDevice_rpc);
-  if (dstDevice_is_managed_host || srcDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(srcDevice, &srcDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   if (!lupine_deviceptrs_share_route(dstDevice_rpc, srcDevice_rpc)) {
     return lupine_cuMemcpyDtoD_via_client(dstDevice_rpc, srcDevice_rpc,
@@ -1431,7 +1397,7 @@ CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
@@ -1455,7 +1421,7 @@ CUresult cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoA_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoA_v2) < 0 ||
       rpc_write(conn, &dstArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &dstOffset, sizeof(size_t)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1478,7 +1444,7 @@ CUresult cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpyAtoD_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyAtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &srcOffset, sizeof(size_t)) < 0 ||
@@ -1501,7 +1467,7 @@ CUresult cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
       rpc_write(conn, &dstArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &dstOffset, sizeof(size_t)) < 0 ||
       rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
@@ -1531,7 +1497,7 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpyPeerAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyPeerAsync) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstContext, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1548,17 +1514,9 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
 CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                               size_t ByteCount, CUstream hStream) {
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   CUdeviceptr srcDevice_rpc = srcDevice;
-  bool srcDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(srcDevice, &srcDevice_rpc);
-  if (dstDevice_is_managed_host || srcDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(srcDevice, &srcDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   if (!lupine_deviceptrs_share_route(dstDevice_rpc, srcDevice_rpc)) {
     return lupine_cuMemcpyDtoD_via_client(dstDevice_rpc, srcDevice_rpc,
@@ -1572,7 +1530,7 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
@@ -1584,19 +1542,8 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
 }
 
 CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned char, size_t);
@@ -1607,7 +1554,7 @@ CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD8_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD8_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1621,19 +1568,8 @@ CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
 }
 
 CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned short, size_t);
@@ -1644,7 +1580,7 @@ CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD16_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD16_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1658,19 +1594,8 @@ CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
 }
 
 CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t);
@@ -1681,7 +1606,7 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD32_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD32_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1696,19 +1621,8 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
 
 CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
                          unsigned char uc, size_t Width, size_t Height) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t =
@@ -1721,7 +1635,7 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD2D8_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D8_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
@@ -1738,19 +1652,8 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
 
 CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
                           unsigned short us, size_t Width, size_t Height) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t =
@@ -1763,7 +1666,7 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD2D16_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D16_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
@@ -1780,19 +1683,8 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
 
 CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
                           unsigned int ui, size_t Width, size_t Height) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t =
@@ -1805,7 +1697,7 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD2D32_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D32_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
@@ -1823,14 +1715,7 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
                          CUstream hStream) {
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned char, size_t, CUstream);
@@ -1840,7 +1725,7 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD8Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1854,14 +1739,7 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
 CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
                           CUstream hStream) {
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned short, size_t, CUstream);
@@ -1871,7 +1749,7 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD16Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1885,14 +1763,7 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
 CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
                           CUstream hStream) {
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t, CUstream);
@@ -1902,7 +1773,7 @@ CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD32Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1917,14 +1788,7 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
                            unsigned char uc, size_t Width, size_t Height,
                            CUstream hStream) {
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned char, size_t,
@@ -1935,7 +1799,7 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D8Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
@@ -1952,14 +1816,7 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
                             unsigned short us, size_t Width, size_t Height,
                             CUstream hStream) {
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned short, size_t,
@@ -1970,7 +1827,7 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D16Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
@@ -1987,14 +1844,7 @@ CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
                             unsigned int ui, size_t Width, size_t Height,
                             CUstream hStream) {
   CUdeviceptr dstDevice_rpc = dstDevice;
-  bool dstDevice_is_managed_host =
-      lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  if (dstDevice_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
   lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
   CUresult return_value;
   using real_fn_t =
@@ -2005,7 +1855,7 @@ CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D32Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
@@ -2028,7 +1878,7 @@ CUresult cuArrayCreate_v2(CUarray *pHandle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuArrayCreate_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuArrayCreate_v2) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUarray)) < 0 ||
       rpc_write(conn, pAllocateArray, sizeof(const CUDA_ARRAY_DESCRIPTOR)) <
           0 ||
@@ -2051,7 +1901,7 @@ CUresult cuArrayGetDescriptor_v2(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
       rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY_DESCRIPTOR)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2074,7 +1924,7 @@ cuArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES *sparseProperties,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuArrayGetSparseProperties) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuArrayGetSparseProperties) < 0 ||
       rpc_write(conn, sparseProperties, sizeof(CUDA_ARRAY_SPARSE_PROPERTIES)) <
           0 ||
       rpc_write(conn, &array, sizeof(CUarray)) < 0 ||
@@ -2099,7 +1949,7 @@ CUresult cuMipmappedArrayGetSparseProperties(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayGetSparseProperties) <
+  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayGetSparseProperties) <
           0 ||
       rpc_write(conn, sparseProperties, sizeof(CUDA_ARRAY_SPARSE_PROPERTIES)) <
           0 ||
@@ -2128,7 +1978,7 @@ cuArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS *memoryRequirements,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
       rpc_write(conn, memoryRequirements,
                 sizeof(CUDA_ARRAY_MEMORY_REQUIREMENTS)) < 0 ||
       rpc_write(conn, &array, sizeof(CUarray)) < 0 ||
@@ -2157,7 +2007,7 @@ CUresult cuMipmappedArrayGetMemoryRequirements(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayGetMemoryRequirements) <
+  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayGetMemoryRequirements) <
           0 ||
       rpc_write(conn, memoryRequirements,
                 sizeof(CUDA_ARRAY_MEMORY_REQUIREMENTS)) < 0 ||
@@ -2183,7 +2033,7 @@ CUresult cuArrayGetPlane(CUarray *pPlaneArray, CUarray hArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuArrayGetPlane) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuArrayGetPlane) < 0 ||
       rpc_write(conn, pPlaneArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &planeIdx, sizeof(unsigned int)) < 0 ||
@@ -2204,7 +2054,7 @@ CUresult cuArrayDestroy(CUarray hArray) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuArrayDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuArrayDestroy) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2224,7 +2074,7 @@ CUresult cuArray3DCreate_v2(CUarray *pHandle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuArray3DCreate_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuArray3DCreate_v2) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUarray)) < 0 ||
       rpc_write(conn, pAllocateArray, sizeof(const CUDA_ARRAY3D_DESCRIPTOR)) <
           0 ||
@@ -2247,7 +2097,7 @@ CUresult cuArray3DGetDescriptor_v2(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
       rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY3D_DESCRIPTOR)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2272,7 +2122,7 @@ cuMipmappedArrayCreate(CUmipmappedArray *pHandle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayCreate) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, pMipmappedArrayDesc,
                 sizeof(const CUDA_ARRAY3D_DESCRIPTOR)) < 0 ||
@@ -2297,7 +2147,7 @@ CUresult cuMipmappedArrayGetLevel(CUarray *pLevelArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
       rpc_write(conn, pLevelArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &level, sizeof(unsigned int)) < 0 ||
@@ -2318,7 +2168,7 @@ CUresult cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2339,7 +2189,7 @@ CUresult cuMemAddressReserve(CUdeviceptr *ptr, size_t size, size_t alignment,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemAddressReserve) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemAddressReserve) < 0 ||
       rpc_write(conn, ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &alignment, sizeof(size_t)) < 0 ||
@@ -2362,7 +2212,7 @@ CUresult cuMemAddressFree(CUdeviceptr ptr, size_t size) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemAddressFree) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemAddressFree) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2385,7 +2235,7 @@ CUresult cuMemCreate(CUmemGenericAllocationHandle *handle, size_t size,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemCreate) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned long long)) < 0 ||
@@ -2406,7 +2256,7 @@ CUresult cuMemRelease(CUmemGenericAllocationHandle handle) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemRelease) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemRelease) < 0 ||
       rpc_write(conn, &handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2428,7 +2278,7 @@ CUresult cuMemMap(CUdeviceptr ptr, size_t size, size_t offset,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemMap) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemMap) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &offset, sizeof(size_t)) < 0 ||
@@ -2453,7 +2303,7 @@ CUresult cuMemMapArrayAsync(CUarrayMapInfo *mapInfoList, unsigned int count,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemMapArrayAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemMapArrayAsync) < 0 ||
       rpc_write(conn, mapInfoList, sizeof(CUarrayMapInfo)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -2474,7 +2324,7 @@ CUresult cuMemUnmap(CUdeviceptr ptr, size_t size) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemUnmap) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemUnmap) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2497,7 +2347,7 @@ CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(const CUmemAccessDesc) != 0 && desc == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuMemSetAccess) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemSetAccess) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &count, sizeof(size_t)) < 0 ||
@@ -2520,7 +2370,7 @@ CUresult cuMemGetAccess(unsigned long long *flags,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemGetAccess) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetAccess) < 0 ||
       rpc_write(conn, location, sizeof(const CUmemLocation)) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2545,7 +2395,7 @@ cuMemGetAllocationGranularity(size_t *granularity,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
       rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
       rpc_write(conn, &option, sizeof(CUmemAllocationGranularity_flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2569,8 +2419,8 @@ cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp *prop,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn,
-                              RPC_cuMemGetAllocationPropertiesFromHandle) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetAllocationPropertiesFromHandle) <
+          0 ||
       rpc_write(conn, prop, sizeof(CUmemAllocationProp)) < 0 ||
       rpc_write(conn, &handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2592,7 +2442,7 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemFreeAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemFreeAsync) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2619,7 +2469,7 @@ CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemAllocAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemAllocAsync) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -2645,7 +2495,7 @@ CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemPoolTrimTo) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolTrimTo) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, &minBytesToKeep, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2667,7 +2517,7 @@ CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc *map,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(const CUmemAccessDesc) != 0 && map == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuMemPoolSetAccess) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolSetAccess) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, &count, sizeof(size_t)) < 0 ||
       rpc_write(conn, map, count * sizeof(const CUmemAccessDesc)) < 0 ||
@@ -2690,7 +2540,7 @@ CUresult cuMemPoolGetAccess(CUmemAccess_flags *flags, CUmemoryPool memPool,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemPoolGetAccess) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolGetAccess) < 0 ||
       rpc_write(conn, flags, sizeof(CUmemAccess_flags)) < 0 ||
       rpc_write(conn, &memPool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, location, sizeof(CUmemLocation)) < 0 ||
@@ -2715,7 +2565,7 @@ CUresult cuMemPoolCreate(CUmemoryPool *pool, const CUmemPoolProps *poolProps) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemPoolCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolCreate) < 0 ||
       rpc_write(conn, pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, poolProps, sizeof(const CUmemPoolProps)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2738,7 +2588,7 @@ CUresult cuMemPoolDestroy(CUmemoryPool pool) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemPoolDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolDestroy) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2764,7 +2614,7 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t bytesize,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
@@ -2792,7 +2642,7 @@ CUresult cuMemPoolExportPointer(CUmemPoolPtrExportData *shareData_out,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemPoolExportPointer) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolExportPointer) < 0 ||
       rpc_write(conn, shareData_out, sizeof(CUmemPoolPtrExportData)) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2815,7 +2665,7 @@ CUresult cuMemPoolImportPointer(CUdeviceptr *ptr_out, CUmemoryPool pool,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemPoolImportPointer) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolImportPointer) < 0 ||
       rpc_write(conn, ptr_out, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, shareData, sizeof(CUmemPoolPtrExportData)) < 0 ||
@@ -2842,7 +2692,7 @@ CUresult cuMemRangeGetAttributes(void **data, size_t *dataSizes,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemRangeGetAttributes) < 0 ||
       rpc_write(conn, data, sizeof(void *)) < 0 ||
       rpc_write(conn, dataSizes, sizeof(size_t)) < 0 ||
       rpc_write(conn, attributes, sizeof(CUmem_range_attribute)) < 0 ||
@@ -2871,7 +2721,7 @@ CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamCreate) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2899,7 +2749,7 @@ CUresult cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamCreateWithPriority) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamCreateWithPriority) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &priority, sizeof(int)) < 0 ||
@@ -2924,7 +2774,7 @@ CUresult cuStreamGetPriority(CUstream hStream, int *priority) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamGetPriority) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetPriority) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, priority, sizeof(int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2945,7 +2795,7 @@ CUresult cuStreamGetFlags(CUstream hStream, unsigned int *flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamGetFlags) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetFlags) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2966,7 +2816,7 @@ CUresult cuStreamGetId(CUstream hStream, unsigned long long *streamId) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamGetId) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetId) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, streamId, sizeof(unsigned long long)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2987,7 +2837,7 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamGetCtx) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetCtx) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, pctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3007,8 +2857,7 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuThreadExchangeStreamCaptureMode) <
-          0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuThreadExchangeStreamCaptureMode) < 0 ||
       rpc_write(conn, mode, sizeof(CUstreamCaptureMode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, mode, sizeof(CUstreamCaptureMode)) < 0 ||
@@ -3021,14 +2870,7 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
 CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
                                 size_t length, unsigned int flags) {
   CUdeviceptr dptr_rpc = dptr;
-  bool dptr_is_managed_host =
-      lupine_translate_managed_host_ptr(dptr, &dptr_rpc);
-  if (dptr_is_managed_host) {
-    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
-    if (managed_result != CUDA_SUCCESS) {
-      return managed_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(dptr, &dptr_rpc);
   lupine_route route =
       (hStream != nullptr ? lupine_route_for_stream(hStream)
                           : lupine_route_for_deviceptr(dptr_rpc));
@@ -3040,7 +2882,7 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamAttachMemAsync) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &dptr_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &length, sizeof(size_t)) < 0 ||
@@ -3053,10 +2895,6 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
 }
 
 CUresult cuStreamQuery(CUstream hStream) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
   CUresult return_value;
@@ -3068,7 +2906,7 @@ CUresult cuStreamQuery(CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamQuery) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamQuery) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3080,10 +2918,6 @@ CUresult cuStreamQuery(CUstream hStream) {
 }
 
 CUresult cuStreamSynchronize(CUstream hStream) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
   CUresult return_value;
@@ -3095,7 +2929,7 @@ CUresult cuStreamSynchronize(CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamSynchronize) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamSynchronize) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -3120,7 +2954,7 @@ CUresult cuStreamDestroy_v2(CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamDestroy_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamDestroy_v2) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3141,7 +2975,7 @@ CUresult cuStreamCopyAttributes(CUstream dst, CUstream src) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamCopyAttributes) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamCopyAttributes) < 0 ||
       rpc_write(conn, &dst, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &src, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3163,7 +2997,7 @@ CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamGetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetAttribute) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
       rpc_write(conn, value_out, sizeof(CUstreamAttrValue)) < 0 ||
@@ -3187,7 +3021,7 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamSetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamSetAttribute) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
       rpc_write(conn, value, sizeof(const CUstreamAttrValue)) < 0 ||
@@ -3210,7 +3044,7 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuEventCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuEventCreate) < 0 ||
       rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3225,10 +3059,6 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
 }
 
 CUresult cuEventSynchronize(CUevent hEvent) {
-  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
-  if (lupine_sync_result != CUDA_SUCCESS) {
-    return lupine_sync_result;
-  }
   lupine_route route = lupine_route_for_event(hEvent);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUevent);
@@ -3239,7 +3069,7 @@ CUresult cuEventSynchronize(CUevent hEvent) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuEventSynchronize) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuEventSynchronize) < 0 ||
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -3263,7 +3093,7 @@ CUresult cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuEventElapsedTime_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuEventElapsedTime_v2) < 0 ||
       rpc_write(conn, pMilliseconds, sizeof(float)) < 0 ||
       rpc_write(conn, &hStart, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &hEnd, sizeof(CUevent)) < 0 ||
@@ -3288,7 +3118,7 @@ cuImportExternalMemory(CUexternalMemory *extMem_out,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuImportExternalMemory) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuImportExternalMemory) < 0 ||
       rpc_write(conn, extMem_out, sizeof(CUexternalMemory)) < 0 ||
       rpc_write(conn, memHandleDesc,
                 sizeof(const CUDA_EXTERNAL_MEMORY_HANDLE_DESC)) < 0 ||
@@ -3313,7 +3143,7 @@ CUresult cuExternalMemoryGetMappedBuffer(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
       rpc_write(conn, devPtr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
       rpc_write(conn, bufferDesc,
@@ -3340,8 +3170,8 @@ CUresult cuExternalMemoryGetMappedMipmappedArray(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(
-          conn, RPC_cuExternalMemoryGetMappedMipmappedArray) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuExternalMemoryGetMappedMipmappedArray) <
+          0 ||
       rpc_write(conn, mipmap, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
       rpc_write(conn, mipmapDesc,
@@ -3363,7 +3193,7 @@ CUresult cuDestroyExternalMemory(CUexternalMemory extMem) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDestroyExternalMemory) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDestroyExternalMemory) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3385,7 +3215,7 @@ CUresult cuImportExternalSemaphore(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuImportExternalSemaphore) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuImportExternalSemaphore) < 0 ||
       rpc_write(conn, extSem_out, sizeof(CUexternalSemaphore)) < 0 ||
       rpc_write(conn, semHandleDesc,
                 sizeof(const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC)) < 0 ||
@@ -3419,7 +3249,7 @@ CUresult cuSignalExternalSemaphoresAsync(
   if (numExtSems * sizeof(const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS) != 0 &&
       paramsArray == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
       rpc_write(conn, &numExtSems, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, extSemArray,
                 numExtSems * sizeof(const CUexternalSemaphore)) < 0 ||
@@ -3456,7 +3286,7 @@ CUresult cuWaitExternalSemaphoresAsync(
   if (numExtSems * sizeof(const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS) != 0 &&
       paramsArray == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
       rpc_write(conn, &numExtSems, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, extSemArray,
                 numExtSems * sizeof(const CUexternalSemaphore)) < 0 ||
@@ -3480,7 +3310,7 @@ CUresult cuDestroyExternalSemaphore(CUexternalSemaphore extSem) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
       rpc_write(conn, &extSem, sizeof(CUexternalSemaphore)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3502,7 +3332,7 @@ CUresult cuStreamWaitValue32_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint32_t)) < 0 ||
@@ -3527,7 +3357,7 @@ CUresult cuStreamWaitValue64_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint64_t)) < 0 ||
@@ -3552,7 +3382,7 @@ CUresult cuStreamWriteValue32_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint32_t)) < 0 ||
@@ -3577,7 +3407,7 @@ CUresult cuStreamWriteValue64_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint64_t)) < 0 ||
@@ -3603,7 +3433,7 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, paramArray, sizeof(CUstreamBatchMemOpParams)) < 0 ||
@@ -3631,7 +3461,7 @@ CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuFuncSetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetAttribute) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_write(conn, &value, sizeof(int)) < 0 ||
@@ -3656,7 +3486,7 @@ CUresult cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuFuncSetCacheConfig) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetCacheConfig) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3679,7 +3509,7 @@ CUresult cuFuncGetModule(CUmodule *hmod, CUfunction hfunc) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuFuncGetModule) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuFuncGetModule) < 0 ||
       rpc_write(conn, hmod, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3703,7 +3533,7 @@ CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuFuncSetBlockShape) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetBlockShape) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &x, sizeof(int)) < 0 ||
       rpc_write(conn, &y, sizeof(int)) < 0 ||
@@ -3724,7 +3554,7 @@ CUresult cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuFuncSetSharedSize) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetSharedSize) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &bytes, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3744,7 +3574,7 @@ CUresult cuParamSetSize(CUfunction hfunc, unsigned int numbytes) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuParamSetSize) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuParamSetSize) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &numbytes, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3764,7 +3594,7 @@ CUresult cuParamSeti(CUfunction hfunc, int offset, unsigned int value) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuParamSeti) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuParamSeti) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &offset, sizeof(int)) < 0 ||
       rpc_write(conn, &value, sizeof(unsigned int)) < 0 ||
@@ -3785,7 +3615,7 @@ CUresult cuParamSetf(CUfunction hfunc, int offset, float value) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuParamSetf) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuParamSetf) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &offset, sizeof(int)) < 0 ||
       rpc_write(conn, &value, sizeof(float)) < 0 ||
@@ -3806,7 +3636,7 @@ CUresult cuLaunch(CUfunction f) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
-  if (rpc_write_start_request(conn, RPC_cuLaunch) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLaunch) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3825,7 +3655,7 @@ CUresult cuLaunchGrid(CUfunction f, int grid_width, int grid_height) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
-  if (rpc_write_start_request(conn, RPC_cuLaunchGrid) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchGrid) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &grid_width, sizeof(int)) < 0 ||
       rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
@@ -3848,7 +3678,7 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
-  if (rpc_write_start_request(conn, RPC_cuLaunchGridAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchGridAsync) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &grid_width, sizeof(int)) < 0 ||
       rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
@@ -3874,7 +3704,7 @@ cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
+  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
           0 ||
       rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
       rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
@@ -3897,7 +3727,7 @@ CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuParamSetTexRef) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuParamSetTexRef) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &texunit, sizeof(int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -3918,7 +3748,7 @@ CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (rpc_write_start_request(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &config, sizeof(CUsharedconfig)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3940,7 +3770,7 @@ CUresult cuGraphCreate(CUgraph *phGraph, unsigned int flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphCreate) < 0 ||
       rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3965,7 +3795,7 @@ CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(CUDA_MEMCPY3D)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3987,7 +3817,7 @@ CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(const CUDA_MEMCPY3D)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4008,7 +3838,7 @@ CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(CUDA_MEMSET_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4030,7 +3860,7 @@ CUresult cuGraphMemsetNodeSetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(const CUDA_MEMSET_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4059,7 +3889,7 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4090,7 +3920,7 @@ CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph *phGraph) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4123,7 +3953,7 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddEmptyNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddEmptyNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4159,7 +3989,7 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4187,7 +4017,7 @@ CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, event_out, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4208,7 +4038,7 @@ CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4237,7 +4067,7 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4265,7 +4095,7 @@ CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, event_out, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4285,7 +4115,7 @@ CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4317,8 +4147,8 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn,
-                              RPC_cuGraphAddExternalSemaphoresSignalNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddExternalSemaphoresSignalNode) <
+          0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4356,7 +4186,7 @@ CUresult cuGraphExternalSemaphoresSignalNodeGetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (params_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(
+  if (lupine_cuda_rpc_start(
           conn, RPC_cuGraphExternalSemaphoresSignalNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4408,7 +4238,7 @@ CUresult cuGraphExternalSemaphoresSignalNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(
+  if (lupine_cuda_rpc_start(
           conn, RPC_cuGraphExternalSemaphoresSignalNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -4446,7 +4276,7 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresWaitNode) <
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddExternalSemaphoresWaitNode) <
           0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
@@ -4484,7 +4314,7 @@ CUresult cuGraphExternalSemaphoresWaitNodeGetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (params_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(
+  if (lupine_cuda_rpc_start(
           conn, RPC_cuGraphExternalSemaphoresWaitNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4536,7 +4366,7 @@ CUresult cuGraphExternalSemaphoresWaitNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(
+  if (lupine_cuda_rpc_start(
           conn, RPC_cuGraphExternalSemaphoresWaitNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -4574,7 +4404,7 @@ CUresult cuGraphAddBatchMemOpNode(
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddBatchMemOpNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddBatchMemOpNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4608,7 +4438,7 @@ cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode,
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeGetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphBatchMemOpNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       (lupine_deep_cache_reset((const void *)nodeParams_out), false) ||
@@ -4646,7 +4476,7 @@ CUresult cuGraphBatchMemOpNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeSetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphBatchMemOpNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       rpc_write(conn, nodeParams->paramArray,
@@ -4673,8 +4503,7 @@ CUresult cuGraphExecBatchMemOpNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphExecBatchMemOpNodeSetParams) <
-          0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecBatchMemOpNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -4707,7 +4536,7 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4737,7 +4566,7 @@ CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, params_out, sizeof(CUDA_MEM_ALLOC_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4767,7 +4596,7 @@ CUresult cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4795,7 +4624,7 @@ CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr *dptr_out) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, dptr_out, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4817,7 +4646,7 @@ CUresult cuDeviceGraphMemTrim(CUdevice device) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
       rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4838,7 +4667,7 @@ CUresult cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphClone) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphClone) < 0 ||
       rpc_write(conn, phGraphClone, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &originalGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4866,7 +4695,7 @@ CUresult cuGraphNodeFindInClone(CUgraphNode *phNode, CUgraphNode hOriginalNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphNodeFindInClone) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphNodeFindInClone) < 0 ||
       rpc_write(conn, phNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hOriginalNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hClonedGraph, sizeof(CUgraph)) < 0 ||
@@ -4890,7 +4719,7 @@ CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphNodeGetType) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphNodeGetType) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, type, sizeof(CUgraphNodeType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4912,7 +4741,7 @@ CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
   conn_t *conn = lupine_route_remote_conn(route);
   size_t numNodes_requested = (nodes != nullptr) ? *numNodes : 0;
   uint8_t nodes_null = nodes == nullptr ? 1 : 0;
-  if (rpc_write_start_request(conn, RPC_cuGraphGetNodes) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphGetNodes) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numNodes_requested, sizeof(size_t)) < 0 ||
       rpc_write(conn, &nodes_null, sizeof(uint8_t)) < 0 ||
@@ -4942,7 +4771,7 @@ CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
   conn_t *conn = lupine_route_remote_conn(route);
   size_t numRootNodes_requested = (rootNodes != nullptr) ? *numRootNodes : 0;
   uint8_t rootNodes_null = rootNodes == nullptr ? 1 : 0;
-  if (rpc_write_start_request(conn, RPC_cuGraphGetRootNodes) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphGetRootNodes) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numRootNodes_requested, sizeof(size_t)) < 0 ||
       rpc_write(conn, &rootNodes_null, sizeof(uint8_t)) < 0 ||
@@ -4970,7 +4799,7 @@ CUresult cuGraphDestroyNode(CUgraphNode hNode) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphDestroyNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphDestroyNode) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4993,7 +4822,7 @@ CUresult cuGraphInstantiateWithFlags(CUgraphExec *phGraphExec, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
       rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned long long)) < 0 ||
@@ -5024,7 +4853,7 @@ cuGraphInstantiateWithParams(CUgraphExec *phGraphExec, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
       rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, instantiateParams,
@@ -5051,7 +4880,7 @@ CUresult cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t *flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphExecGetFlags) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecGetFlags) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, flags, sizeof(cuuint64_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5076,7 +4905,7 @@ CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, copyParams, sizeof(const CUDA_MEMCPY3D)) < 0 ||
@@ -5102,7 +4931,7 @@ cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, memsetParams, sizeof(const CUDA_MEMSET_NODE_PARAMS)) <
@@ -5127,8 +4956,7 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphExecChildGraphNodeSetParams) <
-          0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecChildGraphNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &childGraph, sizeof(CUgraph)) < 0 ||
@@ -5150,8 +4978,7 @@ CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphExecEventRecordNodeSetEvent) <
-          0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecEventRecordNodeSetEvent) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
@@ -5173,7 +5000,7 @@ CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
@@ -5199,7 +5026,7 @@ CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(
+  if (lupine_cuda_rpc_start(
           conn, RPC_cuGraphExecExternalSemaphoresSignalNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5232,7 +5059,7 @@ CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(
+  if (lupine_cuda_rpc_start(
           conn, RPC_cuGraphExecExternalSemaphoresWaitNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5261,7 +5088,7 @@ CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &isEnabled, sizeof(unsigned int)) < 0 ||
@@ -5283,7 +5110,7 @@ CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, isEnabled, sizeof(unsigned int)) < 0 ||
@@ -5304,7 +5131,7 @@ CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphUpload) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphUpload) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5323,7 +5150,7 @@ CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphLaunch) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphLaunch) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5342,7 +5169,7 @@ CUresult cuGraphExecDestroy(CUgraphExec hGraphExec) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphExecDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecDestroy) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -5360,7 +5187,7 @@ CUresult cuGraphDestroy(CUgraph hGraph) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphDestroy) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -5381,7 +5208,7 @@ CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, resultInfo, sizeof(CUgraphExecUpdateResultInfo)) < 0 ||
@@ -5402,7 +5229,7 @@ CUresult cuGraphKernelNodeCopyAttributes(CUgraphNode dst, CUgraphNode src) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
       rpc_write(conn, &dst, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &src, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5425,7 +5252,7 @@ CUresult cuGraphKernelNodeGetAttribute(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUkernelNodeAttrID)) < 0 ||
       rpc_write(conn, value_out, sizeof(CUkernelNodeAttrValue)) < 0 ||
@@ -5450,7 +5277,7 @@ CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUkernelNodeAttrID)) < 0 ||
       rpc_write(conn, value, sizeof(const CUkernelNodeAttrValue)) < 0 ||
@@ -5472,7 +5299,7 @@ CUresult cuGraphDebugDotPrint(CUgraph hGraph, const char *path,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t path_len = std::strlen(path) + 1;
-  if (rpc_write_start_request(conn, RPC_cuGraphDebugDotPrint) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphDebugDotPrint) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &path_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, path, path_len) < 0 ||
@@ -5493,7 +5320,7 @@ CUresult cuUserObjectRetain(CUuserObject object, unsigned int count) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuUserObjectRetain) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuUserObjectRetain) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5512,7 +5339,7 @@ CUresult cuUserObjectRelease(CUuserObject object, unsigned int count) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuUserObjectRelease) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuUserObjectRelease) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5534,7 +5361,7 @@ CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphRetainUserObject) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphRetainUserObject) < 0 ||
       rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -5557,7 +5384,7 @@ CUresult cuGraphReleaseUserObject(CUgraph graph, CUuserObject object,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphReleaseUserObject) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphReleaseUserObject) < 0 ||
       rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -5581,8 +5408,8 @@ CUresult cuOccupancyAvailableDynamicSMemPerBlock(size_t *dynamicSmemSize,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
-  if (rpc_write_start_request(
-          conn, RPC_cuOccupancyAvailableDynamicSMemPerBlock) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuOccupancyAvailableDynamicSMemPerBlock) <
+          0 ||
       rpc_write(conn, dynamicSmemSize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &func_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &numBlocks, sizeof(int)) < 0 ||
@@ -5609,8 +5436,7 @@ CUresult cuOccupancyMaxPotentialClusterSize(int *clusterSize, CUfunction func,
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
   if (config == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuOccupancyMaxPotentialClusterSize) <
-          0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuOccupancyMaxPotentialClusterSize) < 0 ||
       rpc_write(conn, clusterSize, sizeof(int)) < 0 ||
       rpc_write(conn, &func_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, config, sizeof(*config)) < 0 ||
@@ -5638,7 +5464,7 @@ CUresult cuOccupancyMaxActiveClusters(int *numClusters, CUfunction func,
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
   if (config == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
       rpc_write(conn, numClusters, sizeof(int)) < 0 ||
       rpc_write(conn, &func_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, config, sizeof(*config)) < 0 ||
@@ -5662,7 +5488,7 @@ CUresult cuTexRefSetArray(CUtexref hTexRef, CUarray hArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetArray) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetArray) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -5685,7 +5511,7 @@ CUresult cuTexRefSetMipmappedArray(CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -5707,7 +5533,7 @@ CUresult cuTexRefSetAddress_v2(size_t *ByteOffset, CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
       rpc_write(conn, ByteOffset, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -5733,7 +5559,7 @@ CUresult cuTexRefSetAddress2D_v3(CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, desc, sizeof(const CUDA_ARRAY_DESCRIPTOR)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -5756,7 +5582,7 @@ CUresult cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetFormat) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetFormat) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &fmt, sizeof(CUarray_format)) < 0 ||
       rpc_write(conn, &NumPackedComponents, sizeof(int)) < 0 ||
@@ -5776,7 +5602,7 @@ CUresult cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetAddressMode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetAddressMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &dim, sizeof(int)) < 0 ||
       rpc_write(conn, &am, sizeof(CUaddress_mode)) < 0 ||
@@ -5796,7 +5622,7 @@ CUresult cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetFilterMode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetFilterMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &fm, sizeof(CUfilter_mode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5815,7 +5641,7 @@ CUresult cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &fm, sizeof(CUfilter_mode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5834,7 +5660,7 @@ CUresult cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &bias, sizeof(float)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5856,7 +5682,7 @@ CUresult cuTexRefSetMipmapLevelClamp(CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &minMipmapLevelClamp, sizeof(float)) < 0 ||
       rpc_write(conn, &maxMipmapLevelClamp, sizeof(float)) < 0 ||
@@ -5877,7 +5703,7 @@ CUresult cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &maxAniso, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5897,7 +5723,7 @@ CUresult cuTexRefSetBorderColor(CUtexref hTexRef, float *pBorderColor) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetBorderColor) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetBorderColor) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, pBorderColor, sizeof(float)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5917,7 +5743,7 @@ CUresult cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefSetFlags) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetFlags) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5936,7 +5762,7 @@ CUresult cuTexRefGetAddress_v2(CUdeviceptr *pdptr, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
       rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5956,7 +5782,7 @@ CUresult cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetArray) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetArray) < 0 ||
       rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5978,7 +5804,7 @@ CUresult cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
       rpc_write(conn, phMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5999,7 +5825,7 @@ CUresult cuTexRefGetAddressMode(CUaddress_mode *pam, CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetAddressMode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetAddressMode) < 0 ||
       rpc_write(conn, pam, sizeof(CUaddress_mode)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &dim, sizeof(int)) < 0 ||
@@ -6020,7 +5846,7 @@ CUresult cuTexRefGetFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetFilterMode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetFilterMode) < 0 ||
       rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6042,7 +5868,7 @@ CUresult cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetFormat) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetFormat) < 0 ||
       rpc_write(conn, pFormat, sizeof(CUarray_format)) < 0 ||
       rpc_write(conn, pNumChannels, sizeof(int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6064,7 +5890,7 @@ CUresult cuTexRefGetMipmapFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
       rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6084,7 +5910,7 @@ CUresult cuTexRefGetMipmapLevelBias(float *pbias, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
       rpc_write(conn, pbias, sizeof(float)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6107,7 +5933,7 @@ CUresult cuTexRefGetMipmapLevelClamp(float *pminMipmapLevelClamp,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
       rpc_write(conn, pminMipmapLevelClamp, sizeof(float)) < 0 ||
       rpc_write(conn, pmaxMipmapLevelClamp, sizeof(float)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6130,7 +5956,7 @@ CUresult cuTexRefGetMaxAnisotropy(int *pmaxAniso, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
       rpc_write(conn, pmaxAniso, sizeof(int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6151,7 +5977,7 @@ CUresult cuTexRefGetBorderColor(float *pBorderColor, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetBorderColor) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetBorderColor) < 0 ||
       rpc_write(conn, pBorderColor, sizeof(float)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6171,7 +5997,7 @@ CUresult cuTexRefGetFlags(unsigned int *pFlags, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefGetFlags) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetFlags) < 0 ||
       rpc_write(conn, pFlags, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6191,7 +6017,7 @@ CUresult cuTexRefCreate(CUtexref *pTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefCreate) < 0 ||
       rpc_write(conn, pTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pTexRef, sizeof(CUtexref)) < 0 ||
@@ -6210,7 +6036,7 @@ CUresult cuTexRefDestroy(CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexRefDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefDestroy) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6229,7 +6055,7 @@ CUresult cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuSurfRefSetArray) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuSurfRefSetArray) < 0 ||
       rpc_write(conn, &hSurfRef, sizeof(CUsurfref)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -6249,7 +6075,7 @@ CUresult cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuSurfRefGetArray) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuSurfRefGetArray) < 0 ||
       rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hSurfRef, sizeof(CUsurfref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6275,7 +6101,7 @@ CUresult cuTexObjectCreate(CUtexObject *pTexObject,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexObjectCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectCreate) < 0 ||
       rpc_write(conn, pTexObject, sizeof(CUtexObject)) < 0 ||
       rpc_write(conn, pResDesc, sizeof(const CUDA_RESOURCE_DESC)) < 0 ||
       rpc_write(conn, &pTexDesc, sizeof(const CUDA_TEXTURE_DESC *)) < 0 ||
@@ -6303,7 +6129,7 @@ CUresult cuTexObjectDestroy(CUtexObject texObject) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexObjectDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectDestroy) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6323,7 +6149,7 @@ CUresult cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
       rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6345,7 +6171,7 @@ CUresult cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
       rpc_write(conn, pTexDesc, sizeof(CUDA_TEXTURE_DESC)) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6367,7 +6193,7 @@ CUresult cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC *pResViewDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
       rpc_write(conn, pResViewDesc, sizeof(CUDA_RESOURCE_VIEW_DESC)) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6388,7 +6214,7 @@ CUresult cuSurfObjectCreate(CUsurfObject *pSurfObject,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuSurfObjectCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuSurfObjectCreate) < 0 ||
       rpc_write(conn, pSurfObject, sizeof(CUsurfObject)) < 0 ||
       rpc_write(conn, pResDesc, sizeof(const CUDA_RESOURCE_DESC)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6408,7 +6234,7 @@ CUresult cuSurfObjectDestroy(CUsurfObject surfObject) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuSurfObjectDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuSurfObjectDestroy) < 0 ||
       rpc_write(conn, &surfObject, sizeof(CUsurfObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6428,7 +6254,7 @@ CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
       rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
       rpc_write(conn, &surfObject, sizeof(CUsurfObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6448,7 +6274,7 @@ CUresult cuGraphicsUnregisterResource(CUgraphicsResource resource) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6471,7 +6297,7 @@ CUresult cuGraphicsSubResourceGetMappedArray(CUarray *pArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphicsSubResourceGetMappedArray) <
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsSubResourceGetMappedArray) <
           0 ||
       rpc_write(conn, pArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
@@ -6497,7 +6323,7 @@ cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray *pMipmappedArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(
+  if (lupine_cuda_rpc_start(
           conn, RPC_cuGraphicsResourceGetMappedMipmappedArray) < 0 ||
       rpc_write(conn, pMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
@@ -6521,7 +6347,7 @@ CUresult cuGraphicsResourceGetMappedPointer_v2(CUdeviceptr *pDevPtr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) <
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) <
           0 ||
       rpc_write(conn, pDevPtr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, pSize, sizeof(size_t)) < 0 ||
@@ -6546,7 +6372,7 @@ CUresult cuGraphicsResourceSetMapFlags_v2(CUgraphicsResource resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6571,7 +6397,7 @@ CUresult cuGraphicsMapResources(unsigned int count,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(CUgraphicsResource) != 0 && resources == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphicsMapResources) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsMapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, resources, count * sizeof(CUgraphicsResource)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -6597,7 +6423,7 @@ CUresult cuGraphicsUnmapResources(unsigned int count,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(CUgraphicsResource) != 0 && resources == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuGraphicsUnmapResources) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsUnmapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, resources, count * sizeof(CUgraphicsResource)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -6621,7 +6447,7 @@ CUresult cuGreenCtxGetDevResource(CUgreenCtx hCtx, CUdevResource *resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGreenCtxGetDevResource) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGreenCtxGetDevResource) < 0 ||
       rpc_write(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
       rpc_write(conn, &type, sizeof(CUdevResourceType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6645,7 +6471,7 @@ CUresult cuStreamGetGreenCtx(CUstream hStream, CUgreenCtx *phCtx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamGetGreenCtx) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetGreenCtx) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phCtx, sizeof(CUgreenCtx)) < 0 ||
@@ -6672,7 +6498,7 @@ CUresult cuGreenCtxStreamCreate(CUstream *phStream, CUgreenCtx greenCtx,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGreenCtxStreamCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGreenCtxStreamCreate) < 0 ||
       rpc_write(conn, &greenCtx, sizeof(CUgreenCtx)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &priority, sizeof(int)) < 0 ||

--- a/copy_pipeline.cpp
+++ b/copy_pipeline.cpp
@@ -12,7 +12,6 @@
 
 extern "C" const void *lupine_mapped_host_read_source(const void *host,
                                                       size_t size);
-extern "C" CUresult lupine_flush_dirty_host_pages_to_server();
 extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
                                                   CUdeviceptr *translated);
 
@@ -28,13 +27,8 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUdeviceptr src_rpc = srcDevice;
-  if (lupine_translate_managed_host_ptr(srcDevice, &src_rpc)) {
-    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
-    if (flush_result != CUDA_SUCCESS) {
-      return flush_result;
-    }
-  }
-  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
+  lupine_translate_managed_host_ptr(srcDevice, &src_rpc);
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
       rpc_write(conn, &src_rpc, sizeof(src_rpc)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -95,13 +89,8 @@ extern "C" CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
   srcHost = lupine_mapped_host_read_source(srcHost, ByteCount);
   conn_t *conn = lupine_route_remote_conn(route);
   CUdeviceptr dst_rpc = dstDevice;
-  if (lupine_translate_managed_host_ptr(dstDevice, &dst_rpc)) {
-    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
-    if (flush_result != CUDA_SUCCESS) {
-      return flush_result;
-    }
-  }
-  if (rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
+  lupine_translate_managed_host_ptr(dstDevice, &dst_rpc);
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
       rpc_write(conn, &dst_rpc, sizeof(dst_rpc)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -782,7 +782,7 @@ static bool lupine_cuda_is_initialized() {
 
 static CUresult lupine_remote_cuInit(conn_t *conn, unsigned int flags) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuInit) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuInit) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -866,7 +866,7 @@ extern "C" CUresult cuDeviceGetP2PAttribute(int *value,
 
   conn_t *conn = lupine_route_remote_conn(src_route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
       rpc_write(conn, value, sizeof(*value)) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
@@ -911,7 +911,7 @@ extern "C" CUresult cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev,
   }
 
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuDeviceCanAccessPeer) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceCanAccessPeer) < 0 ||
       rpc_write(conn, canAccessPeer, sizeof(*canAccessPeer)) < 0 ||
       rpc_write(conn, &dev, sizeof(dev)) < 0 ||
       rpc_write(conn, &peerDev, sizeof(peerDev)) < 0 ||
@@ -939,7 +939,7 @@ extern "C" CUresult cuCtxEnablePeerAccess(CUcontext peerContext,
   }
   conn_t *conn = lupine_route_remote_conn(current_route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuCtxEnablePeerAccess) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxEnablePeerAccess) < 0 ||
       rpc_write(conn, &peerContext, sizeof(peerContext)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -963,7 +963,7 @@ extern "C" CUresult cuCtxDisablePeerAccess(CUcontext peerContext) {
   }
   conn_t *conn = lupine_route_remote_conn(current_route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuCtxDisablePeerAccess) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxDisablePeerAccess) < 0 ||
       rpc_write(conn, &peerContext, sizeof(peerContext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -1039,7 +1039,7 @@ extern "C" CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
-  if (rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetKernel) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -1107,8 +1107,8 @@ static void lupine_prefetch_function_param_layout(CUfunction function,
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(
-          conn, LUPINE_RPC_lupineFunctionParamLayoutSnapshot) < 0 ||
+  if (lupine_cuda_rpc_start(conn,
+                            LUPINE_RPC_lupineFunctionParamLayoutSnapshot) < 0 ||
       rpc_write(conn, &function, sizeof(function)) < 0 ||
       rpc_wait_for_response(conn) < 0) {
     return;
@@ -1148,8 +1148,8 @@ static void lupine_prefill_function_attribute_snapshot(CUfunction function,
     return;
   }
 
-  if (rpc_write_start_request(conn,
-                              LUPINE_RPC_lupineFunctionAttributeSnapshot) < 0 ||
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineFunctionAttributeSnapshot) <
+          0 ||
       rpc_write(conn, &function, sizeof(function)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_function_attributes(conn, route, function) < 0 ||
@@ -1177,7 +1177,7 @@ extern "C" CUresult cuModuleGetFunction(CUfunction *function, CUmodule module,
 
   conn_t *conn = lupine_route_remote_conn(route);
   size_t name_len = std::strlen(name) + 1;
-  if (rpc_write_start_request(conn, RPC_cuModuleGetFunction) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetFunction) < 0 ||
       rpc_write(conn, &module, sizeof(module)) < 0 ||
       rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -1242,7 +1242,7 @@ static CUresult lupine_load_recorded_module_on_route(CUmodule source_module,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     size_t image_size = record.image.size();
-    if (rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
+    if (lupine_cuda_rpc_start(conn, RPC_cuModuleLoadData) < 0 ||
         rpc_write(conn, &record.kind, sizeof(record.kind)) < 0 ||
         rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
         rpc_write_payload(conn, record.image.data(), image_size) < 0 ||
@@ -1316,7 +1316,7 @@ extern "C" CUresult cuModuleLoad(CUmodule *module, const char *fname) {
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
 
-  bool failed = rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
+  bool failed = lupine_cuda_rpc_start(conn, RPC_cuModuleLoad) < 0 ||
                 rpc_write(conn, &mapped_size, sizeof(mapped_size)) < 0 ||
                 rpc_write_payload(conn, mapping, mapped_size) < 0 ||
                 rpc_wait_for_response(conn) < 0 ||
@@ -1383,7 +1383,7 @@ static CUresult lupine_load_recorded_library_on_route(CUlibrary source_library,
     conn_t *conn = lupine_route_remote_conn(route);
     size_t image_size = record.image.size();
     unsigned int zero_options = 0;
-    if (rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
+    if (lupine_cuda_rpc_start(conn, RPC_cuLibraryLoadData) < 0 ||
         rpc_write(conn, &record.kind, sizeof(record.kind)) < 0 ||
         rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
         rpc_write_payload(conn, record.image.data(), image_size) < 0 ||
@@ -1461,7 +1461,7 @@ static CUresult lupine_resolve_library_kernel_for_route(CUfunction function,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     std::size_t name_len = record.name.size() + 1;
-    if (rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
+    if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetKernel) < 0 ||
         rpc_write(conn, &library, sizeof(library)) < 0 ||
         rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
         rpc_write(conn, record.name.c_str(), name_len) < 0 ||
@@ -1540,7 +1540,7 @@ static CUresult lupine_resolve_module_function_for_route(CUfunction function,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     std::size_t name_len = record.name.size() + 1;
-    if (rpc_write_start_request(conn, RPC_cuModuleGetFunction) < 0 ||
+    if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetFunction) < 0 ||
         rpc_write(conn, &module, sizeof(module)) < 0 ||
         rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
         rpc_write(conn, record.name.c_str(), name_len) < 0 ||
@@ -1846,7 +1846,7 @@ static void lupine_prefill_device_snapshot(conn_t *conn) {
     return;
   }
   CUresult result = CUDA_ERROR_UNKNOWN;
-  if (rpc_write_start_request(conn, LUPINE_RPC_lupineDeviceSnapshot) < 0 ||
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineDeviceSnapshot) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0) {
     return;
@@ -1927,7 +1927,7 @@ extern "C" CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib,
   }
   CUresult return_value;
   int value = 0;
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetAttribute) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(remote_dev)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1971,7 +1971,7 @@ extern "C" CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
     }
   }
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetName) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetName) < 0 ||
       rpc_write(conn, &len, sizeof(int)) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2007,7 +2007,7 @@ extern "C" CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev) {
     return CUDA_SUCCESS;
   }
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 || rpc_read(conn, uuid, 16) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2040,7 +2040,7 @@ extern "C" CUresult cuDeviceTotalMem_v2(size_t *bytes, CUdevice dev) {
     return CUDA_SUCCESS;
   }
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, bytes, sizeof(size_t)) < 0 ||
@@ -2082,7 +2082,7 @@ extern "C" CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRetain) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxRetain) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pctx, sizeof(CUcontext)) < 0 ||
@@ -2113,7 +2113,7 @@ extern "C" CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRelease_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxRelease_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2142,7 +2142,7 @@ extern "C" CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxSetFlags_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxSetFlags_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2176,7 +2176,7 @@ cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags, int *active) {
     }
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxGetState) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxGetState) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, flags, sizeof(unsigned int)) < 0 ||
@@ -2209,7 +2209,7 @@ extern "C" CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxReset_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxReset_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2289,7 +2289,7 @@ static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
   size_t size = 0;
   conn_t *conn = lupine_route_remote_conn(route);
   int rpc = kernel ? RPC_cuKernelGetParamInfo : RPC_cuFuncGetParamInfo;
-  if (rpc_write_start_request(conn, rpc) < 0 ||
+  if (lupine_cuda_rpc_start(conn, rpc) < 0 ||
       rpc_write(conn, &handle, sizeof(handle)) < 0 ||
       rpc_write(conn, &param_index, sizeof(param_index)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2361,7 +2361,7 @@ extern "C" CUresult cuKernelGetFunction(CUfunction *pFunc, CUkernel kernel) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction function = nullptr;
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuKernelGetFunction) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuKernelGetFunction) < 0 ||
       rpc_write(conn, &route_kernel, sizeof(route_kernel)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &function, sizeof(function)) < 0 ||
@@ -2405,7 +2405,7 @@ extern "C" CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   int value = 0;
-  if (rpc_write_start_request(conn, RPC_cuKernelGetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuKernelGetAttribute) < 0 ||
       rpc_write(conn, &value, sizeof(value)) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &kernel, sizeof(kernel)) < 0 ||
@@ -2445,7 +2445,7 @@ extern "C" CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
 
   conn_t *conn = lupine_route_remote_conn(route);
   int value = 0;
-  if (rpc_write_start_request(conn, RPC_cuFuncGetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuFuncGetAttribute) < 0 ||
       rpc_write(conn, &value, sizeof(value)) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
@@ -2519,7 +2519,7 @@ static CUresult lupine_cuOccupancy_cached(int *numBlocks, CUfunction func,
   int opcode = with_flags
                    ? RPC_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
                    : RPC_cuOccupancyMaxActiveBlocksPerMultiprocessor;
-  if (rpc_write_start_request(conn, opcode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, opcode) < 0 ||
       rpc_write(conn, &remote_num_blocks, sizeof(remote_num_blocks)) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &blockSize, sizeof(blockSize)) < 0 ||
@@ -2586,7 +2586,7 @@ static CUresult lupine_get_remote_private_module_node(CUcontext context,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_UNKNOWN;
-  if (rpc_write_start_request(conn, LUPINE_RPC_cuPrivateGetModuleNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuPrivateGetModuleNode) < 0 ||
       rpc_write(conn, &context, sizeof(context)) < 0 ||
       rpc_write(conn, &module, sizeof(module)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2942,7 +2942,7 @@ static const void *lupine_remote_private_export_table(const CUuuid *uuid) {
   uint32_t trusted = 0;
   uint64_t hashes[LUPINE_PRIVATE_EXPORT_MAX_SLOTS] = {};
 
-  if (rpc_write_start_request(conn, LUPINE_RPC_cuGetExportTableMetadata) < 0 ||
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuGetExportTableMetadata) < 0 ||
       rpc_write(conn, uuid->bytes, sizeof(uuid->bytes)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 ||
@@ -3066,7 +3066,7 @@ static CUresult lupine_error_string_lookup(int rpc_op, const char *symbol,
   constexpr uint32_t kMaxLength = 4096;
   conn_t *conn = lupine_route_remote_conn(route);
   uint32_t length = 0;
-  if (rpc_write_start_request(conn, rpc_op) < 0 ||
+  if (lupine_cuda_rpc_start(conn, rpc_op) < 0 ||
       rpc_write(conn, &error, sizeof(error)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &length, sizeof(length)) < 0 || length > kMaxLength) {
@@ -3128,7 +3128,7 @@ extern "C" CUresult cuEventDestroy_v2(CUevent hEvent) {
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuEventDestroy_v2) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -3233,7 +3233,7 @@ extern "C" CUresult cuMemPoolSetAttribute(CUmemoryPool pool,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuMemPoolSetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolSetAttribute) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -3303,7 +3303,7 @@ CUresult cuMemExportToShareableHandle(void *shareableHandle,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   lupine_ipc_token token = {};
-  if (rpc_write_start_request(conn, RPC_cuMemExportToShareableHandle) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemExportToShareableHandle) < 0 ||
       rpc_write(conn, &handle, sizeof(handle)) < 0 ||
       rpc_write(conn, &handleType, sizeof(handleType)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -3345,7 +3345,7 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle *handle,
     return CUDA_ERROR_INVALID_VALUE;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemImportFromShareableHandle) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemImportFromShareableHandle) < 0 ||
       rpc_write(conn, &token, sizeof(token)) < 0 ||
       rpc_write(conn, &shHandleType, sizeof(shHandleType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3371,7 +3371,7 @@ CUresult cuMemPoolExportToShareableHandle(void *handle_out, CUmemoryPool pool,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   lupine_ipc_token token = {};
-  if (rpc_write_start_request(conn, RPC_cuMemPoolExportToShareableHandle) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolExportToShareableHandle) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &handleType, sizeof(handleType)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -3416,8 +3416,7 @@ cuMemPoolImportFromShareableHandle(CUmemoryPool *pool_out, void *handle,
     return CUDA_ERROR_INVALID_VALUE;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemPoolImportFromShareableHandle) <
-          0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolImportFromShareableHandle) < 0 ||
       rpc_write(conn, &token, sizeof(token)) < 0 ||
       rpc_write(conn, &handleType, sizeof(handleType)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -3579,7 +3578,7 @@ extern "C" CUresult cuCtxGetDevice(CUdevice *device) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUdevice remote_device = 0;
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuCtxGetDevice) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetDevice) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &remote_device, sizeof(remote_device)) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -3621,7 +3620,7 @@ extern "C" CUresult cuCtxGetDevice_v2(CUdevice *device, CUcontext ctx) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUdevice remote_device = 0;
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuCtxGetDevice_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetDevice_v2) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &remote_device, sizeof(remote_device)) < 0 ||
@@ -3658,7 +3657,7 @@ extern "C" CUresult cuMemPoolGetAttribute(CUmemoryPool pool,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuMemPoolGetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolGetAttribute) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -3691,10 +3690,7 @@ static CUresult lupine_prepare_prefetch_ptr(CUdeviceptr devPtr,
                                             bool *managed_alias) {
   *translated = devPtr;
   *managed_alias = lupine_translate_managed_host_ptr(devPtr, translated);
-  if (!*managed_alias) {
-    return CUDA_SUCCESS;
-  }
-  return lupine_flush_dirty_host_pages_to_server();
+  return CUDA_SUCCESS;
 }
 
 extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
@@ -3738,7 +3734,7 @@ extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuMemPrefetchAsync) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPrefetchAsync) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &route_device, sizeof(route_device)) < 0 ||
@@ -3792,7 +3788,7 @@ extern "C" CUresult cuMemAdvise(CUdeviceptr devPtr, size_t count,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuMemAdvise) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemAdvise) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &advice, sizeof(advice)) < 0 ||
@@ -3852,7 +3848,7 @@ extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuMemPrefetchAsync_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemPrefetchAsync_v2) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &route_location, sizeof(route_location)) < 0 ||
@@ -3902,7 +3898,7 @@ extern "C" CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuMemAdvise_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemAdvise_v2) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &advice, sizeof(advice)) < 0 ||
@@ -3931,7 +3927,7 @@ extern "C" CUresult cuCtxGetStreamPriorityRange(int *leastPriority,
   int least = 0;
   int greatest = 0;
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuCtxGetStreamPriorityRange) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetStreamPriorityRange) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &least, sizeof(least)) < 0 ||
       rpc_read(conn, &greatest, sizeof(greatest)) < 0 ||
@@ -3982,7 +3978,7 @@ extern "C" CUresult cuLinkCreate_v2(unsigned int numOptions,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuLinkCreate_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLinkCreate_v2) < 0 ||
       rpc_write(conn, &numOptions, sizeof(numOptions)) < 0 ||
       rpc_write(conn, options, numOptions * sizeof(*options)) < 0 ||
       rpc_write(conn, optionValues, numOptions * sizeof(*optionValues)) < 0 ||
@@ -4021,7 +4017,7 @@ extern "C" CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type,
   CUresult return_value;
   size_t name_len = name == nullptr ? 0 : strlen(name) + 1;
   size_t jit_output_length = 0;
-  if (rpc_write_start_request(conn, RPC_cuLinkAddData_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLinkAddData_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_write(conn, &type, sizeof(type)) < 0 ||
       rpc_write(conn, &size, sizeof(size)) < 0 ||
@@ -4093,7 +4089,7 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
   file_payload = file_mapping;
   file_size = mapped_file_size;
   has_file_data = 1;
-  if (rpc_write_start_request(conn, RPC_cuLinkAddFile_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLinkAddFile_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_write(conn, &type, sizeof(type)) < 0 ||
       rpc_write(conn, &path_len, sizeof(path_len)) < 0 ||
@@ -4141,7 +4137,7 @@ extern "C" CUresult cuLinkComplete(CUlinkState state, void **cubinOut,
   size_t cubin_size = 0;
   std::vector<void *> option_values;
   size_t jit_output_length = 0;
-  if (rpc_write_start_request(conn, RPC_cuLinkComplete) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLinkComplete) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &cubin_size, sizeof(cubin_size)) < 0) {
@@ -4186,7 +4182,7 @@ extern "C" CUresult cuLinkDestroy(CUlinkState state) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuLinkDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLinkDestroy) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -4284,7 +4280,7 @@ extern "C" CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuStreamWaitEvent) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWaitEvent) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &Flags, sizeof(Flags)) < 0 ||
@@ -4314,7 +4310,7 @@ extern "C" CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
   }
   lupine_note_event_recorded(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuEventRecord) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write_end(conn) < 0) {
@@ -4343,7 +4339,7 @@ extern "C" CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
   }
   lupine_note_event_recorded(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuEventRecordWithFlags) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 || rpc_write_end(conn) < 0) {
@@ -4374,7 +4370,7 @@ static void lupine_prefetch_event_queries(CUevent exclude, conn_t *conn) {
   }
 
   CUresult results[kLupineEventQueryBatch];
-  if (rpc_write_start_request(conn, LUPINE_RPC_lupineEventQueryBatch) < 0 ||
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineEventQueryBatch) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, events, count * sizeof(*events)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4386,10 +4382,6 @@ static void lupine_prefetch_event_queries(CUevent exclude, conn_t *conn) {
 }
 
 extern "C" CUresult cuEventQuery(CUevent hEvent) {
-  CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
-  if (flush_result != CUDA_SUCCESS) {
-    return flush_result;
-  }
   lupine_route route = lupine_route_for_event(hEvent);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUevent);
@@ -4409,7 +4401,7 @@ extern "C" CUresult cuEventQuery(CUevent hEvent) {
     return lupine_sync_mapped_device_to_host();
   }
   CUresult result = CUDA_ERROR_UNKNOWN;
-  if (rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuEventQuery) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -4450,7 +4442,7 @@ extern "C" CUresult cuCtxCreate_v2(CUcontext *pctx, unsigned int flags,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuCtxCreate_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxCreate_v2) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_write(conn, &dev, sizeof(dev)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4522,7 +4514,7 @@ static CUresult lupine_occupancy_max_potential_block_size(
   CUresult return_value;
   int op = with_flags ? RPC_cuOccupancyMaxPotentialBlockSizeWithFlags
                       : RPC_cuOccupancyMaxPotentialBlockSize;
-  if (rpc_write_start_request(conn, op) < 0 ||
+  if (lupine_cuda_rpc_start(conn, op) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &dynamicSMemSize, sizeof(dynamicSMemSize)) < 0 ||
       rpc_write(conn, &blockSizeLimit, sizeof(blockSizeLimit)) < 0 ||
@@ -4681,7 +4673,7 @@ extern "C" CUresult cuModuleLoadData(CUmodule *module, const void *image) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t image_size = image_bytes.size();
-  if (rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuModuleLoadData) < 0 ||
       rpc_write(conn, &kind, sizeof(kind)) < 0 ||
       rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
       rpc_write_payload(conn, image_bytes.data(), image_size) < 0 ||
@@ -4726,7 +4718,7 @@ static void lupine_prefill_library_snapshot(CUlibrary library, conn_t *conn) {
 
   CUresult result = CUDA_ERROR_UNKNOWN;
   uint32_t table_count = 0;
-  if (rpc_write_start_request(conn, LUPINE_RPC_lupineLibrarySnapshot) < 0 ||
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineLibrarySnapshot) < 0 ||
       rpc_write(conn, &library, sizeof(library)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 ||
@@ -4802,7 +4794,7 @@ static void lupine_prefill_library_attribute_snapshot(CUlibrary library,
 
   CUresult result = CUDA_ERROR_UNKNOWN;
   CUdevice remote_device = -1;
-  if (rpc_write_start_request(conn, LUPINE_RPC_lupineLibraryAttributeSnapshot) <
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineLibraryAttributeSnapshot) <
           0 ||
       rpc_write(conn, &library, sizeof(library)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4911,7 +4903,7 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
   CUresult return_value;
   size_t image_size = image_bytes.size();
   size_t jit_output_length = 0;
-  if (rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryLoadData) < 0 ||
       rpc_copy_alloc(conn, libraryOptionValues == nullptr
                                ? numLibraryOptions * sizeof(uintptr_t)
                                : 0) < 0 ||
@@ -5168,7 +5160,7 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
        lupine_managed_kernel_requires_launch_sync(f));
   conn_t *conn = lupine_route_remote_conn(route);
   // Fire-and-forget; launch errors are sticky and surface at the next sync.
-  if (rpc_write_start_request(conn, RPC_cuLaunchKernel) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchKernel) < 0 ||
       rpc_write(conn, &f, sizeof(f)) < 0 ||
       rpc_write(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_write(conn, &gridDimY, sizeof(gridDimY)) < 0 ||
@@ -5286,7 +5278,7 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
   // cluster dimensions) are reported from the launch itself. The server
   // applies the same numAttrs rule when deciding whether to respond.
   bool fire_and_forget = config->numAttrs == 0;
-  if (rpc_write_start_request(conn, RPC_cuLaunchKernelEx) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchKernelEx) < 0 ||
       rpc_write(conn, config, sizeof(*config)) < 0 ||
       rpc_write(conn, config->attrs,
                 config->numAttrs * sizeof(*config->attrs)) < 0 ||
@@ -5368,7 +5360,7 @@ cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
       rpc_write(conn, &f, sizeof(f)) < 0 ||
       rpc_write(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_write(conn, &gridDimY, sizeof(gridDimY)) < 0 ||
@@ -5470,7 +5462,7 @@ extern "C" CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
       rpc_write(conn, &srcArray, sizeof(srcArray)) < 0 ||
       rpc_write(conn, &srcOffset, sizeof(srcOffset)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
@@ -5520,13 +5512,8 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
   CUdeviceptr src_rpc = srcDevice;
-  if (lupine_translate_managed_host_ptr(srcDevice, &src_rpc)) {
-    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
-    if (flush_result != CUDA_SUCCESS) {
-      return flush_result;
-    }
-  }
-  if (rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
+  lupine_translate_managed_host_ptr(srcDevice, &src_rpc);
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
       rpc_write(conn, &dstHost, sizeof(dstHost)) < 0 ||
       rpc_write(conn, &src_rpc, sizeof(src_rpc)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
@@ -5624,26 +5611,15 @@ static CUresult lupine_cuMemcpy2D_common(const CUDA_MEMCPY2D *pCopy,
   } else {
     conn = lupine_rpc_conn_for_current_context();
   }
-  bool translated = false;
   if (copy.srcMemoryType == CU_MEMORYTYPE_DEVICE) {
-    translated =
-        lupine_translate_managed_host_ptr(copy.srcDevice, &copy.srcDevice) ||
-        translated;
+    lupine_translate_managed_host_ptr(copy.srcDevice, &copy.srcDevice);
   }
   if (copy.dstMemoryType == CU_MEMORYTYPE_DEVICE) {
-    translated =
-        lupine_translate_managed_host_ptr(copy.dstDevice, &copy.dstDevice) ||
-        translated;
-  }
-  if (translated) {
-    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
-    if (flush_result != CUDA_SUCCESS) {
-      return flush_result;
-    }
+    lupine_translate_managed_host_ptr(copy.dstDevice, &copy.dstDevice);
   }
   CUresult return_value;
   size_t returned_dst_size = 0;
-  if (rpc_write_start_request(conn, lupine_memcpy2d_rpc_op(async, unaligned)) <
+  if (lupine_cuda_rpc_start(conn, lupine_memcpy2d_rpc_op(async, unaligned)) <
           0 ||
       rpc_write(conn, &copy, sizeof(copy)) < 0 ||
       rpc_write(conn, &src_host_size, sizeof(src_host_size)) < 0 ||
@@ -5723,7 +5699,7 @@ static CUresult lupine_graph_mem_attribute_rpc(CUdevice device,
   CUresult result = CUDA_ERROR_UNKNOWN;
   int op =
       set ? RPC_cuDeviceSetGraphMemAttribute : RPC_cuDeviceGetGraphMemAttribute;
-  if (rpc_write_start_request(conn, op) < 0 ||
+  if (lupine_cuda_rpc_start(conn, op) < 0 ||
       rpc_write(conn, &device, sizeof(device)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       (set && rpc_write(conn, value, sizeof(*value)) < 0) ||
@@ -5789,26 +5765,15 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
   } else {
     conn = lupine_rpc_conn_for_current_context();
   }
-  bool translated = false;
   if (copy.srcMemoryType == CU_MEMORYTYPE_DEVICE) {
-    translated =
-        lupine_translate_managed_host_ptr(copy.srcDevice, &copy.srcDevice) ||
-        translated;
+    lupine_translate_managed_host_ptr(copy.srcDevice, &copy.srcDevice);
   }
   if (copy.dstMemoryType == CU_MEMORYTYPE_DEVICE) {
-    translated =
-        lupine_translate_managed_host_ptr(copy.dstDevice, &copy.dstDevice) ||
-        translated;
-  }
-  if (translated) {
-    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
-    if (flush_result != CUDA_SUCCESS) {
-      return flush_result;
-    }
+    lupine_translate_managed_host_ptr(copy.dstDevice, &copy.dstDevice);
   }
   CUresult return_value;
   size_t returned_dst_size = 0;
-  if (rpc_write_start_request(conn, RPC_cuMemcpy3D_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpy3D_v2) < 0 ||
       rpc_write(conn, &copy, sizeof(copy)) < 0 ||
       rpc_write(conn, &src_host_size, sizeof(src_host_size)) < 0 ||
       rpc_write(conn, src_host, src_host_size) < 0 ||
@@ -6000,7 +5965,7 @@ cuGraphKernelNodeGetParams_v2(CUgraphNode hNode,
       std::make_shared<lupine_graph_kernel_node_params_storage>();
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   CUresult param_info_result = CUDA_SUCCESS;
-  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read_buffer(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -6078,7 +6043,7 @@ cuGraphKernelNodeSetParams_v2(CUgraphNode hNode,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
       rpc_copy_alloc(conn, lupine_param_info_copy_capacity()) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0) {
@@ -6161,7 +6126,7 @@ cuGraphAddKernelNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddKernelNode_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddKernelNode_v2) < 0 ||
       rpc_copy_alloc(conn, lupine_param_info_copy_capacity()) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -6251,7 +6216,7 @@ cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddMemcpyNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddMemcpyNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6290,8 +6255,7 @@ cuGraphExecKernelNodeSetParams_v2(CUgraphExec hGraphExec, CUgraphNode hNode,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphExecKernelNodeSetParams_v2) <
-          0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecKernelNodeSetParams_v2) < 0 ||
       rpc_copy_alloc(conn, lupine_param_info_copy_capacity()) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
@@ -6368,7 +6332,7 @@ cuGraphAddMemsetNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddMemsetNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddMemsetNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6412,7 +6376,7 @@ cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddHostNode) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddHostNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6447,7 +6411,7 @@ extern "C" CUresult cuGraphConditionalHandleCreate(
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, LUPINE_RPC_cuGraphConditionalHandleCreate) <
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuGraphConditionalHandleCreate) <
           0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
@@ -6514,7 +6478,7 @@ extern "C" CUresult cuGraphAddNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
   size_t copy_size = nodeParams->type == CU_GRAPH_NODE_TYPE_KERNEL
                          ? lupine_param_info_copy_capacity()
                          : 0;
-  if (rpc_write_start_request(conn, LUPINE_RPC_cuGraphAddNode_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuGraphAddNode_v2) < 0 ||
       rpc_copy_alloc(conn, copy_size) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -6637,7 +6601,7 @@ extern "C" CUresult cuGraphGetEdges_v2(CUgraph hGraph, CUgraphNode *from,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphGetEdges_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6693,7 +6657,7 @@ extern "C" CUresult cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphGetEdges_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6759,7 +6723,7 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (rpc_write_start_request(conn, rpc_id) < 0 ||
+  if (lupine_cuda_rpc_start(conn, rpc_id) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6851,7 +6815,7 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (rpc_write_start_request(conn, rpc_id) < 0 ||
+  if (lupine_cuda_rpc_start(conn, rpc_id) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6905,7 +6869,7 @@ cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARAMS *nodeParams) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   CUDA_HOST_NODE_PARAMS params{};
-  if (rpc_write_start_request(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &params, sizeof(params)) < 0 ||
@@ -6933,7 +6897,7 @@ cuGraphHostNodeSetParams(CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6961,7 +6925,7 @@ cuGraphExecHostNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -6996,7 +6960,7 @@ extern "C" CUresult cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuLaunchHostFunc) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchHostFunc) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &fn, sizeof(fn)) < 0 ||
       rpc_write(conn, &userData, sizeof(userData)) < 0 ||
@@ -7026,7 +6990,7 @@ extern "C" CUresult cuStreamAddCallback(CUstream hStream,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuStreamAddCallback) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamAddCallback) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &callback, sizeof(callback)) < 0 ||
       rpc_write(conn, &userData, sizeof(userData)) < 0 ||
@@ -7150,7 +7114,7 @@ static CUresult lupine_cuStreamGetCaptureInfo(
   bool has_edge_data = false;
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, LUPINE_RPC_cuStreamGetCaptureInfo_v3) < 0 ||
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuStreamGetCaptureInfo_v3) < 0 ||
       rpc_write(conn, &stream, sizeof(stream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &status, sizeof(status)) < 0 ||
@@ -7303,7 +7267,7 @@ extern "C" CUresult cuStreamIsCapturing(CUstream hStream,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamIsCapturing) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamIsCapturing) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, captureStatus, sizeof(CUstreamCaptureStatus)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -7327,7 +7291,7 @@ extern "C" CUresult cuStreamBeginCapture_v2(CUstream hStream,
     return capture_guard.complete(return_value);
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &mode, sizeof(CUstreamCaptureMode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -7352,7 +7316,7 @@ extern "C" CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUgraph *phGraph_null_check;
-  if (rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamEndCapture) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &phGraph, sizeof(CUgraph *)) < 0 ||
       (phGraph != nullptr && rpc_write(conn, phGraph, sizeof(CUgraph)) < 0) ||
@@ -7465,8 +7429,7 @@ cuStreamBeginCaptureToGraph(CUstream hStream, CUgraph hGraph,
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, LUPINE_RPC_cuStreamBeginCaptureToGraph) <
-          0 ||
+  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuStreamBeginCaptureToGraph) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -7504,7 +7467,7 @@ extern "C" CUresult cuStreamUpdateCaptureDependencies_v2(
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamUpdateCaptureDependencies_v2) <
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamUpdateCaptureDependencies_v2) <
           0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -8401,7 +8364,7 @@ extern "C" CUresult cuKernelGetLibrary(CUlibrary *pLib, CUkernel kernel) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuKernelGetLibrary) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuKernelGetLibrary) < 0 ||
       rpc_write(conn, &kernel, sizeof(kernel)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pLib, sizeof(*pLib)) < 0 ||
@@ -8639,14 +8602,7 @@ extern "C" CUresult cuTensorMapEncodeTiled(
   }
 
   CUdeviceptr address_rpc = reinterpret_cast<CUdeviceptr>(globalAddress);
-  const bool managed_alias =
-      lupine_translate_managed_host_ptr(address_rpc, &address_rpc);
-  if (managed_alias) {
-    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
-    if (flush_result != CUDA_SUCCESS) {
-      return flush_result;
-    }
-  }
+  lupine_translate_managed_host_ptr(address_rpc, &address_rpc);
   lupine_route route = lupine_route_for_deviceptr(address_rpc);
   using real_fn_t = CUresult (*)(
       CUtensorMap *, CUtensorMapDataType, cuuint32_t, void *,
@@ -8668,7 +8624,7 @@ extern "C" CUresult cuTensorMapEncodeTiled(
   const size_t stride_bytes = (tensorRank - 1) * sizeof(cuuint64_t);
   const size_t rank_bytes_u32 = tensorRank * sizeof(cuuint32_t);
 
-  if (rpc_write_start_request(conn, RPC_cuTensorMapEncodeTiled) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuTensorMapEncodeTiled) < 0 ||
       rpc_write(conn, &tensorDataType, sizeof(tensorDataType)) < 0 ||
       rpc_write(conn, &tensorRank, sizeof(tensorRank)) < 0 ||
       rpc_write(conn, &remote_address, sizeof(remote_address)) < 0 ||

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1175,6 +1175,8 @@ void test_rpc_read_uses_w_offset() {
               pair.client.mirror_writes[0].start == read_address &&
               pair.client.mirror_writes[0].size == expected.size(),
           "alias response write was not tracked");
+  require(pair.client.mirror_writes_pending != 0,
+          "alias response write was not marked pending");
 
   munmap(read_view, page_size);
   munmap(write_view, page_size);

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -114,8 +114,11 @@ static std::mutex &lupine_host_allocation_mutex() {
   return mutex;
 }
 
+// CUDA libraries can issue teardown requests after function-local statics have
+// started finalizing. Keep the registry alive for those late request flushes.
 static lupine_host_allocation_map &lupine_mutable_host_allocations_locked() {
-  static lupine_host_allocation_map allocations;
+  static lupine_host_allocation_map &allocations =
+      *new lupine_host_allocation_map();
   return allocations;
 }
 
@@ -153,6 +156,10 @@ struct lupine_dirty_host_range_queue {
 
 static lupine_dirty_host_range_queue
     lupine_dirty_host_range_queues[LUPINE_MAX_MANAGED_HOST_FLUSH_ROUTES];
+// Keep dirty state visible until a flush completes. A single exchanged boolean
+// would let another request start while the first request is still flushing.
+static uint64_t lupine_dirty_host_epoch = 0;
+static std::atomic<uint64_t> lupine_flushed_host_epoch{0};
 
 struct lupine_fault_entry {
   uintptr_t base = 0;
@@ -418,12 +425,14 @@ static void lupine_queue_dirty_host_range(lupine_host_allocation *allocation,
   if (lupine_reserve_dirty_host_range(queue, &slot)) {
     queue.ranges[slot] = {allocation, start, end};
     __atomic_store_n(&queue.ready[slot], 1, __ATOMIC_RELEASE);
+    __atomic_add_fetch(&lupine_dirty_host_epoch, 1, __ATOMIC_RELEASE);
     return;
   }
 
   __atomic_sub_fetch(&allocation->pending_dirty_ranges, 1, __ATOMIC_RELEASE);
   __atomic_store_n(&allocation->full_dirty, 1, __ATOMIC_RELEASE);
   __atomic_store_n(&queue.full_dirty_pending, 1, __ATOMIC_RELEASE);
+  __atomic_add_fetch(&lupine_dirty_host_epoch, 1, __ATOMIC_RELEASE);
 }
 
 static void lupine_sigsegv_handler(int sig, siginfo_t *info, void *uctx) {
@@ -704,8 +713,10 @@ static void lupine_mark_device_mapping_used(void *host, bool managed) {
   auto it = lupine_mutable_host_allocations_locked().find(host);
   if (it != lupine_mutable_host_allocations_locked().end()) {
     it->second.device_mapping_used = true;
-    if (!it->second.tracking_enabled) {
-      __atomic_store_n(&it->second.eager_flush_pending, 1, __ATOMIC_RELEASE);
+    if (!it->second.tracking_enabled &&
+        __atomic_exchange_n(&it->second.eager_flush_pending, 1,
+                            __ATOMIC_ACQ_REL) == 0) {
+      __atomic_add_fetch(&lupine_dirty_host_epoch, 1, __ATOMIC_RELEASE);
     }
   }
   if (managed) {
@@ -723,6 +734,7 @@ static CUresult lupine_collect_rpc_mirror_writes(conn_t *conn) {
     return CUDA_ERROR_UNKNOWN;
   }
   writes.swap(conn->mirror_writes);
+  __atomic_store_n(&conn->mirror_writes_pending, 0, __ATOMIC_RELEASE);
   if (pthread_mutex_unlock(&conn->write_mutex) != 0) {
     return CUDA_ERROR_UNKNOWN;
   }
@@ -914,6 +926,8 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
     if (count == 0) {
       return CUDA_SUCCESS;
     }
+    // This is the flush performed by lupine_cuda_rpc_start(), so it must use
+    // the raw transport primitive.
     if (rpc_write_start_request(conn, LUPINE_RPC_lupineManagedHostFlush) < 0 ||
         rpc_write(conn, &count, sizeof(count)) < 0 ||
         rpc_write_cursors(conn, cursors.data(), count * 2) < 0 ||
@@ -960,7 +974,7 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
   return CUDA_SUCCESS;
 }
 
-extern "C" CUresult lupine_flush_dirty_host_pages_to_server() {
+static CUresult lupine_flush_dirty_host_pages_to_server() {
   for (int route_id = 0; route_id < rpc_size(); ++route_id) {
     CUresult result =
         lupine_flush_dirty_host_pages_to_route(static_cast<size_t>(route_id));
@@ -969,6 +983,27 @@ extern "C" CUresult lupine_flush_dirty_host_pages_to_server() {
     }
   }
   return CUDA_SUCCESS;
+}
+
+extern "C" int lupine_cuda_rpc_start(conn_t *conn, int op) {
+  if (conn == nullptr) {
+    return -1;
+  }
+  if (__atomic_load_n(&conn->mirror_writes_pending, __ATOMIC_ACQUIRE) != 0 &&
+      lupine_collect_rpc_mirror_writes(conn) != CUDA_SUCCESS) {
+    return -1;
+  }
+
+  uint64_t dirty_epoch =
+      __atomic_load_n(&lupine_dirty_host_epoch, __ATOMIC_ACQUIRE);
+  if (dirty_epoch !=
+      lupine_flushed_host_epoch.load(std::memory_order_acquire)) {
+    if (lupine_flush_dirty_host_pages_to_server() != CUDA_SUCCESS) {
+      return -1;
+    }
+    lupine_flushed_host_epoch.store(dirty_epoch, std::memory_order_release);
+  }
+  return rpc_write_start_request(conn, op);
 }
 
 static CUresult
@@ -1227,7 +1262,7 @@ CUresult lupine_sync_mapped_host_to_device_for_launch(
   if (used_managed_mapping != nullptr) {
     *used_managed_mapping = used_managed;
   }
-  return lupine_flush_dirty_host_pages_to_server();
+  return CUDA_SUCCESS;
 }
 
 // Wire-fetch [offset, offset + bytes) of the backing. Handler-safe: must
@@ -1243,6 +1278,8 @@ static bool lupine_fetch_stale_range(lupine_host_allocation *allocation,
   if (allocation->host_base == 0 || bytes == 0 || allocation->device_ptr == 0) {
     return bytes == 0;
   }
+  // Demand fetch can run from the fault handler and must not re-enter the
+  // normal CUDA request-start flush.
   if (rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
       rpc_write(conn, &src, sizeof(src)) < 0 ||
       rpc_write(conn, &bytes, sizeof(bytes)) < 0) {
@@ -1652,7 +1689,7 @@ static CUresult lupine_remote_cuMemHostAlloc(void **remote_host,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   *remote_host = nullptr;
-  if (rpc_write_start_request(conn, RPC_cuMemHostAlloc) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemHostAlloc) < 0 ||
       rpc_write(conn, remote_host, sizeof(*remote_host)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(bytesize)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -1680,7 +1717,7 @@ static CUresult lupine_remote_cuMemFreeHost(void *remote_host,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuMemFreeHost) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemFreeHost) < 0 ||
       rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -1707,7 +1744,7 @@ static CUresult lupine_remote_cuMemHostGetDevicePointer(CUdeviceptr *device_ptr,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   *device_ptr = 0;
-  if (rpc_write_start_request(conn, RPC_cuMemHostGetDevicePointer_v2) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemHostGetDevicePointer_v2) < 0 ||
       rpc_write(conn, device_ptr, sizeof(*device_ptr)) < 0 ||
       rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -1735,7 +1772,7 @@ static CUresult lupine_remote_cuMemHostGetFlags(unsigned int *flags,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuMemHostGetFlags) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemHostGetFlags) < 0 ||
       rpc_write(conn, flags, sizeof(*flags)) < 0 ||
       rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2007,9 +2044,10 @@ extern "C" CUresult cuMemHostGetDevicePointer_v2(CUdeviceptr *pdptr, void *p,
       known_allocation = true;
       if (it->second.device_ptr != 0) {
         it->second.device_mapping_used = true;
-        if (!it->second.tracking_enabled) {
-          __atomic_store_n(&it->second.eager_flush_pending, 1,
-                           __ATOMIC_RELEASE);
+        if (!it->second.tracking_enabled &&
+            __atomic_exchange_n(&it->second.eager_flush_pending, 1,
+                                __ATOMIC_ACQ_REL) == 0) {
+          __atomic_add_fetch(&lupine_dirty_host_epoch, 1, __ATOMIC_RELEASE);
         }
         uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
         uintptr_t addr = reinterpret_cast<uintptr_t>(p);
@@ -2363,7 +2401,7 @@ extern "C" CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
   size_t backing_size = std::max(bytesize, LUPINE_MANAGED_ALLOCATION_MIN_BYTES);
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (rpc_write_start_request(conn, RPC_cuMemAllocManaged) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuMemAllocManaged) < 0 ||
       rpc_write(conn, &device_alloc_base, sizeof(device_alloc_base)) < 0 ||
       rpc_write(conn, &backing_size, sizeof(backing_size)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -2460,7 +2498,7 @@ extern "C" CUresult cuMemFree_v2(CUdeviceptr dptr) {
     }
     conn_t *conn = lupine_route_remote_conn(route);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemFree_v2) < 0 ||
+    if (lupine_cuda_rpc_start(conn, RPC_cuMemFree_v2) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2557,7 +2595,7 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuPointerGetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuPointerGetAttribute) < 0 ||
       rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
       rpc_write(conn, &query_ptr, sizeof(query_ptr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -2621,7 +2659,7 @@ extern "C" CUresult cuPointerSetAttribute(const void *value,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuPointerSetAttribute) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuPointerSetAttribute) < 0 ||
       rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
       rpc_write(conn, &target_ptr, sizeof(target_ptr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -2818,11 +2856,10 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuPointerGetAttributes) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuPointerGetAttributes) < 0 ||
       rpc_write(conn, &numAttributes, sizeof(numAttributes)) < 0 ||
       rpc_write(conn, rpc_attributes,
-                numAttributes * sizeof(CUpointer_attribute)) <
-          0 ||
+                numAttributes * sizeof(CUpointer_attribute)) < 0 ||
       rpc_write(conn, &query_ptr, sizeof(query_ptr)) < 0 ||
       rpc_wait_for_response(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;

--- a/memcpy.h
+++ b/memcpy.h
@@ -9,7 +9,6 @@
 
 struct rpc_write_cursor;
 
-extern "C" CUresult lupine_flush_dirty_host_pages_to_server();
 extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
                                                   CUdeviceptr *translated);
 extern "C" CUresult lupine_sync_mapped_device_to_host();

--- a/routing.cpp
+++ b/routing.cpp
@@ -192,7 +192,7 @@ lupine_route lupine_route_from_known_kernel_deviceptr_args(
 static CUresult lupine_remote_cuDeviceGetCount(conn_t *conn, int *count) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (count == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetCount) < 0 ||
+      lupine_cuda_rpc_start(conn, RPC_cuDeviceGetCount) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, count, sizeof(*count)) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -204,7 +204,7 @@ static CUresult lupine_remote_cuDeviceGetCount(conn_t *conn, int *count) {
 static CUresult lupine_remote_cuDeviceGet(conn_t *conn, CUdevice *device,
                                           int ordinal) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (device == nullptr || rpc_write_start_request(conn, RPC_cuDeviceGet) < 0 ||
+  if (device == nullptr || lupine_cuda_rpc_start(conn, RPC_cuDeviceGet) < 0 ||
       rpc_write(conn, &ordinal, sizeof(ordinal)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, device, sizeof(*device)) < 0 ||
@@ -749,7 +749,7 @@ CUresult lupine_set_current_context_on_route(lupine_route route,
     result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(ctx);
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
-    if (rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
+    if (lupine_cuda_rpc_start(conn, RPC_cuCtxSetCurrent) < 0 ||
         rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -529,6 +529,9 @@ static int rpc_read_into_context(conn_t *conn, void *data, size_t size,
     pthread_mutex_unlock(&conn->write_mutex);
     return -1;
   }
+  if (written != 0) {
+    __atomic_store_n(&conn->mirror_writes_pending, 1, __ATOMIC_RELEASE);
+  }
   if (pthread_mutex_unlock(&conn->write_mutex) != 0) {
     return -1;
   }

--- a/rpc.h
+++ b/rpc.h
@@ -80,6 +80,7 @@ struct conn_t {
   pthread_mutex_t write_mutex, call_mutex;
   std::vector<rpc_write_cursor> write_queue;
   std::vector<rpc_mirror_write> mirror_writes;
+  int mirror_writes_pending;
   unsigned char *write_copy_buffer;
   size_t write_copy_capacity;
   size_t write_copy_offset;


### PR DESCRIPTION
## Summary

- flush dirty mapped-host pages before CUDA RPC requests
- keep coherence policy in the CUDA client instead of adding generic RPC hooks
- record only a per-connection pending bit when RPC reads land through a writable mirror
- retain raw RPC entry points only for the flush itself and signal-handler demand fetches

## Testing

- `h2_test`
- ASan + UBSan CPU suite
- TSan CPU suite
- CUDA 13.3 targeted GPU tests: unified-memory coherence, managed driver APIs, mapped demand fetch, mapped host registration, and identity-VA nested pointers