### PR TITLE
ci: cancel stale pull request runs

### DIFF
--- a/.github/workflows/build-cuda-matrix.yml
+++ b/.github/workflows/build-cuda-matrix.yml
@@ -1,5 +1,9 @@
 name: Build CUDA Matrix
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/build-lambda-client.yml
+++ b/.github/workflows/build-lambda-client.yml
@@ -1,5 +1,9 @@
 name: Build Lambda Client
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/build-macos-client.yml
+++ b/.github/workflows/build-macos-client.yml
@@ -1,5 +1,9 @@
 name: Build macOS Client
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/build-windows-client.yml
+++ b/.github/workflows/build-windows-client.yml
@@ -1,5 +1,9 @@
 name: Build Windows Client
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -1,5 +1,9 @@
 name: Build Windows Server EXE
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,5 +1,9 @@
 name: Codegen Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,9 @@
 name: clang-format Check
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   - pull_request
 permissions:

--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -1,5 +1,9 @@
 name: GPU Integration on GCE
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Expected repository variables:
 #   GCP_PROJECT_ID, GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT
 #

--- a/.github/workflows/publish-client-image.yml
+++ b/.github/workflows/publish-client-image.yml
@@ -1,5 +1,9 @@
 name: Publish Client Image
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -1,5 +1,9 @@
 name: Publish Server Image
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,5 +1,9 @@
 name: Python
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
   push:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,5 +1,9 @@
 name: Sanitizers
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
   push:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,9 @@
 name: C++ Unit Tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
## Summary

- group CI runs by workflow and pull request number
- cancel older in-progress runs when a PR receives a new commit
- keep release, push, and manually dispatched runs independent

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -color -ignore 'label ".+" is unknown'`\n- verified all 13 PR-triggered workflows define PR-only cancellation\n- `git diff --check`