### PR TITLE
Fix CUDA 13 context ABI dispatch

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2192,6 +2192,7 @@ CUresult cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags,
  */
 CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev);
 /**
+ * @disabled - manual client and server maintain context ownership state
  * @recordowner CONTEXT pctx
  * @param pctx RECV_ONLY
  * @param flags SEND_ONLY
@@ -2240,6 +2241,14 @@ CUresult cuCtxGetCurrent(CUcontext *pctx);
  */
 CUresult cuCtxGetDevice(CUdevice *device);
 /**
+ * @guard CUDA_VERSION >= 13000
+ * @disabled client - manual client resolves the device of the supplied context
+ * @routingkey CONTEXT ctx
+ * @param device RECV_ONLY
+ * @param ctx SEND_ONLY
+ */
+CUresult cuCtxGetDevice_v2(CUdevice *device, CUcontext ctx);
+/**
  * @param flags RECV_ONLY
  */
 CUresult cuCtxGetFlags(unsigned int *flags);
@@ -2255,6 +2264,15 @@ CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId);
  * @server CUDA
  */
 CUresult cuCtxSynchronize();
+/**
+ * @guard CUDA_VERSION >= 13000
+ * @disabled server
+ * @synchronize DEFERRED_DTOH STDOUT
+ * @routingkey CONTEXT ctx
+ * @param ctx SEND_ONLY
+ * @server CUDA
+ */
+CUresult cuCtxSynchronize_v2(CUcontext ctx);
 /**
  * @param limit SEND_ONLY
  * @param value SEND_ONLY
@@ -3347,15 +3365,30 @@ CUresult cuMemPoolImportPointer(CUdeviceptr *ptr_out, CUmemoryPool pool,
  */
 CUresult cuPointerGetAttribute(void *data, CUpointer_attribute attribute,
                                CUdeviceptr ptr);
+#ifdef cuMemPrefetchAsync
+#undef cuMemPrefetchAsync
+#endif
 /**
+ * @disabled client - manual client handles managed-pointer and target routing
  * @param devPtr SEND_ONLY
  * @param count SEND_ONLY
  * @param dstDevice SEND_ONLY
  * @param hStream SEND_ONLY
- * @server CUDA
  */
 CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
                             CUdevice dstDevice, CUstream hStream);
+/**
+ * @guard CUDA_VERSION >= 12020
+ * @disabled client - manual client handles managed-pointer and target routing
+ * @param devPtr SEND_ONLY
+ * @param count SEND_ONLY
+ * @param location SEND_ONLY
+ * @param flags SEND_ONLY
+ * @param hStream SEND_ONLY
+ */
+CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
+                               CUmemLocation location, unsigned int flags,
+                               CUstream hStream);
 /**
  * @param devPtr SEND_ONLY
  * @param count SEND_ONLY
@@ -4836,7 +4869,7 @@ CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
  * @param l2Promotion SEND_ONLY
  * @param oobFill SEND_ONLY
  * @server CUDA
- * @serverguard CUDA_VERSION >= 12000
+ * @guard CUDA_VERSION >= 12000
  */
 CUresult cuTensorMapEncodeTiled(
     CUtensorMap *tensorMap, CUtensorMapDataType tensorDataType,

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -184,7 +184,6 @@ PRIVATE_RPC_FUNCTIONS = [
     "cuGetExportTableMetadata",
     "cuGraphAddNode_v2",
     "cuGraphConditionalHandleCreate",
-    "cuMemPrefetchAsync",
     "cuPrivateGetModuleNode",
     "cuStreamBeginCaptureToGraph",
     "cuStreamGetCaptureInfo_v3",
@@ -290,18 +289,12 @@ def parse_server_binding(name: str, annotation: str) -> Optional[ServerBinding]:
                 raise RuntimeError(f"Unknown RPC server backend {backend}")
             if len(parts) == 3:
                 handler = parts[2]
-        elif parts[0] == "@serverguard":
+        elif parts[0] == "@guard":
             if guard is not None or len(parts) < 2:
-                raise RuntimeError(
-                    f"Invalid @serverguard annotation for {name}"
-                )
-            guard = directive.removeprefix("@serverguard").strip()
+                raise RuntimeError(f"Invalid @guard annotation for {name}")
+            guard = directive.removeprefix("@guard").strip()
 
     if backend is None:
-        if guard is not None:
-            raise RuntimeError(
-                f"@serverguard without @server for {name}"
-            )
         return None
 
     if handler is None:
@@ -1371,6 +1364,49 @@ def main():
             (function, annotation, metadata.operations, metadata)
         )
 
+    # cuda.h hides some legacy ABI entry points behind macros. When such an
+    # entry point is explicitly declared in annotations.h, keep its manual
+    # client while generating the ordinary server marshalling from that
+    # declaration.
+    server_functions_with_annotations = list(functions_with_annotations)
+    server_function_names = {
+        function.name.format()
+        for function, _, _, _ in server_functions_with_annotations
+    }
+    annotation_only_server_functions = []
+    for annotation in annotations.namespace.functions:
+        name = annotation.name.format()
+        if (
+            len(name) <= 2
+            or not name.startswith("cu")
+            or not name[2].isupper()
+            or name in server_function_names
+        ):
+            continue
+        directives = annotation_directives(annotation.doxygen)
+        if not any(
+            directive.startswith("@disabled client")
+            for directive in directives
+        ):
+            continue
+        if any(
+            directive == "@disabled"
+            or directive.startswith("@disabled server")
+            for directive in directives
+        ):
+            continue
+        metadata = parse_annotation(annotation.doxygen, annotation.parameters)
+        validate_async_annotation(annotation, metadata)
+        annotated_function = (
+            annotation,
+            annotation,
+            metadata.operations,
+            metadata,
+        )
+        server_functions_with_annotations.append(annotated_function)
+        annotation_only_server_functions.append(annotated_function)
+        server_function_names.add(name)
+
     nvml_functions_with_annotations = collect_nvml_functions(
         annotations, server_bindings
     )
@@ -1879,7 +1915,22 @@ def main():
             '#include <cstdio>\n\n'
             '#include "rpc.h"\n\n'
         )
-        for function, annotation, operations, metadata in functions_with_annotations:
+        for function, _, _, _ in annotation_only_server_functions:
+            name = function.name.format()
+            f.write(f"#ifdef {name}\n#undef {name}\n#endif\n")
+            f.write(
+                'extern "C" {return_type} CUDAAPI {name}({params});\n\n'.format(
+                    return_type=function.return_type.format(),
+                    name=name,
+                    params=", ".join(format_function_params(function)),
+                )
+            )
+        for (
+            function,
+            annotation,
+            operations,
+            metadata,
+        ) in server_functions_with_annotations:
             if (
                 metadata.disabled_server
                 or function.name.format() in server_bindings
@@ -1992,7 +2043,7 @@ def main():
             f"handle_{function.name.format()}",
             metadata.guard,
         )
-        for function, _, _, metadata in functions_with_annotations
+        for function, _, _, metadata in server_functions_with_annotations
         if not metadata.disabled_server
         and function.name.format() not in server_bindings
     ]

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -427,6 +427,37 @@ CUresult cuCtxSynchronize() {
   return return_value;
 }
 
+#if CUDA_VERSION >= 13000
+CUresult cuCtxSynchronize_v2(CUcontext ctx) {
+  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
+  if (lupine_sync_result != CUDA_SUCCESS) {
+    return lupine_sync_result;
+  }
+  lupine_route route = lupine_route_for_context(ctx);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUcontext);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxSynchronize_v2",
+                                                  &return_value, ctx)) {
+    if (return_value == CUDA_SUCCESS)
+      return_value = lupine_sync_mapped_device_to_host();
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (rpc_write_start_request(conn, RPC_cuCtxSynchronize_v2) < 0 ||
+      rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      lupine_read_deferred_dtoh_copies(conn) < 0 ||
+      lupine_forward_remote_stdout(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    return_value = lupine_sync_mapped_device_to_host();
+  return return_value;
+}
+
+#endif
+
 CUresult cuCtxSetLimit(CUlimit limit, size_t value) {
   lupine_route route = lupine_route_for_default();
   CUresult return_value;
@@ -6793,9 +6824,15 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuCtxSetCurrent", (void *)cuCtxSetCurrent},
     {"cuCtxGetCurrent", (void *)cuCtxGetCurrent},
     {"cuCtxGetDevice", (void *)cuCtxGetDevice},
+#if CUDA_VERSION >= 13000
+    {"cuCtxGetDevice_v2", (void *)cuCtxGetDevice_v2},
+#endif
     {"cuCtxGetFlags", (void *)cuCtxGetFlags},
     {"cuCtxGetId", (void *)cuCtxGetId},
     {"cuCtxSynchronize", (void *)cuCtxSynchronize},
+#if CUDA_VERSION >= 13000
+    {"cuCtxSynchronize_v2", (void *)cuCtxSynchronize_v2},
+#endif
     {"cuCtxSetLimit", (void *)cuCtxSetLimit},
     {"cuCtxGetLimit", (void *)cuCtxGetLimit},
     {"cuCtxGetCacheConfig", (void *)cuCtxGetCacheConfig},
@@ -6906,6 +6943,9 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemAllocFromPoolAsync", (void *)cuMemAllocFromPoolAsync},
     {"cuMemPoolExportPointer", (void *)cuMemPoolExportPointer},
     {"cuMemPoolImportPointer", (void *)cuMemPoolImportPointer},
+#if CUDA_VERSION >= 12020
+    {"cuMemPrefetchAsync_v2", (void *)cuMemPrefetchAsync_v2},
+#endif
     {"cuMemRangeGetAttributes", (void *)cuMemRangeGetAttributes},
     {"cuPointerGetAttributes", (void *)cuPointerGetAttributes},
     {"cuStreamCreate", (void *)cuStreamCreate},

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -12,6 +12,13 @@
 
 #include "rpc.h"
 
+#ifdef cuMemPrefetchAsync
+#undef cuMemPrefetchAsync
+#endif
+extern "C" CUresult CUDAAPI cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
+                                               CUdevice dstDevice,
+                                               CUstream hStream);
+
 int handle_cuInit(conn_t *conn) {
   unsigned int Flags;
   int request_id;
@@ -612,6 +619,33 @@ int handle_cuCtxGetDevice(conn_t *conn) {
 ERROR_0:
   return -1;
 }
+
+#if CUDA_VERSION >= 13000
+int handle_cuCtxGetDevice_v2(conn_t *conn) {
+  CUdevice device;
+  CUcontext ctx;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &ctx, sizeof(CUcontext)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuCtxGetDevice_v2(&device, ctx);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
 
 int handle_cuCtxGetFlags(conn_t *conn) {
   unsigned int flags;
@@ -3325,6 +3359,40 @@ int handle_cuMemPoolImportPointer(conn_t *conn) {
 ERROR_0:
   return -1;
 }
+
+#if CUDA_VERSION >= 12020
+int handle_cuMemPrefetchAsync_v2(conn_t *conn) {
+  CUdeviceptr devPtr;
+  size_t count;
+  CUmemLocation location;
+  unsigned int flags;
+  CUstream hStream;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &devPtr, sizeof(CUdeviceptr)) < 0 ||
+      rpc_read(conn, &count, sizeof(size_t)) < 0 ||
+      rpc_read(conn, &location, sizeof(CUmemLocation)) < 0 ||
+      rpc_read(conn, &flags, sizeof(unsigned int)) < 0 ||
+      rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result =
+      cuMemPrefetchAsync_v2(devPtr, count, location, flags, hStream);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
 
 int handle_cuMemRangeGetAttributes(conn_t *conn) {
   void *data;
@@ -7812,3 +7880,32 @@ ERROR_0:
 }
 
 #endif
+
+int handle_cuMemPrefetchAsync(conn_t *conn) {
+  CUdeviceptr devPtr;
+  size_t count;
+  CUdevice dstDevice;
+  CUstream hStream;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &devPtr, sizeof(CUdeviceptr)) < 0 ||
+      rpc_read(conn, &count, sizeof(size_t)) < 0 ||
+      rpc_read(conn, &dstDevice, sizeof(CUdevice)) < 0 ||
+      rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result =
+      cuMemPrefetchAsync(devPtr, count, dstDevice, hStream);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}

--- a/codegen/gen_rpc_ids.h
+++ b/codegen/gen_rpc_ids.h
@@ -32,9 +32,11 @@
 #define RPC_cuCtxSetCurrent 1801040174
 #define RPC_cuCtxGetCurrent 1159499964
 #define RPC_cuCtxGetDevice 1876605837
+#define RPC_cuCtxGetDevice_v2 566885354
 #define RPC_cuCtxGetFlags 492061685
 #define RPC_cuCtxGetId 1704852972
 #define RPC_cuCtxSynchronize 484046796
+#define RPC_cuCtxSynchronize_v2 357846365
 #define RPC_cuCtxSetLimit 288806398
 #define RPC_cuCtxGetLimit 1774709295
 #define RPC_cuCtxGetCacheConfig 1342146307
@@ -167,6 +169,7 @@
 #define RPC_cuMemPoolImportFromShareableHandle 1891033213
 #define RPC_cuMemPoolExportPointer 858999363
 #define RPC_cuMemPoolImportPointer 1026713940
+#define RPC_cuMemPrefetchAsync_v2 199313298
 #define RPC_cuMemRangeGetAttributes 694140572
 #define RPC_cuPointerSetAttribute 749063765
 #define RPC_cuPointerGetAttributes 1948058610
@@ -372,7 +375,7 @@
 #define RPC_cuMemHostUnregister 983276883
 #define RPC_cuMemPoolGetAttribute 830843819
 #define RPC_cuMemPoolSetAttribute 1050377512
-#define RPC_cuMemPrefetchAsync_v2 199313298
+#define RPC_cuMemPrefetchAsync 596440383
 #define RPC_cuMemRangeGetAttribute 1819983801
 #define RPC_cuMemRetainAllocationHandle 1903553150
 #define RPC_cuMemcpyAtoHAsync_v2 1591028942
@@ -451,7 +454,6 @@
 #define LUPINE_RPC_cuGetExportTableMetadata 565915314
 #define LUPINE_RPC_cuGraphAddNode_v2 1958016248
 #define LUPINE_RPC_cuGraphConditionalHandleCreate 1689373620
-#define LUPINE_RPC_cuMemPrefetchAsync 596440383
 #define LUPINE_RPC_cuPrivateGetModuleNode 1986234018
 #define LUPINE_RPC_cuStreamBeginCaptureToGraph 1423223781
 #define LUPINE_RPC_cuStreamGetCaptureInfo_v3 1793131524

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -46,7 +46,6 @@
   HANDLER(RPC_cuMemPoolExportToShareableHandle, handle_cuMemPoolExportToShareableHandle, rpc_backend::cuda) \
   HANDLER(RPC_cuMemPoolImportFromShareableHandle, handle_cuMemPoolImportFromShareableHandle, rpc_backend::cuda) \
   HANDLER(RPC_cuPointerGetAttribute, handle_cuPointerGetAttribute, rpc_backend::cuda) \
-  HANDLER(LUPINE_RPC_cuMemPrefetchAsync, handle_cuMemPrefetchAsync, rpc_backend::cuda) \
   HANDLER(RPC_cuPointerSetAttribute, handle_cuPointerSetAttribute, rpc_backend::cuda) \
   HANDLER(RPC_cuPointerGetAttributes, handle_cuPointerGetAttributes, rpc_backend::cuda) \
   HANDLER(RPC_cuStreamWaitEvent, handle_cuStreamWaitEvent, rpc_backend::cuda) \
@@ -374,7 +373,8 @@
   HANDLER(RPC_cuGraphicsResourceGetMappedPointer_v2, handle_cuGraphicsResourceGetMappedPointer_v2, rpc_backend::cuda) \
   HANDLER(RPC_cuGraphicsResourceSetMapFlags_v2, handle_cuGraphicsResourceSetMapFlags_v2, rpc_backend::cuda) \
   HANDLER(RPC_cuGraphicsMapResources, handle_cuGraphicsMapResources, rpc_backend::cuda) \
-  HANDLER(RPC_cuGraphicsUnmapResources, handle_cuGraphicsUnmapResources, rpc_backend::cuda)
+  HANDLER(RPC_cuGraphicsUnmapResources, handle_cuGraphicsUnmapResources, rpc_backend::cuda) \
+  HANDLER(RPC_cuMemPrefetchAsync, handle_cuMemPrefetchAsync, rpc_backend::cuda)
 #define LUPINE_NVML_RPC_HANDLERS(HANDLER) \
   HANDLER(RPC_nvmlDeviceGetComputeRunningProcesses, handle_nvmlDeviceGetComputeRunningProcesses, rpc_backend::nvml) \
   HANDLER(RPC_nvmlDeviceGetComputeRunningProcesses_v2, handle_nvmlDeviceGetComputeRunningProcesses_v2, rpc_backend::nvml) \
@@ -445,9 +445,21 @@
   int handler(conn_t *conn);
 #ifdef LUPINE_BUILD_CUDA_BACKEND
 LUPINE_CUDA_RPC_HANDLERS(LUPINE_DECLARE_HANDLER)
+#if CUDA_VERSION >= 13000
+LUPINE_DECLARE_HANDLER(RPC_cuCtxSynchronize_v2, handle_cuCtxSynchronize_v2,
+                       rpc_backend::cuda)
+#endif
 #if CUDA_VERSION >= 12000
 LUPINE_DECLARE_HANDLER(RPC_cuTensorMapEncodeTiled,
                        handle_cuTensorMapEncodeTiled, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 13000
+LUPINE_DECLARE_HANDLER(RPC_cuCtxGetDevice_v2, handle_cuCtxGetDevice_v2,
+                       rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12020
+LUPINE_DECLARE_HANDLER(RPC_cuMemPrefetchAsync_v2, handle_cuMemPrefetchAsync_v2,
+                       rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
 LUPINE_DECLARE_HANDLER(RPC_cuStreamGetGreenCtx, handle_cuStreamGetGreenCtx,
@@ -466,19 +478,33 @@ const rpc_handler_registry &lupine_rpc_handlers() {
   static const rpc_handler_registry handlers = {
 #ifdef LUPINE_BUILD_CUDA_BACKEND
       LUPINE_CUDA_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
+#if CUDA_VERSION >= 13000
+          LUPINE_REGISTER_HANDLER(RPC_cuCtxSynchronize_v2,
+                                  handle_cuCtxSynchronize_v2, rpc_backend::cuda)
+#endif
 #if CUDA_VERSION >= 12000
-          LUPINE_REGISTER_HANDLER(RPC_cuTensorMapEncodeTiled,
-                                  handle_cuTensorMapEncodeTiled,
-                                  rpc_backend::cuda)
+              LUPINE_REGISTER_HANDLER(RPC_cuTensorMapEncodeTiled,
+                                      handle_cuTensorMapEncodeTiled,
+                                      rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 13000
+                  LUPINE_REGISTER_HANDLER(RPC_cuCtxGetDevice_v2,
+                                          handle_cuCtxGetDevice_v2,
+                                          rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12020
+                      LUPINE_REGISTER_HANDLER(RPC_cuMemPrefetchAsync_v2,
+                                              handle_cuMemPrefetchAsync_v2,
+                                              rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
-              LUPINE_REGISTER_HANDLER(RPC_cuStreamGetGreenCtx,
-                                      handle_cuStreamGetGreenCtx,
-                                      rpc_backend::cuda)
+                          LUPINE_REGISTER_HANDLER(RPC_cuStreamGetGreenCtx,
+                                                  handle_cuStreamGetGreenCtx,
+                                                  rpc_backend::cuda)
 #endif
 #endif
 #ifdef LUPINE_BUILD_NVML_BACKEND
-                  LUPINE_NVML_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
+                              LUPINE_NVML_RPC_HANDLERS(LUPINE_REGISTER_HANDLER)
 
 #endif
   };

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -3587,6 +3587,50 @@ extern "C" CUresult cuCtxGetDevice(CUdevice *device) {
   return return_value;
 }
 
+#if CUDA_VERSION >= 13000
+extern "C" CUresult cuCtxGetDevice_v2(CUdevice *device, CUcontext ctx) {
+  if (device == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (!lupine_cuda_is_initialized()) {
+    return CUDA_ERROR_NOT_INITIALIZED;
+  }
+  if (ctx == nullptr) {
+    return cuCtxGetDevice(device);
+  }
+
+  lupine_route route = lupine_route_for_context(ctx);
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUdevice *, CUcontext);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuCtxGetDevice_v2");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    return real(device, ctx);
+  }
+  if (lupine_current_context_device_cache_lookup(ctx, device)) {
+    return CUDA_SUCCESS;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUdevice remote_device = 0;
+  CUresult return_value;
+  if (rpc_write_start_request(conn, RPC_cuCtxGetDevice_v2) < 0 ||
+      rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &remote_device, sizeof(remote_device)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    *device = lupine_local_device_for_remote(conn, remote_device);
+    lupine_current_context_device_cache_insert(ctx, *device);
+  }
+  return return_value;
+}
+#endif
+
 extern "C" CUresult cuMemPoolGetAttribute(CUmemoryPool pool,
                                           CUmemPool_attribute attr,
                                           void *value) {
@@ -8433,6 +8477,25 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
   // without changing the name and must also use the requested API version.
   (void)flags;
 
+#if CUDA_VERSION >= 13000
+  if (symbol != nullptr && cudaVersion >= 13000 &&
+      strcmp(symbol, "cuCtxGetDevice") == 0) {
+    *pfn = reinterpret_cast<void *>(&cuCtxGetDevice_v2);
+    if (symbolStatus != nullptr) {
+      *symbolStatus = CU_GET_PROC_ADDRESS_SUCCESS;
+    }
+    return CUDA_SUCCESS;
+  }
+  if (symbol != nullptr && cudaVersion >= 13000 &&
+      strcmp(symbol, "cuCtxSynchronize") == 0) {
+    *pfn = reinterpret_cast<void *>(&cuCtxSynchronize_v2);
+    if (symbolStatus != nullptr) {
+      *symbolStatus = CU_GET_PROC_ADDRESS_SUCCESS;
+    }
+    return CUDA_SUCCESS;
+  }
+#endif
+
   if (strcmp(symbol, "cuFuncGetAttribute") == 0) {
     *pfn = reinterpret_cast<void *>(&lupine_cuFuncGetAttribute_safe);
     if (symbolStatus != nullptr) {
@@ -8466,6 +8529,7 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
     }
     return CUDA_SUCCESS;
   }
+#if CUDA_VERSION >= 12020
   if (symbol != nullptr && cudaVersion >= 12020 &&
       (strcmp(symbol, "cuMemPrefetchAsync") == 0 ||
        strcmp(symbol, "cuMemPrefetchAsync_ptsz") == 0)) {
@@ -8475,6 +8539,7 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
     }
     return CUDA_SUCCESS;
   }
+#endif
 
   auto it = get_function_pointer(symbol);
   if (it != nullptr) {
@@ -8719,7 +8784,6 @@ lupine_manual_function_map() {
       {"cuMemGetInfo", (void *)cuMemGetInfo},
       {"cuMemPrefetchAsync", (void *)cuMemPrefetchAsync},
       {"cuMemPrefetchAsync_ptsz", (void *)cuMemPrefetchAsync_ptsz},
-      {"cuMemPrefetchAsync_v2", (void *)cuMemPrefetchAsync_v2},
       {"cuArrayCreate", (void *)cuArrayCreate_v2},
       {"cuArrayCreate_v2", (void *)cuArrayCreate_v2},
       {"cuArray3DCreate", (void *)cuArray3DCreate_v2},

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -1855,52 +1855,6 @@ int handle_cuPointerGetAttributes(conn_t *conn) {
   return 0;
 }
 
-int handle_cuMemPrefetchAsync(conn_t *conn) {
-  CUdeviceptr devPtr;
-  size_t count;
-  int location_type;
-  int location_id;
-  unsigned int flags;
-  CUstream hStream;
-  int request_id;
-  CUresult result;
-  if (rpc_read(conn, &devPtr, sizeof(devPtr)) < 0 ||
-      rpc_read(conn, &count, sizeof(count)) < 0 ||
-      rpc_read(conn, &location_type, sizeof(location_type)) < 0 ||
-      rpc_read(conn, &location_id, sizeof(location_id)) < 0 ||
-      rpc_read(conn, &flags, sizeof(flags)) < 0 ||
-      rpc_read(conn, &hStream, sizeof(hStream)) < 0) {
-    return -1;
-  }
-  request_id = rpc_read_end(conn);
-  if (request_id < 0) {
-    return -1;
-  }
-
-  CUmemLocation location = {};
-  location.type = static_cast<CUmemLocationType>(location_type);
-  location.id = location_id;
-#if CUDA_VERSION >= 12020
-  result = cuMemPrefetchAsync_v2(devPtr, count, location, flags, hStream);
-#else
-  if (flags != 0 || (location.type != CU_MEM_LOCATION_TYPE_DEVICE &&
-                     location.type != LUPINE_CU_MEM_LOCATION_TYPE_HOST)) {
-    result = CUDA_ERROR_INVALID_VALUE;
-  } else {
-    CUdevice dstDevice = location.type == CU_MEM_LOCATION_TYPE_DEVICE
-                             ? location.id
-                             : CU_DEVICE_CPU;
-    result = cuMemPrefetchAsync(devPtr, count, dstDevice, hStream);
-  }
-#endif
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    return -1;
-  }
-  return 0;
-}
-
 int handle_cuLinkCreate_v2(conn_t *conn) {
   auto link_state = std::make_unique<lupine_link_state>();
   CUlinkState client_state = nullptr;
@@ -4351,6 +4305,32 @@ int handle_cuCtxSynchronize(conn_t *conn) {
   lupine_cleanup_pending_dtoh_copies(&pending);
   return failed ? -1 : 0;
 }
+
+#if CUDA_VERSION >= 13000
+int handle_cuCtxSynchronize_v2(conn_t *conn) {
+  CUcontext ctx = nullptr;
+  if (rpc_read(conn, &ctx, sizeof(ctx)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+  lupine_captured_stdout capture;
+  lupine_start_stdout_capture(&capture);
+  CUresult result = cuCtxSynchronize_v2(ctx);
+  lupine_finish_stdout_capture(&capture);
+  auto pending = lupine_detach_pending_dtoh_copies(conn, nullptr, true);
+  bool failed = rpc_write_start_response(conn, request_id) < 0 ||
+                rpc_copy_alloc(conn, 2 * sizeof(uint64_t)) < 0 ||
+                lupine_write_pending_dtoh_copies(conn, pending, true) < 0 ||
+                lupine_write_captured_stdout(conn, capture) < 0 ||
+                rpc_write(conn, &result, sizeof(result)) < 0 ||
+                rpc_write_end(conn) < 0;
+  lupine_cleanup_pending_dtoh_copies(&pending);
+  return failed ? -1 : 0;
+}
+#endif
 
 int handle_cuStreamSynchronize(conn_t *conn) {
   CUstream stream = nullptr;

--- a/cuda_server.h
+++ b/cuda_server.h
@@ -55,7 +55,6 @@ int handle_cuGraphAddNode(conn_t *conn);
 int handle_cuGraphGetEdges(conn_t *conn);
 int handle_cuGraphNodeGetDependencies(conn_t *conn);
 int handle_cuGraphNodeGetDependentNodes(conn_t *conn);
-int handle_cuMemPrefetchAsync(conn_t *conn);
 int handle_cuGraphHostNodeGetParams(conn_t *conn);
 int handle_cuGraphHostNodeSetParams(conn_t *conn);
 int handle_cuGraphExecHostNodeSetParams(conn_t *conn);

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -2668,17 +2668,79 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
   return return_value;
 }
 
-static CUresult lupine_cuMemPrefetchAsync_location(CUdeviceptr devPtr,
-                                                   size_t count,
-                                                   CUmemLocation location,
-                                                   unsigned int flags,
-                                                   CUstream hStream) {
+static CUresult lupine_prepare_prefetch_ptr(CUdeviceptr devPtr,
+                                            CUdeviceptr *translated) {
+  *translated = devPtr;
+  if (!lupine_translate_managed_host_ptr(devPtr, translated)) {
+    return CUDA_SUCCESS;
+  }
+  return lupine_flush_dirty_host_pages_to_server();
+}
+
+extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
+                                       CUdevice dstDevice, CUstream hStream) {
   CUdeviceptr translated = devPtr;
-  if (lupine_translate_managed_host_ptr(devPtr, &translated)) {
-    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
-    if (flush_result != CUDA_SUCCESS) {
-      return flush_result;
+  CUresult prepare_result = lupine_prepare_prefetch_ptr(devPtr, &translated);
+  if (prepare_result != CUDA_SUCCESS) {
+    return prepare_result;
+  }
+
+  CUdevice route_device = dstDevice;
+  lupine_route route;
+  if (dstDevice != CU_DEVICE_CPU) {
+    route = lupine_route_for_device(&route_device);
+    if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE) {
+      return CUDA_ERROR_INVALID_DEVICE;
     }
+  } else {
+    route = hStream != nullptr ? lupine_route_for_stream(hStream)
+                               : lupine_route_for_deviceptr(translated);
+  }
+  if (hStream != nullptr) {
+    lupine_route stream_route = lupine_route_for_stream(hStream);
+    if (!lupine_routes_share_server(route, stream_route)) {
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+  }
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, CUdevice, CUstream);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemPrefetchAsync");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    return real(translated, count, route_device, hStream);
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult return_value;
+  if (rpc_write_start_request(conn, RPC_cuMemPrefetchAsync) < 0 ||
+      rpc_write(conn, &translated, sizeof(translated)) < 0 ||
+      rpc_write(conn, &count, sizeof(count)) < 0 ||
+      rpc_write(conn, &route_device, sizeof(route_device)) < 0 ||
+      rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return return_value;
+}
+
+extern "C" CUresult cuMemPrefetchAsync_ptsz(CUdeviceptr devPtr, size_t count,
+                                            CUdevice dstDevice,
+                                            CUstream hStream) {
+  return cuMemPrefetchAsync(devPtr, count, dstDevice, hStream);
+}
+
+#if CUDA_VERSION >= 12020
+extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
+                                          CUmemLocation location,
+                                          unsigned int flags,
+                                          CUstream hStream) {
+  CUdeviceptr translated = devPtr;
+  CUresult prepare_result = lupine_prepare_prefetch_ptr(devPtr, &translated);
+  if (prepare_result != CUDA_SUCCESS) {
+    return prepare_result;
   }
 
   CUmemLocation route_location = location;
@@ -2701,7 +2763,6 @@ static CUresult lupine_cuMemPrefetchAsync_location(CUdeviceptr devPtr,
     }
   }
   if (lupine_route_is_local(route)) {
-#if CUDA_VERSION >= 12020
     using real_fn_t = CUresult (*)(CUdeviceptr, size_t, CUmemLocation,
                                    unsigned int, CUstream);
     auto real = lupine_real_cuda_fn<real_fn_t>("cuMemPrefetchAsync_v2");
@@ -2709,32 +2770,14 @@ static CUresult lupine_cuMemPrefetchAsync_location(CUdeviceptr devPtr,
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
     return real(translated, count, route_location, flags, hStream);
-#else
-    if (flags != 0 ||
-        (route_location.type != CU_MEM_LOCATION_TYPE_DEVICE &&
-         route_location.type != LUPINE_CU_MEM_LOCATION_TYPE_HOST)) {
-      return CUDA_ERROR_INVALID_VALUE;
-    }
-    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, CUdevice, CUstream);
-    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemPrefetchAsync");
-    if (real == nullptr) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-    CUdevice dstDevice = route_location.type == CU_MEM_LOCATION_TYPE_DEVICE
-                             ? route_location.id
-                             : CU_DEVICE_CPU;
-    return real(translated, count, dstDevice, hStream);
-#endif
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  int location_type = static_cast<int>(route_location.type);
   CUresult return_value;
-  if (rpc_write_start_request(conn, LUPINE_RPC_cuMemPrefetchAsync) < 0 ||
+  if (rpc_write_start_request(conn, RPC_cuMemPrefetchAsync_v2) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
-      rpc_write(conn, &location_type, sizeof(location_type)) < 0 ||
-      rpc_write(conn, &route_location.id, sizeof(route_location.id)) < 0 ||
+      rpc_write(conn, &route_location, sizeof(route_location)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2744,27 +2787,4 @@ static CUresult lupine_cuMemPrefetchAsync_location(CUdeviceptr devPtr,
   }
   return return_value;
 }
-
-extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
-                                       CUdevice dstDevice, CUstream hStream) {
-  CUmemLocation location = {};
-  location.type = dstDevice == CU_DEVICE_CPU ? LUPINE_CU_MEM_LOCATION_TYPE_HOST
-                                             : CU_MEM_LOCATION_TYPE_DEVICE;
-  location.id = dstDevice == CU_DEVICE_CPU ? 0 : dstDevice;
-  return lupine_cuMemPrefetchAsync_location(devPtr, count, location, 0,
-                                            hStream);
-}
-
-extern "C" CUresult cuMemPrefetchAsync_ptsz(CUdeviceptr devPtr, size_t count,
-                                            CUdevice dstDevice,
-                                            CUstream hStream) {
-  return cuMemPrefetchAsync(devPtr, count, dstDevice, hStream);
-}
-
-extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
-                                          CUmemLocation location,
-                                          unsigned int flags,
-                                          CUstream hStream) {
-  return lupine_cuMemPrefetchAsync_location(devPtr, count, location, flags,
-                                            hStream);
-}
+#endif

--- a/memcpy.h
+++ b/memcpy.h
@@ -21,9 +21,11 @@ extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
 extern "C" CUresult cuMemPrefetchAsync_ptsz(CUdeviceptr devPtr, size_t count,
                                             CUdevice dstDevice,
                                             CUstream hStream);
+#if CUDA_VERSION >= 12020
 extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
                                           CUmemLocation location,
                                           unsigned int flags, CUstream hStream);
+#endif
 
 extern "C" void lupine_mark_host_range_clean(void *host, size_t size);
 extern "C" void lupine_prepare_host_range_write(void *host, size_t size);


### PR DESCRIPTION
## Summary

- add distinct, CUDA 13-guarded RPCs for `cuCtxGetDevice_v2` and `cuCtxSynchronize_v2`
- use the existing handwritten `cuGetProcAddress_v2` resolver to select the explicit-context ABI for CUDA 13 requests
- route `cuCtxGetDevice_v2` through Lupine's device-alias/cache handling
- preserve deferred DtoH and stdout synchronization for `cuCtxSynchronize_v2`
- split the old and v2 `cuMemPrefetchAsync` ABIs into distinct RPCs, removing the server-side downgrade shim under the client-CUDA-version <= server-CUDA-version contract
- generate both `cuMemPrefetchAsync` server handlers and the v2 client symbol-map entry from annotations
- use the existing function-level `@guard` for client, server, function-map, and server-registry generation

## Why

CUDA 13 changed the signatures of `cuCtxGetDevice` and `cuCtxSynchronize` without changing the base names requested through `cuGetProcAddress`. Lupine previously ignored the requested API version and returned the legacy function pointer. CUDA 13.3 cuBLAS passes an explicit context, so the old wrapper ignored that context and `cublasCreate` returned `CUBLAS_STATUS_NOT_INITIALIZED` (14).

This was found while validating #567. The private `cuGetExportTable` UUID requested by cuBLAS is used for logging/TLS and was not the initialization failure.

## ABI and codegen boundary

- `cuGetProcAddress_v2` remains the project's existing handwritten resolver; no additional remapping generator or table is introduced.
- v1 and v2 entry points use separate RPC IDs and call their matching server ABI. Newer ABIs and registry entries are guarded by the toolkit version that introduced them.
- `cuda_client.cpp` manually implements `cuCtxGetDevice_v2` because it translates the remote device ordinal and maintains Lupine's context/device cache. Its server handler is generated.
- `cuCtxSynchronize_v2` has a generated client wrapper and a manual server handler so deferred DtoH copies and captured stdout are returned correctly.
- both prefetch server handlers are generated. The prefetch clients remain manual because they translate managed pointers and target device ordinals, handle the CPU-target routing fallback, and reject cross-server stream/target combinations.
- the existing generator now accepts explicitly annotated legacy server ABIs hidden by `cuda.h` macros; it emits their declarations, handlers, IDs, and registry entries through the normal path.

## Validation

- regenerated sources with CUDA 13.1.80
- build succeeds
- CTest: 8 passed, 0 failed, 2 environment-dependent tests skipped
- versioned `cuGetProcAddress_v2` probe verifies context v1/v2 and prefetch v1/v2 boundaries
- remote `test_cublas_create`: 2 devices, `cublasCreate` succeeds, cuBLAS version 130200
- remote `test_unified_prefetch`: `managed prefetch value=42`
