### PR TITLE
Refactor RPC write queue to use std::vector

### DIFF
--- a/compress.cpp
+++ b/compress.cpp
@@ -20,7 +20,7 @@
 // schedule chosen by the writer.
 //
 // Framed payloads are never materialized in full. The write side only marks
-// the payload iovec (rpc_write_framed) and the HTTP/2 transport compresses
+// the payload cursor (rpc_write_framed) and the HTTP/2 transport compresses
 // one block at a time into a reusable scratch buffer as nghttp2 pulls data
 // (see h2.cpp), so memory stays bounded by a single block and early blocks
 // reach the wire while later blocks are still being compressed. The read

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -4876,7 +4876,7 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
   bool used_managed_mapping = false;
   uint32_t param_count = static_cast<uint32_t>(param_sizes.size());
   std::vector<CUdeviceptr> translated_params(param_count);
-  std::vector<struct iovec> rpc_params(param_count);
+  std::vector<rpc_write_cursor> rpc_params(param_count);
   status = lupine_sync_mapped_host_to_device_for_launch(
       kernelParams, param_sizes.data(), param_count, translated_params.data(),
       rpc_params.data(), &used_managed_mapping);
@@ -4903,7 +4903,7 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
       rpc_write(conn, &param_count, sizeof(param_count)) < 0 ||
       rpc_write(conn, param_sizes.data(),
                 param_sizes.size() * sizeof(*param_sizes.data())) < 0 ||
-      rpc_write_iovecs(conn, rpc_params.data(), rpc_params.size()) < 0 ||
+      rpc_write_cursors(conn, rpc_params.data(), rpc_params.size()) < 0 ||
       rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
@@ -4989,7 +4989,7 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
   bool used_managed_mapping = false;
   uint32_t param_count = static_cast<uint32_t>(param_sizes.size());
   std::vector<CUdeviceptr> translated_params(param_count);
-  std::vector<struct iovec> rpc_params(param_count);
+  std::vector<rpc_write_cursor> rpc_params(param_count);
   status = lupine_sync_mapped_host_to_device_for_launch(
       kernelParams, param_sizes.data(), param_count, translated_params.data(),
       rpc_params.data(), &used_managed_mapping);
@@ -5016,7 +5016,7 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
       rpc_write(conn, &param_count, sizeof(param_count)) < 0 ||
       rpc_write(conn, param_sizes.data(),
                 param_sizes.size() * sizeof(*param_sizes.data())) < 0 ||
-      rpc_write_iovecs(conn, rpc_params.data(), rpc_params.size()) < 0) {
+      rpc_write_cursors(conn, rpc_params.data(), rpc_params.size()) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (fire_and_forget) {
@@ -5080,7 +5080,7 @@ cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX,
 
   uint32_t param_count = static_cast<uint32_t>(param_sizes.size());
   std::vector<CUdeviceptr> translated_params(param_count);
-  std::vector<struct iovec> rpc_params(param_count);
+  std::vector<rpc_write_cursor> rpc_params(param_count);
   status = lupine_sync_mapped_host_to_device_for_launch(
       kernelParams, param_sizes.data(), param_count, translated_params.data(),
       rpc_params.data());
@@ -5103,7 +5103,7 @@ cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX,
       rpc_write(conn, &param_count, sizeof(param_count)) < 0 ||
       rpc_write(conn, param_sizes.data(),
                 param_sizes.size() * sizeof(*param_sizes.data())) < 0 ||
-      rpc_write_iovecs(conn, rpc_params.data(), rpc_params.size()) < 0 ||
+      rpc_write_cursors(conn, rpc_params.data(), rpc_params.size()) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -1948,7 +1948,7 @@ int handle_cuLinkComplete(conn_t *conn) {
   lupine_jit_state *jit_outputs = &empty_jit_outputs;
   // Held until the response is flushed: the cubin buffer belongs to the
   // driver's link state, and a concurrent cuLinkDestroy would free it while
-  // the queued iovec still points at it.
+  // the queued cursor still points at it.
   std::unique_lock<std::mutex> lock;
   if (link_state != nullptr) {
     lock = std::unique_lock<std::mutex>(link_state->mutex);

--- a/h2.cpp
+++ b/h2.cpp
@@ -79,30 +79,15 @@ struct h2_transport {
   std::string session_id;
 };
 
-// h2_write_cursor either points at caller bytes that are sent verbatim
-// (base/len) or, for LZ4-framed payloads, at uncompressed source bytes
-// (src/src_len) that are compressed into the transport scratch one block at
-// a time as nghttp2 pulls data. For a framed cursor, base/len cover only the
-// currently materialized block.
-struct h2_write_cursor {
-  const unsigned char *base = nullptr;
-  size_t len = 0;
-  const char *src = nullptr;
-  size_t src_len = 0;
-  // For a framed cursor whose source is already compressed (e.g. a fatbin
-  // with compressed members), skip the per-block LZ4 attempt and emit every
-  // block with the raw fallback token. Same wire format, no wasted CPU.
-};
-
 struct h2_write_source {
-  std::vector<h2_write_cursor> cursors;
+  std::vector<rpc_write_cursor> &cursors;
   size_t index = 0;
   size_t pending_len = 0;
 
   size_t remaining() const {
     size_t total = 0;
     for (size_t i = index; i < cursors.size(); ++i) {
-      total += cursors[i].len + cursors[i].src_len;
+      total += cursors[i].remaining();
     }
     return total;
   }
@@ -253,30 +238,32 @@ ssize_t h2_send_callback(nghttp2_session *, const uint8_t *data, size_t length,
 // compressed. Only the cursor at write_source->index is ever materialized,
 // and only after its previous block has been fully sent, so a single scratch
 // buffer per connection is safe.
-void h2_materialize_block(h2_transport *transport, h2_write_cursor &cursor) {
-  size_t raw = std::min<size_t>(LUPINE_COMPRESS_BLOCK_BYTES, cursor.src_len);
+void h2_materialize_block(h2_transport *transport, rpc_write_cursor &cursor) {
+  size_t raw =
+      std::min<size_t>(LUPINE_COMPRESS_BLOCK_BYTES, cursor.source_size);
   size_t bound =
       static_cast<size_t>(LZ4_compressBound(LUPINE_COMPRESS_BLOCK_BYTES));
   if (transport->compress_scratch.size() < sizeof(uint32_t) + bound) {
     transport->compress_scratch.resize(sizeof(uint32_t) + bound);
   }
   unsigned char *out = transport->compress_scratch.data();
-  int compressed = LZ4_compress_default(
-      cursor.src, reinterpret_cast<char *>(out + sizeof(uint32_t)),
-      static_cast<int>(raw), static_cast<int>(bound));
+  int compressed =
+      LZ4_compress_default(reinterpret_cast<const char *>(cursor.source),
+                           reinterpret_cast<char *>(out + sizeof(uint32_t)),
+                           static_cast<int>(raw), static_cast<int>(bound));
   uint32_t token = 0;
   size_t block_len = raw;
   if (compressed > 0 && static_cast<size_t>(compressed) < raw) {
     token = static_cast<uint32_t>(compressed);
     block_len = static_cast<size_t>(compressed);
   } else {
-    memcpy(out + sizeof(uint32_t), cursor.src, raw);
+    memcpy(out + sizeof(uint32_t), cursor.source, raw);
   }
   memcpy(out, &token, sizeof(token));
-  cursor.base = out;
-  cursor.len = sizeof(uint32_t) + block_len;
-  cursor.src += raw;
-  cursor.src_len -= raw;
+  cursor.data = out;
+  cursor.size = sizeof(uint32_t) + block_len;
+  cursor.source += raw;
+  cursor.source_size -= raw;
 }
 
 ssize_t h2_data_source_read_callback(nghttp2_session *, int32_t, uint8_t *,
@@ -287,8 +274,7 @@ ssize_t h2_data_source_read_callback(nghttp2_session *, int32_t, uint8_t *,
   auto *write_source = static_cast<h2_write_source *>(source->ptr);
   auto &cursors = write_source->cursors;
   while (write_source->index < cursors.size() &&
-         cursors[write_source->index].len == 0 &&
-         cursors[write_source->index].src_len == 0) {
+         cursors[write_source->index].remaining() == 0) {
     ++write_source->index;
   }
   if (write_source->index == cursors.size()) {
@@ -296,7 +282,7 @@ ssize_t h2_data_source_read_callback(nghttp2_session *, int32_t, uint8_t *,
     write_source->pending_len = 0;
     return 0;
   }
-  if (cursors[write_source->index].len == 0) {
+  if (cursors[write_source->index].size == 0) {
     h2_materialize_block(transport, cursors[write_source->index]);
   }
   // Offer only materialized bytes; a framed cursor with unconsumed source
@@ -304,8 +290,8 @@ ssize_t h2_data_source_read_callback(nghttp2_session *, int32_t, uint8_t *,
   size_t available = 0;
   bool lazy_pending = false;
   for (size_t i = write_source->index; i < cursors.size(); ++i) {
-    available += cursors[i].len;
-    if (cursors[i].src_len > 0) {
+    available += cursors[i].size;
+    if (cursors[i].source_size > 0) {
       lazy_pending = true;
       break;
     }
@@ -357,8 +343,8 @@ int h2_send_data_callback(nghttp2_session *, nghttp2_frame *frame,
   size_t cursor_index = write_source->index;
   while (remaining > 0 && cursor_index < write_source->cursors.size()) {
     auto &cursor = write_source->cursors[cursor_index];
-    size_t chunk = std::min(remaining, cursor.len);
-    iov.push_back({const_cast<unsigned char *>(cursor.base), chunk});
+    size_t chunk = std::min(remaining, cursor.size);
+    iov.push_back({const_cast<unsigned char *>(cursor.data), chunk});
     remaining -= chunk;
     ++cursor_index;
   }
@@ -378,12 +364,12 @@ int h2_send_data_callback(nghttp2_session *, nghttp2_frame *frame,
   remaining = length;
   while (remaining > 0) {
     auto &cursor = write_source->cursors[write_source->index];
-    size_t chunk = std::min(remaining, cursor.len);
-    cursor.base += chunk;
-    cursor.len -= chunk;
+    size_t chunk = std::min(remaining, cursor.size);
+    cursor.data += chunk;
+    cursor.size -= chunk;
     remaining -= chunk;
-    if (cursor.len == 0) {
-      if (cursor.src_len != 0) {
+    if (cursor.size == 0) {
+      if (cursor.source_size != 0) {
         // Framed cursor: the sent block is done but more source remains; the
         // next block is materialized by the next read callback.
         break;
@@ -821,27 +807,10 @@ int rpc_http2_read(conn_t *conn, void *data, size_t size) {
   return static_cast<int>(size);
 }
 
-int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
-                     int entry_count) {
+int rpc_http2_write(conn_t *conn, std::vector<rpc_write_cursor> &cursors) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
-  h2_write_source source;
-  source.cursors.reserve(entry_count);
-  for (int i = 0; i < entry_count; ++i) {
-    const rpc_write_entry &entry = entries[i];
-    if (entry.iov.iov_len == 0) {
-      continue;
-    }
-    h2_write_cursor cursor;
-    if (entry.framed) {
-      cursor.src = static_cast<const char *>(entry.iov.iov_base);
-      cursor.src_len = entry.iov.iov_len;
-    } else {
-      cursor.base = static_cast<const unsigned char *>(entry.iov.iov_base);
-      cursor.len = entry.iov.iov_len;
-    }
-    source.cursors.push_back(cursor);
-  }
-  if (source.cursors.empty()) {
+  h2_write_source source{cursors};
+  if (source.remaining() == 0) {
     return 0;
   }
 

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -32,8 +32,8 @@ template <typename T>
 struct has_owned_member<T, std::void_t<decltype(std::declval<T>().owned)>>
     : std::true_type {};
 
-static_assert(!has_owned_member<rpc_write_entry>::value,
-              "RPC write entries must not own individual iovecs");
+static_assert(!has_owned_member<rpc_write_cursor>::value,
+              "RPC write cursors must not own their bytes");
 
 struct h2_pair {
   conn_t client = {};
@@ -117,14 +117,17 @@ void read_rpc_prefix(conn_t *conn) {
 }
 
 void write_all(conn_t *conn, const std::vector<std::string> &chunks) {
-  std::vector<rpc_write_entry> entries;
-  entries.reserve(chunks.size());
+  std::vector<rpc_write_cursor> cursors;
+  cursors.reserve(chunks.size());
   for (const std::string &chunk : chunks) {
-    entries.push_back({{const_cast<char *>(chunk.data()), chunk.size()}, 0});
+    cursors.push_back(rpc_write_cursor::plain(chunk.data(), chunk.size()));
   }
-  require(rpc_http2_writev(conn, entries.data(),
-                           static_cast<int>(entries.size())) == 0,
-          "h2 write failed");
+  require(rpc_http2_write(conn, cursors) == 0, "h2 write failed");
+}
+
+int write_bytes(conn_t *conn, const void *data, size_t size) {
+  std::vector<rpc_write_cursor> cursors = {rpc_write_cursor::plain(data, size)};
+  return rpc_http2_write(conn, cursors);
 }
 
 std::string read_string(conn_t *conn, size_t size) {
@@ -274,7 +277,7 @@ void test_head_probe_cuda_version_metadata() {
 #endif
 }
 
-void test_fragmented_iovec() {
+void test_fragmented_cursors() {
   h2_pair pair = make_pair();
   std::vector<std::string> chunks = {"alpha", "", ":", "beta", ":gamma"};
   std::string received;
@@ -607,8 +610,7 @@ void test_payload_larger_than_flow_control_window() {
     (void)rpc_http2_read(&pair.client, &unused, sizeof(unused));
   });
 
-  rpc_write_entry entry = {{payload, payload_size}, 0};
-  int write_result = rpc_http2_writev(&pair.client, &entry, 1);
+  int write_result = write_bytes(&pair.client, payload, payload_size);
   if (write_result != 0) {
     shutdown(pair.client.connfd, SHUT_RDWR);
     shutdown(pair.server.connfd, SHUT_RDWR);
@@ -650,8 +652,8 @@ void test_server_window_hold_caps_and_releases() {
             "held payload read failed");
     held = rpc_http2_window_hold_end(&pair.server);
   });
-  rpc_write_entry entry = {{payload.data(), payload.size()}, 0};
-  require(rpc_http2_writev(&pair.client, &entry, 1) == 0, "held write failed");
+  require(write_bytes(&pair.client, payload.data(), payload.size()) == 0,
+          "held write failed");
   reader.join();
   require(received == payload, "held payload mismatch");
   require(held == LUPINE_FF_STAGING_WINDOW_BYTES / 2,
@@ -665,7 +667,7 @@ void test_server_window_hold_caps_and_releases() {
                 static_cast<int>(received.size()),
             "read under an outstanding hold failed");
   });
-  require(rpc_http2_writev(&pair.client, &entry, 1) == 0,
+  require(write_bytes(&pair.client, payload.data(), payload.size()) == 0,
           "write under an outstanding hold failed");
   held_reader.join();
   require(received == payload, "payload under an outstanding hold mismatch");
@@ -752,8 +754,7 @@ void test_reset_wakes_flow_controlled_writer() {
   });
 
   std::string payload(128 * 1024, 'x');
-  rpc_write_entry entry = {{payload.data(), payload.size()}, 0};
-  int write_result = rpc_http2_writev(&pair.client, &entry, 1);
+  int write_result = write_bytes(&pair.client, payload.data(), payload.size());
   shutdown(pair.client.connfd, SHUT_RDWR);
   shutdown(pair.server.connfd, SHUT_RDWR);
   server_reset.join();
@@ -768,7 +769,7 @@ void test_reset_wakes_flow_controlled_writer() {
 // lazily block by block (h2.cpp) and rpc_read_payload_part decodes it with
 // chunked, block-aligned reads (compress.cpp). The payload mixes
 // compressible and random data so both compressed and raw block tokens are
-// exercised, and plain iovecs surround the framed one as in a real message.
+// exercised, and plain cursors surround the framed one as in a real message.
 void test_framed_payload_round_trip() {
   h2_pair pair = make_pair();
   exchange_settings(&pair);
@@ -801,13 +802,11 @@ void test_framed_payload_round_trip() {
     received_suffix = read_string(&pair.server, suffix.size());
   });
 
-  rpc_write_entry entries[3] = {
-      {{const_cast<char *>(prefix.data()), prefix.size()}, 0},
-      {{payload.data(), payload.size()}, 1},
-      {{const_cast<char *>(suffix.data()), suffix.size()}, 0},
-  };
-  require(rpc_http2_writev(&pair.client, entries, 3) == 0,
-          "framed write failed");
+  std::vector<rpc_write_cursor> cursors = {
+      rpc_write_cursor::plain(prefix.data(), prefix.size()),
+      rpc_write_cursor::framed(payload.data(), payload.size()),
+      rpc_write_cursor::plain(suffix.data(), suffix.size())};
+  require(rpc_http2_write(&pair.client, cursors) == 0, "framed write failed");
   reader.join();
   require(received_prefix == prefix, "framed prefix mismatch");
   require(received == payload, "framed payload mismatch");
@@ -891,19 +890,17 @@ void test_rpc_write_buffer_uses_fixed_allocation() {
   require(pair.client.write_queue.size() == 6,
           "fixed copy queue count mismatch");
   require(pair.client.write_copy_offset == 20, "fixed copy cursor mismatch");
-  require(pair.client.write_queue[3].iov.iov_base ==
-                  pair.client.write_copy_buffer &&
-              pair.client.write_queue[4].iov.iov_base ==
+  require(pair.client.write_queue[3].data == pair.client.write_copy_buffer &&
+              pair.client.write_queue[4].data ==
                   pair.client.write_copy_buffer + 8 &&
-              pair.client.write_queue[5].iov.iov_base ==
+              pair.client.write_queue[5].data ==
                   pair.client.write_copy_buffer + 16,
           "fixed copy queued the wrong spans");
-  require(*static_cast<uint8_t *>(pair.client.write_queue[3].iov.iov_base) ==
-                  first &&
-              *static_cast<uint64_t *>(
-                  pair.client.write_queue[4].iov.iov_base) == second &&
-              *static_cast<uint32_t *>(
-                  pair.client.write_queue[5].iov.iov_base) == third,
+  require(*pair.client.write_queue[3].data == first &&
+              *reinterpret_cast<const uint64_t *>(
+                  pair.client.write_queue[4].data) == second &&
+              *reinterpret_cast<const uint32_t *>(
+                  pair.client.write_queue[5].data) == third,
           "fixed copy changed buffered values");
   require(rpc_write_end(&pair.client) == 21, "fixed response write end failed");
   require(pair.client.write_copy_buffer == nullptr,
@@ -1035,7 +1032,7 @@ int main() {
   test_server_receives_session_id();
   test_server_to_client_after_request_headers();
   test_head_probe_cuda_version_metadata();
-  test_fragmented_iovec();
+  test_fragmented_cursors();
   test_fragmented_frames_direct();
   test_partial_read_stages_only_overflow();
   test_truncated_read_clears_direct_destination();

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -820,9 +820,8 @@ void test_rpc_write_queue_grows() {
           "zero-length rpc_write failed");
   require(rpc_write_payload(&zero_length, nullptr, 0) == 0,
           "zero-length rpc_write_payload failed");
-  require(zero_length.write_queue_count == 0,
+  require(zero_length.write_queue.empty(),
           "zero-length write consumed a queue entry");
-  rpc_write_queue_free(&zero_length);
 
   h2_pair pair = make_pair();
   init_rpc_write(&pair.client);
@@ -854,7 +853,7 @@ void test_rpc_write_queue_grows() {
     require(rpc_write(&pair.client, &values[i], sizeof(values[i])) == 0,
             "large queue rpc_write failed");
   }
-  require(pair.client.write_queue_count == kCount + 3,
+  require(pair.client.write_queue.size() == kCount + 3,
           "large queue count mismatch");
   require(rpc_write_end(&pair.client) == 17, "large queue write_end failed");
   reader.join();
@@ -889,7 +888,7 @@ void test_rpc_write_buffer_uses_fixed_allocation() {
   *direct = third;
   require(rpc_write_buffer(&pair.client, 1, alignof(uint8_t)) == nullptr,
           "rpc_write_buffer exceeded its fixed allocation");
-  require(pair.client.write_queue_count == 6,
+  require(pair.client.write_queue.size() == 6,
           "fixed copy queue count mismatch");
   require(pair.client.write_copy_offset == 20, "fixed copy cursor mismatch");
   require(pair.client.write_queue[3].iov.iov_base ==

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -716,8 +716,8 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
                         LUPINE_MANAGED_HOST_FLUSH_HEADER_BYTES>,
              LUPINE_MANAGED_HOST_FLUSH_BATCH_RANGES>
       headers;
-  std::array<struct iovec, LUPINE_MANAGED_HOST_FLUSH_BATCH_RANGES * 2>
-      iovecs;
+  std::array<rpc_write_cursor, LUPINE_MANAGED_HOST_FLUSH_BATCH_RANGES * 2>
+      cursors;
 
   auto send_batch = [&](uint32_t count) {
     if (count == 0) {
@@ -725,7 +725,7 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
     }
     if (rpc_write_start_request(conn, LUPINE_RPC_lupineManagedHostFlush) < 0 ||
         rpc_write(conn, &count, sizeof(count)) < 0 ||
-        rpc_write_iovecs(conn, iovecs.data(), count * 2) < 0 ||
+        rpc_write_cursors(conn, cursors.data(), count * 2) < 0 ||
         rpc_write_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
@@ -743,9 +743,10 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
     CUdeviceptr dst = allocation.server_host_ptr + offset;
     memcpy(headers[count].data(), &dst, sizeof(dst));
     memcpy(headers[count].data() + sizeof(dst), &bytes, sizeof(bytes));
-    iovecs[count * 2] = {headers[count].data(),
-                         LUPINE_MANAGED_HOST_FLUSH_HEADER_BYTES};
-    iovecs[count * 2 + 1] = {reinterpret_cast<void *>(range.start), bytes};
+    cursors[count * 2] = rpc_write_cursor::plain(
+        headers[count].data(), LUPINE_MANAGED_HOST_FLUSH_HEADER_BYTES);
+    cursors[count * 2 + 1] =
+        rpc_write_cursor::plain(reinterpret_cast<void *>(range.start), bytes);
     ++count;
     if (count == LUPINE_MANAGED_HOST_FLUSH_BATCH_RANGES) {
       CUresult result = send_batch(count);
@@ -995,14 +996,14 @@ extern "C" CUresult cuMemcpyAsync_ptsz(CUdeviceptr dst, CUdeviceptr src,
 
 CUresult lupine_sync_mapped_host_to_device_for_launch(
     void *const *kernel_params, const size_t *sizes, uint32_t count,
-    CUdeviceptr *translated_params, struct iovec *rpc_params,
+    CUdeviceptr *translated_params, rpc_write_cursor *rpc_params,
     bool *used_managed_mapping) {
   if (kernel_params == nullptr || sizes == nullptr ||
       translated_params == nullptr || rpc_params == nullptr) {
     return count == 0 ? CUDA_SUCCESS : CUDA_ERROR_INVALID_VALUE;
   }
   for (uint32_t i = 0; i < count; ++i) {
-    rpc_params[i] = {kernel_params[i], sizes[i]};
+    rpc_params[i] = rpc_write_cursor::plain(kernel_params[i], sizes[i]);
   }
   if (used_managed_mapping != nullptr) {
     *used_managed_mapping = false;
@@ -1020,7 +1021,8 @@ CUresult lupine_sync_mapped_host_to_device_for_launch(
       CUdeviceptr translated = 0;
       if (lupine_host_ptr_in_mapping(arg, mapping, &translated)) {
         translated_params[i] = translated;
-        rpc_params[i].iov_base = &translated_params[i];
+        rpc_params[i].data =
+            reinterpret_cast<const unsigned char *>(&translated_params[i]);
         lupine_mark_mapped_device_dirty(mapping.host);
         used_managed = used_managed || mapping.managed;
         break;

--- a/memcpy.h
+++ b/memcpy.h
@@ -11,7 +11,7 @@
 #undef cuMemPrefetchAsync
 #endif
 
-struct iovec;
+struct rpc_write_cursor;
 #ifdef cuMemPrefetchAsync_ptsz
 #undef cuMemPrefetchAsync_ptsz
 #endif
@@ -34,5 +34,5 @@ extern "C" CUresult lupine_sync_mapped_device_to_host();
 
 CUresult lupine_sync_mapped_host_to_device_for_launch(
     void *const *kernel_params, const size_t *sizes, uint32_t count,
-    CUdeviceptr *translated_params, struct iovec *rpc_params,
+    CUdeviceptr *translated_params, rpc_write_cursor *rpc_params,
     bool *used_managed_mapping = nullptr);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <new>
 #include <string.h>
 #include <thread>
 
@@ -117,34 +118,6 @@ void rpc_close_transport_socket(conn_t *conn) {
   (void)lupine_socket_close(socket);
 }
 
-static int rpc_write_queue_reserve(conn_t *conn, int capacity) {
-  if (conn == nullptr || capacity < 0) {
-    return -1;
-  }
-  if (capacity <= conn->write_queue_capacity) {
-    return 0;
-  }
-
-  int new_capacity =
-      conn->write_queue_capacity > 0 ? conn->write_queue_capacity : 16;
-  while (new_capacity < capacity) {
-    if (new_capacity > INT_MAX / 2) {
-      new_capacity = capacity;
-      break;
-    }
-    new_capacity *= 2;
-  }
-
-  void *next = realloc(conn->write_queue, static_cast<size_t>(new_capacity) *
-                                              sizeof(*conn->write_queue));
-  if (next == nullptr) {
-    return -1;
-  }
-  conn->write_queue = static_cast<rpc_write_entry *>(next);
-  conn->write_queue_capacity = new_capacity;
-  return 0;
-}
-
 static void rpc_write_buffer_release(conn_t *conn) {
   if (conn == nullptr) {
     return;
@@ -155,40 +128,33 @@ static void rpc_write_buffer_release(conn_t *conn) {
   conn->write_copy_offset = 0;
 }
 
-static int rpc_write_queue_reset(conn_t *conn, int count) {
+static int rpc_write_queue_reset(conn_t *conn, size_t count) {
   rpc_write_buffer_release(conn);
-  if (conn != nullptr) {
-    conn->write_queue_count = 0;
-  }
-  if (rpc_write_queue_reserve(conn, count) < 0) {
+  if (conn == nullptr) {
     return -1;
   }
-  conn->write_queue_count = count;
-  for (int i = 0; i < count; ++i) {
-    conn->write_queue[i] = {};
+  conn->write_queue.clear();
+  try {
+    conn->write_queue.resize(count);
+  } catch (const std::bad_alloc &) {
+    return -1;
   }
   return 0;
 }
 
 static int rpc_write_queue_push(conn_t *conn, const void *data, size_t size,
                                 unsigned char framed) {
-  if (conn == nullptr || conn->write_queue_count == INT_MAX ||
-      rpc_write_queue_reserve(conn, conn->write_queue_count + 1) < 0) {
+  if (conn == nullptr ||
+      conn->write_queue.size() >= static_cast<size_t>(INT_MAX) ||
+      conn->write_queue.size() == conn->write_queue.max_size()) {
     return -1;
   }
-  conn->write_queue[conn->write_queue_count++] = {{(void *)data, size}, framed};
-  return 0;
-}
-
-void rpc_write_queue_free(conn_t *conn) {
-  if (conn == nullptr) {
-    return;
+  try {
+    conn->write_queue.push_back({{(void *)data, size}, framed});
+  } catch (const std::bad_alloc &) {
+    return -1;
   }
-  rpc_write_buffer_release(conn);
-  free(conn->write_queue);
-  conn->write_queue = nullptr;
-  conn->write_queue_count = 0;
-  conn->write_queue_capacity = 0;
+  return 0;
 }
 
 int rpc_conn_init(conn_t *conn, lupine_socket_t connfd, int request_id) {
@@ -228,7 +194,8 @@ void rpc_conn_destroy(conn_t *conn) {
   }
   rpc_close_transport_socket(conn);
   rpc_http2_destroy(conn);
-  rpc_write_queue_free(conn);
+  rpc_write_buffer_release(conn);
+  std::vector<rpc_write_entry>().swap(conn->write_queue);
   pthread_mutex_destroy(&conn->read_mutex);
   pthread_mutex_destroy(&conn->write_mutex);
   pthread_mutex_destroy(&conn->call_mutex);
@@ -254,7 +221,8 @@ int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id) {
     conn->write_queue[0] = {{&conn->write_id, sizeof(conn->write_id)}, 0};
     conn->write_queue[1] = {{&lane_id, sizeof(lane_id)}, 0};
     conn->write_queue[2] = {{&conn->write_op, sizeof(conn->write_op)}, 0};
-    result = rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
+    result = rpc_http2_writev(conn, conn->write_queue.data(),
+                              static_cast<int>(conn->write_queue.size()));
   }
   pthread_mutex_unlock(&conn->write_mutex);
   pthread_mutex_unlock(&conn->call_mutex);
@@ -673,17 +641,21 @@ int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs, size_t count) {
     return 0;
   }
   if (conn == nullptr || iovecs == nullptr ||
-      count > static_cast<size_t>(INT_MAX - conn->write_queue_count) ||
-      rpc_write_queue_reserve(conn, conn->write_queue_count +
-                                        static_cast<int>(count)) < 0) {
+      count > static_cast<size_t>(INT_MAX) - conn->write_queue.size() ||
+      count > conn->write_queue.max_size() - conn->write_queue.size()) {
     return -1;
   }
 
+  try {
+    conn->write_queue.reserve(conn->write_queue.size() + count);
+  } catch (const std::bad_alloc &) {
+    return -1;
+  }
   for (size_t i = 0; i < count; ++i) {
     if (iovecs[i].iov_base == nullptr && iovecs[i].iov_len != 0) {
       return -1;
     }
-    conn->write_queue[conn->write_queue_count++] = {iovecs[i], 0};
+    conn->write_queue.push_back({iovecs[i], 0});
   }
   return 0;
 }
@@ -713,12 +685,13 @@ int rpc_write_end(conn_t *conn) {
   }
   int write_id = conn->write_id;
   int result = -1;
-  if (conn->write_queue_count >= 3) {
+  if (conn->write_queue.size() >= 3) {
     conn->write_queue[0] = {{&conn->write_id, sizeof(conn->write_id)}, 0};
     conn->write_queue[1] = {{&conn->write_lane_id, sizeof(conn->write_lane_id)},
                             0};
     conn->write_queue[2] = {{&conn->write_op, sizeof(conn->write_op)}, 0};
-    result = rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
+    result = rpc_http2_writev(conn, conn->write_queue.data(),
+                              static_cast<int>(conn->write_queue.size()));
   }
   rpc_write_buffer_release(conn);
   pthread_mutex_unlock(&conn->write_mutex);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -142,15 +142,14 @@ static int rpc_write_queue_reset(conn_t *conn, size_t count) {
   return 0;
 }
 
-static int rpc_write_queue_push(conn_t *conn, const void *data, size_t size,
-                                unsigned char framed) {
+static int rpc_write_queue_push(conn_t *conn, rpc_write_cursor cursor) {
   if (conn == nullptr ||
       conn->write_queue.size() >= static_cast<size_t>(INT_MAX) ||
       conn->write_queue.size() == conn->write_queue.max_size()) {
     return -1;
   }
   try {
-    conn->write_queue.push_back({{(void *)data, size}, framed});
+    conn->write_queue.push_back(cursor);
   } catch (const std::bad_alloc &) {
     return -1;
   }
@@ -195,7 +194,7 @@ void rpc_conn_destroy(conn_t *conn) {
   rpc_close_transport_socket(conn);
   rpc_http2_destroy(conn);
   rpc_write_buffer_release(conn);
-  std::vector<rpc_write_entry>().swap(conn->write_queue);
+  std::vector<rpc_write_cursor>().swap(conn->write_queue);
   pthread_mutex_destroy(&conn->read_mutex);
   pthread_mutex_destroy(&conn->write_mutex);
   pthread_mutex_destroy(&conn->call_mutex);
@@ -218,11 +217,12 @@ int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id) {
   conn->write_op = LUPINE_RPC_TERMINATE_LANE;
   int result = -1;
   if (rpc_write_queue_reset(conn, 3) == 0) {
-    conn->write_queue[0] = {{&conn->write_id, sizeof(conn->write_id)}, 0};
-    conn->write_queue[1] = {{&lane_id, sizeof(lane_id)}, 0};
-    conn->write_queue[2] = {{&conn->write_op, sizeof(conn->write_op)}, 0};
-    result = rpc_http2_writev(conn, conn->write_queue.data(),
-                              static_cast<int>(conn->write_queue.size()));
+    conn->write_queue[0] =
+        rpc_write_cursor::plain(&conn->write_id, sizeof(conn->write_id));
+    conn->write_queue[1] = rpc_write_cursor::plain(&lane_id, sizeof(lane_id));
+    conn->write_queue[2] =
+        rpc_write_cursor::plain(&conn->write_op, sizeof(conn->write_op));
+    result = rpc_http2_write(conn, conn->write_queue);
   }
   pthread_mutex_unlock(&conn->write_mutex);
   pthread_mutex_unlock(&conn->call_mutex);
@@ -580,7 +580,7 @@ int rpc_write(conn_t *conn, const void *data, const size_t size) {
   if (size == 0) {
     return 0;
   }
-  return rpc_write_queue_push(conn, data, size, 0);
+  return rpc_write_queue_push(conn, rpc_write_cursor::plain(data, size));
 }
 
 // Rows are queued, not copied, so the caller's buffer must stay valid until
@@ -636,11 +636,12 @@ void *rpc_write_buffer(conn_t *conn, size_t size, size_t alignment) {
   return buffer;
 }
 
-int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs, size_t count) {
+int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
+                      size_t count) {
   if (count == 0) {
     return 0;
   }
-  if (conn == nullptr || iovecs == nullptr ||
+  if (conn == nullptr || cursors == nullptr ||
       count > static_cast<size_t>(INT_MAX) - conn->write_queue.size() ||
       count > conn->write_queue.max_size() - conn->write_queue.size()) {
     return -1;
@@ -652,10 +653,12 @@ int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs, size_t count) {
     return -1;
   }
   for (size_t i = 0; i < count; ++i) {
-    if (iovecs[i].iov_base == nullptr && iovecs[i].iov_len != 0) {
+    if ((cursors[i].data == nullptr && cursors[i].size != 0) ||
+        (cursors[i].source == nullptr && cursors[i].source_size != 0) ||
+        (cursors[i].size != 0 && cursors[i].source_size != 0)) {
       return -1;
     }
-    conn->write_queue.push_back({iovecs[i], 0});
+    conn->write_queue.push_back(cursors[i]);
   }
   return 0;
 }
@@ -665,7 +668,7 @@ int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs, size_t count) {
 // buffer must stay valid until rpc_write_end() returns, exactly like
 // rpc_write(). See compress.cpp for the framing format.
 int rpc_write_framed(conn_t *conn, const void *data, const size_t size) {
-  return rpc_write_queue_push(conn, data, size, 1);
+  return rpc_write_queue_push(conn, rpc_write_cursor::framed(data, size));
 }
 
 // rpc_write_end finalizes the current request builder on the given connection
@@ -686,12 +689,13 @@ int rpc_write_end(conn_t *conn) {
   int write_id = conn->write_id;
   int result = -1;
   if (conn->write_queue.size() >= 3) {
-    conn->write_queue[0] = {{&conn->write_id, sizeof(conn->write_id)}, 0};
-    conn->write_queue[1] = {{&conn->write_lane_id, sizeof(conn->write_lane_id)},
-                            0};
-    conn->write_queue[2] = {{&conn->write_op, sizeof(conn->write_op)}, 0};
-    result = rpc_http2_writev(conn, conn->write_queue.data(),
-                              static_cast<int>(conn->write_queue.size()));
+    conn->write_queue[0] =
+        rpc_write_cursor::plain(&conn->write_id, sizeof(conn->write_id));
+    conn->write_queue[1] = rpc_write_cursor::plain(&conn->write_lane_id,
+                                                   sizeof(conn->write_lane_id));
+    conn->write_queue[2] =
+        rpc_write_cursor::plain(&conn->write_op, sizeof(conn->write_op));
+    result = rpc_http2_write(conn, conn->write_queue);
   }
   rpc_write_buffer_release(conn);
   pthread_mutex_unlock(&conn->write_mutex);

--- a/rpc.h
+++ b/rpc.h
@@ -3,6 +3,7 @@
 
 #include "lupine_platform.h"
 #include <stdint.h>
+#include <vector>
 
 // Uncompressed block size for the optional LZ4 payload framing. The framed
 // bytes are produced lazily, one block at a time, by the HTTP/2 transport
@@ -49,12 +50,7 @@ struct conn_t {
   pthread_t rpc_thread;
   pthread_mutex_t read_mutex, write_mutex, call_mutex;
   pthread_cond_t read_cond;
-  // Explicitly managed so conn_t remains trivially destructible. Client APIs
-  // can call back into a shim during process teardown, after C++ globals have
-  // begun finalizing.
-  rpc_write_entry *write_queue;
-  int write_queue_count;
-  int write_queue_capacity;
+  std::vector<rpc_write_entry> write_queue;
   unsigned char *write_copy_buffer;
   size_t write_copy_capacity;
   size_t write_copy_offset;
@@ -121,7 +117,6 @@ extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
 // socket before aborting it. Safe after a transport error has already set
 // conn->closed, and safe for concurrent/idempotent cleanup.
 extern void rpc_close_transport_socket(conn_t *conn);
-extern void rpc_write_queue_free(conn_t *conn);
 extern int rpc_conn_init(conn_t *conn, lupine_socket_t connfd, int request_id);
 extern void rpc_conn_destroy(conn_t *conn);
 

--- a/rpc.h
+++ b/rpc.h
@@ -10,12 +10,25 @@
 // (h2.cpp) and decoded by the rpc_read_payload helpers (compress.cpp).
 #define LUPINE_COMPRESS_BLOCK_BYTES (4 * 1024 * 1024)
 
-struct rpc_write_entry {
-  struct iovec iov;
-  // 0 = plain bytes, 1 = framed with per-block LZ4 attempts, 2 = framed but
-  // every block is stored raw (the source is already compressed, so the LZ4
-  // attempt would only waste CPU; the wire format is unchanged).
-  unsigned char framed;
+// References caller-owned bytes while an RPC is being serialized. Plain
+// cursors use data/size directly. Framed cursors keep uncompressed bytes in
+// source/source_size while HTTP/2 materializes one framed block at a time into
+// data/size.
+struct rpc_write_cursor {
+  const unsigned char *data = nullptr;
+  size_t size = 0;
+  const unsigned char *source = nullptr;
+  size_t source_size = 0;
+
+  static rpc_write_cursor plain(const void *data, size_t size) {
+    return {static_cast<const unsigned char *>(data), size, nullptr, 0};
+  }
+
+  static rpc_write_cursor framed(const void *data, size_t size) {
+    return {nullptr, 0, static_cast<const unsigned char *>(data), size};
+  }
+
+  size_t remaining() const { return size + source_size; }
 };
 
 struct rpc_http2_read_stats {
@@ -50,7 +63,7 @@ struct conn_t {
   pthread_t rpc_thread;
   pthread_mutex_t read_mutex, write_mutex, call_mutex;
   pthread_cond_t read_cond;
-  std::vector<rpc_write_entry> write_queue;
+  std::vector<rpc_write_cursor> write_queue;
   unsigned char *write_copy_buffer;
   size_t write_copy_capacity;
   size_t write_copy_offset;
@@ -108,8 +121,8 @@ extern int rpc_copy_alloc(conn_t *conn, const size_t size);
 // The complete allocation is fixed before serialization starts, so returned
 // pointers remain valid until the request ends.
 extern void *rpc_write_buffer(conn_t *conn, size_t size, size_t alignment);
-extern int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs,
-                            size_t count);
+extern int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
+                             size_t count);
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
@@ -131,8 +144,8 @@ extern lupine_socket_t lupine_tcp_connect(const char *host, const char *port,
                                           unsigned int max_retries = 5);
 
 extern int rpc_http2_read(conn_t *conn, void *data, size_t size);
-extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
-                            int entry_count);
+extern int rpc_http2_write(conn_t *conn,
+                           std::vector<rpc_write_cursor> &cursors);
 extern int rpc_http2_client_init(conn_t *conn);
 extern void rpc_http2_client_start_heartbeat(conn_t *conn);
 extern void rpc_http2_destroy(conn_t *conn);


### PR DESCRIPTION
## Summary

- replace the manually allocated RPC write queue with `std::vector<rpc_write_cursor>`
- produce cursors directly for ordinary writes, framed payloads, kernel parameters, and managed-memory batches
- pass the queue directly through HTTP/2 without rebuilding it as a second cursor vector
- keep `iovec` only at OS vectored-I/O boundaries such as `sendmsg` and `WSASend`

## Testing

- `cmake --build build --target h2_test h2_unknown_cuda_version_test lupine_cuda_client lupine_driver_server -j4`
- `ctest --test-dir build --output-on-failure -R ^'h2(_unknown_cuda_version)?_test$'`