### PR TITLE
feat: add cuStreamGetGreenCtx RPC

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -40,6 +40,11 @@ route-local device back to its virtual client ordinal before returning it.
 manual client implementation with the original API name. These manual symbols
 remain part of the generated client function map.
 
+`@guard <preprocessor-expression>` wraps the generated client wrapper, server
+handler, function-map entry, and server registration. Use it for APIs that are
+not declared by every supported CUDA toolkit, such as an API introduced in a
+newer CUDA minor release.
+
 Generated wrappers can record ownership for handles returned by an API with
 `@recordowner <kind> <param>`. Supported owner kinds are `CONTEXT`, `MODULE`,
 `FUNCTION`, `STREAM`, `EVENT`, `MEMORY_POOL`, `GRAPH`, `GRAPH_NODE`,

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -3447,6 +3447,13 @@ CUresult cuStreamGetId(CUstream hStream, unsigned long long *streamId);
  */
 CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx);
 /**
+ * @guard CUDA_VERSION >= 12040
+ * @routingkey STREAM hStream
+ * @param hStream SEND_ONLY
+ * @param phCtx RECV_ONLY
+ */
+CUresult cuStreamGetGreenCtx(CUstream hStream, CUgreenCtx *phCtx);
+/**
  * @disabled - manual client handles cross-server event waits
  * @routingkey STREAM hStream
  * @param hStream SEND_ONLY

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -447,6 +447,12 @@ def parse_annotation(
                 stdout="STDOUT" in options,
             )
             continue
+        if line.strip().startswith("@guard"):
+            guard = line.strip().removeprefix("@guard").strip()
+            if not guard or metadata.guard is not None:
+                raise RuntimeError("Invalid @guard annotation")
+            metadata.guard = guard
+            continue
         if line.startswith("@server"):
             continue
         if line.startswith("@routingkey"):
@@ -1511,6 +1517,9 @@ def main():
             if metadata.disabled_client:
                 continue
 
+            if metadata.guard is not None:
+                f.write(f"#if {metadata.guard}\n")
+
             joined_params = ", ".join(format_function_params(function))
 
             f.write(
@@ -1731,6 +1740,8 @@ def main():
                 else:
                     f.write("    return CUDA_SUCCESS;\n")
                 f.write("}\n\n")
+                if metadata.guard is not None:
+                    f.write("#endif\n\n")
                 continue
 
             f.write(
@@ -1777,6 +1788,8 @@ def main():
             if metadata.routing_kind == "ALL":
                 f.write("        });\n")
             f.write("}\n\n")
+            if metadata.guard is not None:
+                f.write("#endif\n\n")
 
         function_by_name = {
             function.name.format(): function
@@ -1817,11 +1830,15 @@ def main():
             if metadata.disabled_client and metadata.disabled_server:
                 continue
 
+            if metadata.guard is not None:
+                f.write(f"#if {metadata.guard}\n")
             f.write(
                 '    {{"{name}", (void *){name}}},\n'.format(
                     name=function.name.format()
                 )
             )
+            if metadata.guard is not None:
+                f.write("#endif\n")
         # write manual overrides
         function_names = set(
             f.name.format()
@@ -1868,6 +1885,9 @@ def main():
                 or function.name.format() in server_bindings
             ):
                 continue
+
+            if metadata.guard is not None:
+                f.write(f"#if {metadata.guard}\n")
 
             # parse the annotation doxygen
             f.write(
@@ -1938,6 +1958,8 @@ def main():
                 write_server_buffer_cleanup(f, owned_buffers, "    ")
                 f.write("    return -1;\n")
                 f.write("}\n\n")
+                if metadata.guard is not None:
+                    f.write("#endif\n\n")
                 continue
 
             f.write("    if (rpc_write_start_response(conn, request_id) < 0 ||\n")
@@ -1960,15 +1982,19 @@ def main():
             write_server_buffer_cleanup(f, owned_buffers, "    ")
             f.write("    return -1;\n")
             f.write("}\n\n")
-
-    cuda_handlers = []
-    for function, _, _, metadata in functions_with_annotations:
-        name = function.name.format()
-        if not metadata.disabled_server and name not in server_bindings:
-            cuda_handlers.append(name)
+            if metadata.guard is not None:
+                f.write("#endif\n\n")
 
     generated_bindings = [
-        ServerBinding(name, "CUDA", f"handle_{name}") for name in cuda_handlers
+        ServerBinding(
+            function.name.format(),
+            "CUDA",
+            f"handle_{function.name.format()}",
+            metadata.guard,
+        )
+        for function, _, _, metadata in functions_with_annotations
+        if not metadata.disabled_server
+        and function.name.format() not in server_bindings
     ]
     generated_bindings.extend(
         ServerBinding(name, "NVML", f"handle_{name}")

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -6377,6 +6377,29 @@ CUresult cuGraphicsUnmapResources(unsigned int count,
   return return_value;
 }
 
+#if CUDA_VERSION >= 12040
+CUresult cuStreamGetGreenCtx(CUstream hStream, CUgreenCtx *phCtx) {
+  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
+                                           : lupine_route_for_default());
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUgreenCtx *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamGetGreenCtx", &return_value, hStream, phCtx)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (rpc_write_start_request(conn, RPC_cuStreamGetGreenCtx) < 0 ||
+      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, phCtx, sizeof(CUgreenCtx)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
 #ifdef cuCtxDestroy
 #undef cuCtxDestroy
 #endif
@@ -7077,6 +7100,9 @@ std::unordered_map<std::string, void *> functionMap = {
      (void *)cuGraphicsResourceSetMapFlags_v2},
     {"cuGraphicsMapResources", (void *)cuGraphicsMapResources},
     {"cuGraphicsUnmapResources", (void *)cuGraphicsUnmapResources},
+#if CUDA_VERSION >= 12040
+    {"cuStreamGetGreenCtx", (void *)cuStreamGetGreenCtx},
+#endif
     {"cuCtxDestroy", (void *)cuCtxDestroy_v2},
     {"cuModuleGetGlobal", (void *)cuModuleGetGlobal_v2},
     {"cuMemAlloc", (void *)cuMemAlloc_v2},

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -7807,3 +7807,30 @@ ERROR_0:
   free((void *)resources);
   return -1;
 }
+
+#if CUDA_VERSION >= 12040
+int handle_cuStreamGetGreenCtx(conn_t *conn) {
+  CUstream hStream;
+  CUgreenCtx phCtx;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuStreamGetGreenCtx(hStream, &phCtx);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &phCtx, sizeof(CUgreenCtx)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif

--- a/codegen/gen_rpc_ids.h
+++ b/codegen/gen_rpc_ids.h
@@ -356,6 +356,7 @@
 #define RPC_cuGraphicsUnmapResources 121118754
 #define RPC_cuGetProcAddress_v2 1976428842
 #define RPC_cuGetExportTable 2020229241
+#define RPC_cuStreamGetGreenCtx 1723357044
 #define RPC_cuCtxCreate_v2 804269166
 #define RPC_cuCtxCreate_v3 1492589816
 #define RPC_cuDeviceGetGraphMemAttribute 622504442

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -1097,6 +1097,7 @@ class SynchronizeAnnotation:
 @dataclass
 class FunctionAnnotationMetadata:
     operations: list[Operation]
+    guard: Optional[str] = None
     disabled_client: bool = False
     disabled_server: bool = False
     # @async: fire-and-forget op; client does not wait, server sends no response.

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -449,6 +449,10 @@ LUPINE_CUDA_RPC_HANDLERS(LUPINE_DECLARE_HANDLER)
 LUPINE_DECLARE_HANDLER(RPC_cuTensorMapEncodeTiled,
                        handle_cuTensorMapEncodeTiled, rpc_backend::cuda)
 #endif
+#if CUDA_VERSION >= 12040
+LUPINE_DECLARE_HANDLER(RPC_cuStreamGetGreenCtx, handle_cuStreamGetGreenCtx,
+                       rpc_backend::cuda)
+#endif
 #endif
 #ifdef LUPINE_BUILD_NVML_BACKEND
 LUPINE_NVML_RPC_HANDLERS(LUPINE_DECLARE_HANDLER)
@@ -467,9 +471,14 @@ const rpc_handler_registry &lupine_rpc_handlers() {
                                   handle_cuTensorMapEncodeTiled,
                                   rpc_backend::cuda)
 #endif
+#if CUDA_VERSION >= 12040
+              LUPINE_REGISTER_HANDLER(RPC_cuStreamGetGreenCtx,
+                                      handle_cuStreamGetGreenCtx,
+                                      rpc_backend::cuda)
+#endif
 #endif
 #ifdef LUPINE_BUILD_NVML_BACKEND
-              LUPINE_NVML_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
+                  LUPINE_NVML_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
 
 #endif
   };


### PR DESCRIPTION
## Summary

- add a CUDA-version-guarded `cuStreamGetGreenCtx` RPC
- extend codegen with `@guard` support for APIs unavailable in older supported CUDA toolkits
- regenerate only the affected client, server, RPC ID, and registry outputs using the current CUDA 13.1 baseline

Extracted from #559 so the RPC support can land independently of the CUDA 13.3 CI changes.

## Validation

- `uv run codegen/codegen.py` (stable regenerated diff)
- `cmake -S . -B /tmp/lupine-custream-greenctx-build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/lupine-custream-greenctx-build --parallel 8`
- `ctest --test-dir /tmp/lupine-custream-greenctx-build --output-on-failure` (10/10 passed; 2 environment-dependent tests skipped)
- CUDA 11.8 `g++ -fsyntax-only` checks for generated client, server, and registry sources
- `git diff --check`