### PR TITLE
Fix simpleStreams default-event DtoH ordering

### DIFF
--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -683,27 +683,6 @@ static bool lupine_is_event_dtoh_marker(const lupine_pending_dtoh_item &item,
   return item.event != nullptr && item.event == event;
 }
 
-static bool lupine_is_legacy_default_stream(CUstream stream) {
-  return stream == nullptr || stream == CU_STREAM_LEGACY;
-}
-
-static CUstream lupine_canonical_dtoh_stream(CUstream stream) {
-  return lupine_is_legacy_default_stream(stream) ? nullptr : stream;
-}
-
-static bool lupine_stream_orders_with_legacy_default(CUstream stream) {
-  stream = lupine_canonical_dtoh_stream(stream);
-  if (stream == nullptr) {
-    return true;
-  }
-  if (stream == CU_STREAM_PER_THREAD) {
-    return false;
-  }
-  unsigned int flags = CU_STREAM_NON_BLOCKING;
-  return cuStreamGetFlags(stream, &flags) == CUDA_SUCCESS &&
-         (flags & CU_STREAM_NON_BLOCKING) == 0;
-}
-
 static libcuckoo::cuckoohash_map<conn_t *, lupine_pending_dtoh_streams> &
 lupine_pending_dtoh_copies() {
   static libcuckoo::cuckoohash_map<conn_t *, lupine_pending_dtoh_streams>
@@ -1000,32 +979,33 @@ lupine_remove_event_dtoh_markers(lupine_pending_dtoh_streams *streams,
 
 static void lupine_note_event_record(conn_t *conn, CUevent event,
                                      CUstream stream) {
-  bool legacy_default = lupine_is_legacy_default_stream(stream);
-  stream = lupine_canonical_dtoh_stream(stream);
   lupine_pending_dtoh_streams initial;
   initial[stream].push_back({event});
   lupine_pending_dtoh_copies().upsert(
       conn,
-      [event, stream, legacy_default](lupine_pending_dtoh_streams &streams,
-                                      libcuckoo::UpsertContext) {
+      [event, stream](lupine_pending_dtoh_streams &streams,
+                      libcuckoo::UpsertContext) {
         lupine_remove_event_dtoh_markers(&streams, event);
-        if (!legacy_default) {
+        if (stream != nullptr) {
           streams[stream].push_back({event});
           return;
         }
 
-        // An operation in the legacy default stream waits for all previously
-        // submitted work in blocking streams. Mark every such DtoH queue so
-        // synchronizing this event returns all copies the event completed.
-        // Non-blocking and per-thread streams do not participate in the
-        // implicit dependency and must remain pending.
+        // The legacy default stream orders this event after every blocking
+        // stream's prior work. The null queue is its sentinel.
+        streams.try_emplace(nullptr);
         for (auto &entry : streams) {
-          if (lupine_stream_orders_with_legacy_default(entry.first)) {
-            entry.second.push_back({event});
+          if (entry.first != nullptr) {
+            if (entry.first == CU_STREAM_PER_THREAD) {
+              continue;
+            }
+            unsigned int flags = 0;
+            if (cuStreamGetFlags(entry.first, &flags) != CUDA_SUCCESS ||
+                (flags & CU_STREAM_NON_BLOCKING) != 0) {
+              continue;
+            }
           }
-        }
-        if (streams.find(nullptr) == streams.end()) {
-          streams[nullptr].push_back({event});
+          entry.second.push_back({event});
         }
       },
       std::move(initial));
@@ -4246,8 +4226,6 @@ int handle_cuMemcpyDtoHAsync_v2(conn_t *conn) {
   if (rpc_read_end(conn) < 0) {
     return -1;
   }
-
-  stream = lupine_canonical_dtoh_stream(stream);
 
   CUstreamCaptureStatus capture_status = CU_STREAM_CAPTURE_STATUS_NONE;
   if (stream != nullptr) {

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -683,6 +683,27 @@ static bool lupine_is_event_dtoh_marker(const lupine_pending_dtoh_item &item,
   return item.event != nullptr && item.event == event;
 }
 
+static bool lupine_is_legacy_default_stream(CUstream stream) {
+  return stream == nullptr || stream == CU_STREAM_LEGACY;
+}
+
+static CUstream lupine_canonical_dtoh_stream(CUstream stream) {
+  return lupine_is_legacy_default_stream(stream) ? nullptr : stream;
+}
+
+static bool lupine_stream_orders_with_legacy_default(CUstream stream) {
+  stream = lupine_canonical_dtoh_stream(stream);
+  if (stream == nullptr) {
+    return true;
+  }
+  if (stream == CU_STREAM_PER_THREAD) {
+    return false;
+  }
+  unsigned int flags = CU_STREAM_NON_BLOCKING;
+  return cuStreamGetFlags(stream, &flags) == CUDA_SUCCESS &&
+         (flags & CU_STREAM_NON_BLOCKING) == 0;
+}
+
 static libcuckoo::cuckoohash_map<conn_t *, lupine_pending_dtoh_streams> &
 lupine_pending_dtoh_copies() {
   static libcuckoo::cuckoohash_map<conn_t *, lupine_pending_dtoh_streams>
@@ -979,14 +1000,33 @@ lupine_remove_event_dtoh_markers(lupine_pending_dtoh_streams *streams,
 
 static void lupine_note_event_record(conn_t *conn, CUevent event,
                                      CUstream stream) {
+  bool legacy_default = lupine_is_legacy_default_stream(stream);
+  stream = lupine_canonical_dtoh_stream(stream);
   lupine_pending_dtoh_streams initial;
   initial[stream].push_back({event});
   lupine_pending_dtoh_copies().upsert(
       conn,
-      [event, stream](lupine_pending_dtoh_streams &streams,
-                      libcuckoo::UpsertContext) {
+      [event, stream, legacy_default](lupine_pending_dtoh_streams &streams,
+                                      libcuckoo::UpsertContext) {
         lupine_remove_event_dtoh_markers(&streams, event);
-        streams[stream].push_back({event});
+        if (!legacy_default) {
+          streams[stream].push_back({event});
+          return;
+        }
+
+        // An operation in the legacy default stream waits for all previously
+        // submitted work in blocking streams. Mark every such DtoH queue so
+        // synchronizing this event returns all copies the event completed.
+        // Non-blocking and per-thread streams do not participate in the
+        // implicit dependency and must remain pending.
+        for (auto &entry : streams) {
+          if (lupine_stream_orders_with_legacy_default(entry.first)) {
+            entry.second.push_back({event});
+          }
+        }
+        if (streams.find(nullptr) == streams.end()) {
+          streams[nullptr].push_back({event});
+        }
       },
       std::move(initial));
 }
@@ -1004,14 +1044,14 @@ lupine_detach_event_dtoh_copies(conn_t *conn, CUevent event) {
   std::vector<lupine_pending_dtoh_item> copies;
   lupine_pending_dtoh_copies().erase_fn(
       conn, [&](lupine_pending_dtoh_streams &streams) {
-        for (auto stream_it = streams.begin(); stream_it != streams.end();
-             ++stream_it) {
+        for (auto stream_it = streams.begin(); stream_it != streams.end();) {
           auto &items = stream_it->second;
           auto marker = std::find_if(
               items.begin(), items.end(), [event](const auto &item) {
                 return lupine_is_event_dtoh_marker(item, event);
               });
           if (marker == items.end()) {
+            ++stream_it;
             continue;
           }
           auto through_marker = std::next(marker);
@@ -1019,11 +1059,12 @@ lupine_detach_event_dtoh_copies(conn_t *conn, CUevent event) {
                                             &copies);
           items.erase(items.begin(), through_marker);
           if (items.empty()) {
-            streams.erase(stream_it);
+            stream_it = streams.erase(stream_it);
+          } else {
+            ++stream_it;
           }
-          return streams.empty();
         }
-        return false;
+        return streams.empty();
       });
   return copies;
 }
@@ -4205,6 +4246,8 @@ int handle_cuMemcpyDtoHAsync_v2(conn_t *conn) {
   if (rpc_read_end(conn) < 0) {
     return -1;
   }
+
+  stream = lupine_canonical_dtoh_stream(stream);
 
   CUstreamCaptureStatus capture_status = CU_STREAM_CAPTURE_STATUS_NONE;
   if (stream != nullptr) {

--- a/test/test_default_stream_event_dtoh.cu
+++ b/test/test_default_stream_event_dtoh.cu
@@ -1,0 +1,122 @@
+// Verify that an event recorded in the legacy default stream returns deferred
+// DtoH copies from every implicitly ordered blocking stream, but not from a
+// non-blocking stream or from work submitted after the event.
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+constexpr size_t kElements = 4096;
+constexpr size_t kBytes = kElements * sizeof(int);
+constexpr int kUntouched = -1;
+
+bool check(cudaError_t result, const char *operation) {
+  if (result == cudaSuccess) {
+    return true;
+  }
+  std::fprintf(stderr, "FAIL: %s: %s\n", operation, cudaGetErrorString(result));
+  return false;
+}
+
+bool all_equal(const int *values, int expected) {
+  return std::all_of(values, values + kElements,
+                     [expected](int value) { return value == expected; });
+}
+
+bool allocate_pair(int value, int **device, int **host) {
+  std::vector<int> source(kElements, value);
+  if (!check(cudaMalloc(reinterpret_cast<void **>(device), kBytes),
+             "cudaMalloc") ||
+      !check(cudaMemcpy(*device, source.data(), kBytes, cudaMemcpyHostToDevice),
+             "cudaMemcpy HtoD") ||
+      !check(cudaMallocHost(reinterpret_cast<void **>(host), kBytes),
+             "cudaMallocHost")) {
+    return false;
+  }
+  std::fill(*host, *host + kElements, kUntouched);
+  return true;
+}
+
+} // namespace
+
+int main() {
+  int *first_device = nullptr;
+  int *second_device = nullptr;
+  int *later_device = nullptr;
+  int *nonblocking_device = nullptr;
+  int *first_host = nullptr;
+  int *second_host = nullptr;
+  int *later_host = nullptr;
+  int *nonblocking_host = nullptr;
+  cudaStream_t first_stream = nullptr;
+  cudaStream_t second_stream = nullptr;
+  cudaStream_t nonblocking_stream = nullptr;
+  cudaEvent_t event = nullptr;
+
+  if (!allocate_pair(7, &first_device, &first_host) ||
+      !allocate_pair(11, &second_device, &second_host) ||
+      !allocate_pair(13, &later_device, &later_host) ||
+      !allocate_pair(17, &nonblocking_device, &nonblocking_host) ||
+      !check(cudaStreamCreate(&first_stream), "create first stream") ||
+      !check(cudaStreamCreate(&second_stream), "create second stream") ||
+      !check(
+          cudaStreamCreateWithFlags(&nonblocking_stream, cudaStreamNonBlocking),
+          "create non-blocking stream") ||
+      !check(cudaEventCreate(&event), "create event") ||
+      !check(cudaMemcpyAsync(first_host, first_device, kBytes,
+                             cudaMemcpyDeviceToHost, first_stream),
+             "first DtoH") ||
+      !check(cudaMemcpyAsync(second_host, second_device, kBytes,
+                             cudaMemcpyDeviceToHost, second_stream),
+             "second DtoH") ||
+      !check(cudaMemcpyAsync(nonblocking_host, nonblocking_device, kBytes,
+                             cudaMemcpyDeviceToHost, nonblocking_stream),
+             "non-blocking DtoH") ||
+      !check(cudaEventRecord(event, nullptr), "record default-stream event") ||
+      !check(cudaMemcpyAsync(later_host, later_device, kBytes,
+                             cudaMemcpyDeviceToHost, first_stream),
+             "later DtoH") ||
+      !check(cudaEventSynchronize(event), "synchronize event")) {
+    return 1;
+  }
+
+  if (!all_equal(first_host, 7) || !all_equal(second_host, 11)) {
+    std::fprintf(stderr,
+                 "FAIL: default-stream event did not deliver blocking-stream "
+                 "DtoH data\n");
+    return 1;
+  }
+  if (!all_equal(later_host, kUntouched) ||
+      !all_equal(nonblocking_host, kUntouched)) {
+    std::fprintf(stderr,
+                 "FAIL: default-stream event delivered unordered DtoH data\n");
+    return 1;
+  }
+
+  if (!check(cudaStreamSynchronize(first_stream), "synchronize first stream") ||
+      !check(cudaStreamSynchronize(nonblocking_stream),
+             "synchronize non-blocking stream") ||
+      !all_equal(later_host, 13) || !all_equal(nonblocking_host, 17)) {
+    std::fprintf(stderr, "FAIL: deferred DtoH data was not delivered later\n");
+    return 1;
+  }
+
+  cudaEventDestroy(event);
+  cudaStreamDestroy(first_stream);
+  cudaStreamDestroy(second_stream);
+  cudaStreamDestroy(nonblocking_stream);
+  cudaFreeHost(first_host);
+  cudaFreeHost(second_host);
+  cudaFreeHost(later_host);
+  cudaFreeHost(nonblocking_host);
+  cudaFree(first_device);
+  cudaFree(second_device);
+  cudaFree(later_device);
+  cudaFree(nonblocking_device);
+
+  std::printf("PASS: legacy default-stream event DtoH ordering\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

- honor legacy default-stream ordering when marking deferred DtoH copies at event record time
- drain every blocking-stream queue completed by a synchronized default-stream event while leaving non-blocking and later work pending
- add a focused CUDA regression for cross-stream, non-blocking, and post-event behavior

## Root cause

PR #566 marked an event only in the queue for the stream passed to `cuEventRecord`. `simpleStreams` enqueues DtoH copies in four blocking streams but records its stop event in the legacy default stream. CUDA orders that event after all four streams, but Lupine found no copies in the default-stream queue, so `cudaEventSynchronize` returned without delivering staged DtoH data. The sample then observed `-1` instead of `2500` and exited 1.

## Validation

- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure` (10 passed; 2 signal tests skipped without a local GPU)
- CUDA 13.1 compilation of `test/test_default_stream_event_dtoh.cu`

The GPU integration workflow will execute the new regression and `simpleStreams` through Lupine.