### PR TITLE
fix: count CUDA attribute snapshots

### DIFF
--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -513,7 +513,11 @@ lupine_function_attribute_cache() {
 static int lupine_read_function_attributes(conn_t *conn, lupine_route route,
                                            CUfunction function) {
   int route_id = lupine_route_identity(route);
-  for (;;) {
+  uint32_t attribute_count = 0;
+  if (rpc_read_buffer(conn, &attribute_count, sizeof(attribute_count)) < 0) {
+    return -1;
+  }
+  for (uint32_t i = 0; i < attribute_count; ++i) {
     CUresult result = CUDA_ERROR_UNKNOWN;
     int attribute = 0;
     int value = 0;
@@ -521,9 +525,6 @@ static int lupine_read_function_attributes(conn_t *conn, lupine_route route,
         rpc_read_buffer(conn, &attribute, sizeof(attribute)) < 0 ||
         rpc_read_buffer(conn, &value, sizeof(value)) < 0) {
       return -1;
-    }
-    if (result == CUDA_ERROR_INVALID_VALUE) {
-      return 0;
     }
     if (result != CUDA_SUCCESS) {
       continue;
@@ -531,12 +532,17 @@ static int lupine_read_function_attributes(conn_t *conn, lupine_route route,
     lupine_function_attribute_cache().insert_or_assign(
         lupine_function_attribute_key{route_id, function, attribute}, value);
   }
+  return 0;
 }
 
 static int lupine_read_kernel_attributes(conn_t *conn, lupine_route route,
                                          CUkernel kernel, CUdevice device) {
   int route_id = lupine_route_identity(route);
-  for (;;) {
+  uint32_t attribute_count = 0;
+  if (rpc_read_buffer(conn, &attribute_count, sizeof(attribute_count)) < 0) {
+    return -1;
+  }
+  for (uint32_t i = 0; i < attribute_count; ++i) {
     CUresult result = CUDA_ERROR_UNKNOWN;
     int attribute = 0;
     int value = 0;
@@ -544,9 +550,6 @@ static int lupine_read_kernel_attributes(conn_t *conn, lupine_route route,
         rpc_read_buffer(conn, &attribute, sizeof(attribute)) < 0 ||
         rpc_read_buffer(conn, &value, sizeof(value)) < 0) {
       return -1;
-    }
-    if (result == CUDA_ERROR_INVALID_VALUE) {
-      return 0;
     }
     if (result != CUDA_SUCCESS) {
       continue;
@@ -555,6 +558,7 @@ static int lupine_read_kernel_attributes(conn_t *conn, lupine_route route,
         lupine_kernel_attribute_key{route_id, kernel, attribute, device},
         value);
   }
+  return 0;
 }
 
 static libcuckoo::cuckoohash_map<lupine_param_info_key, lupine_param_info_value,

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -92,6 +92,37 @@ static constexpr size_t lupine_attribute_copy_size() {
          2 * sizeof(int);
 }
 
+static constexpr size_t lupine_attribute_snapshot_copy_size() {
+  return sizeof(uint32_t) + static_cast<size_t>(CU_FUNC_ATTRIBUTE_MAX) *
+                                lupine_attribute_copy_size();
+}
+
+template <typename Query>
+static int lupine_write_attribute_snapshot(conn_t *conn, Query query) {
+  auto *count = static_cast<uint32_t *>(
+      rpc_write_buffer(conn, sizeof(uint32_t), alignof(uint32_t)));
+  if (count == nullptr) {
+    return -1;
+  }
+  *count = static_cast<uint32_t>(CU_FUNC_ATTRIBUTE_MAX);
+
+  for (int attribute = 0; attribute < CU_FUNC_ATTRIBUTE_MAX; ++attribute) {
+    auto *result = static_cast<CUresult *>(
+        rpc_write_buffer(conn, sizeof(CUresult), alignof(CUresult)));
+    auto *wire_attribute =
+        static_cast<int *>(rpc_write_buffer(conn, sizeof(int), alignof(int)));
+    auto *value =
+        static_cast<int *>(rpc_write_buffer(conn, sizeof(int), alignof(int)));
+    if (result == nullptr || wire_attribute == nullptr || value == nullptr) {
+      return -1;
+    }
+    *wire_attribute = attribute;
+    *value = 0;
+    *result = query(value, static_cast<CUfunction_attribute>(attribute));
+  }
+  return 0;
+}
+
 struct lupine_jit_state {
   unsigned int num_options = 0;
   CUjit_option *options = nullptr;
@@ -1073,23 +1104,14 @@ int handle_lupineFunctionAttributeSnapshot(conn_t *conn) {
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_copy_alloc(conn, static_cast<size_t>(CU_FUNC_ATTRIBUTE_MAX + 1) *
-                               lupine_attribute_copy_size()) < 0) {
+      rpc_copy_alloc(conn, lupine_attribute_snapshot_copy_size()) < 0) {
     return -1;
   }
-  for (int attribute = 0;; ++attribute) {
-    auto *result = static_cast<CUresult *>(
-        rpc_write_buffer(conn, sizeof(CUresult), alignof(CUresult)));
-    auto *wire_attribute =
-        static_cast<int *>(rpc_write_buffer(conn, sizeof(int), alignof(int)));
-    auto *value =
-        static_cast<int *>(rpc_write_buffer(conn, sizeof(int), alignof(int)));
-    *wire_attribute = attribute;
-    *result = cuFuncGetAttribute(
-        value, static_cast<CUfunction_attribute>(attribute), function);
-    if (*result == CUDA_ERROR_INVALID_VALUE) {
-      break;
-    }
+  if (lupine_write_attribute_snapshot(
+          conn, [function](int *value, CUfunction_attribute attribute) {
+            return cuFuncGetAttribute(value, attribute, function);
+          }) < 0) {
+    return -1;
   }
   return rpc_write_end(conn);
 }
@@ -1297,13 +1319,11 @@ int handle_lupineLibraryAttributeSnapshot(conn_t *conn) {
         kernels.data(), snapshot_kernel_count, library);
   }
 
-  size_t copy_size =
-      enumerate_result == CUDA_SUCCESS
-          ? static_cast<size_t>(snapshot_kernel_count) *
-                (lupine_cuda_value_copy_size<CUfunction>() +
-                 2 * static_cast<size_t>(CU_FUNC_ATTRIBUTE_MAX + 1) *
-                     lupine_attribute_copy_size())
-          : 0;
+  size_t copy_size = enumerate_result == CUDA_SUCCESS
+                         ? static_cast<size_t>(snapshot_kernel_count) *
+                               (lupine_cuda_value_copy_size<CUfunction>() +
+                                2 * lupine_attribute_snapshot_copy_size())
+                         : 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_copy_alloc(conn, copy_size) < 0 ||
       rpc_write(conn, &device_result, sizeof(device_result)) < 0 ||
@@ -1340,35 +1360,20 @@ int handle_lupineLibraryAttributeSnapshot(conn_t *conn) {
         rpc_write_buffer(conn, sizeof(CUfunction), alignof(CUfunction)));
     *function_result = cuKernelGetFunction(function, kernel);
     if (*function_result == CUDA_SUCCESS) {
-      for (int attribute = 0;; ++attribute) {
-        auto *result = static_cast<CUresult *>(
-            rpc_write_buffer(conn, sizeof(CUresult), alignof(CUresult)));
-        auto *wire_attribute = static_cast<int *>(
-            rpc_write_buffer(conn, sizeof(int), alignof(int)));
-        auto *value = static_cast<int *>(
-            rpc_write_buffer(conn, sizeof(int), alignof(int)));
-        *wire_attribute = attribute;
-        *result = cuFuncGetAttribute(
-            value, static_cast<CUfunction_attribute>(attribute), *function);
-        if (*result == CUDA_ERROR_INVALID_VALUE) {
-          break;
-        }
+      if (lupine_write_attribute_snapshot(
+              conn, [function](int *value, CUfunction_attribute attribute) {
+                return cuFuncGetAttribute(value, attribute, *function);
+              }) < 0) {
+        return -1;
       }
     }
-    for (int attribute = 0;; ++attribute) {
-      auto *result = static_cast<CUresult *>(
-          rpc_write_buffer(conn, sizeof(CUresult), alignof(CUresult)));
-      auto *wire_attribute =
-          static_cast<int *>(rpc_write_buffer(conn, sizeof(int), alignof(int)));
-      auto *value =
-          static_cast<int *>(rpc_write_buffer(conn, sizeof(int), alignof(int)));
-      *wire_attribute = attribute;
-      *result = cuKernelGetAttribute(
-          value, static_cast<CUfunction_attribute>(attribute), kernel,
-          snapshot_device);
-      if (*result == CUDA_ERROR_INVALID_VALUE) {
-        break;
-      }
+    if (lupine_write_attribute_snapshot(
+            conn, [kernel, snapshot_device](int *value,
+                                            CUfunction_attribute attribute) {
+              return cuKernelGetAttribute(value, attribute, kernel,
+                                          snapshot_device);
+            }) < 0) {
+      return -1;
     }
   }
 #else


### PR DESCRIPTION
## Summary

- prefix CUDA function and kernel attribute snapshots with an explicit attribute count
- bound snapshot generation by `CU_FUNC_ATTRIBUTE_MAX` instead of relying on an invalid-value sentinel
- size function and library snapshot buffers to match the counted wire format
- extracted from #559

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` (10/10 passed; 2 environment-dependent tests skipped)
- `git diff --check`