### PR TITLE
feat: generate CUDA function name APIs

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2365,6 +2365,7 @@ CUresult cuModuleLoadDataEx(CUmodule *module, const void *image,
 CUresult cuModuleLoadFatBinary(CUmodule *module, const void *fatCubin);
 /**
  * @routingkey MODULE hmod
+ * @release MODULE hmod
  * @param hmod SEND_ONLY
  */
 CUresult cuModuleUnload(CUmodule hmod);
@@ -2499,6 +2500,7 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
  * @disabled server - manual server keeps the library loaded, see the handler
  * @async
  * @routingkey LIBRARY library
+ * @release LIBRARY library
  * @param library SEND_ONLY
  * @server CUDA
  */
@@ -2515,6 +2517,7 @@ CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
 /**
  * @routingkey LIBRARY library
  * @recordowner MODULE pMod
+ * @recordparent LIBRARY pMod library
  * @param pMod RECV_ONLY
  * @param library SEND_ONLY
  * @server CUDA

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2608,6 +2608,7 @@ CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
 /**
  * @guard CUDA_VERSION >= 12030
  * @routingkey FUNCTION hfunc
+ * @retain name hfunc
  * @param name RECV_ONLY NULL_TERMINATED
  * @param hfunc SEND_ONLY
  */
@@ -3949,6 +3950,7 @@ CUresult cuFuncGetModule(CUmodule *hmod, CUfunction hfunc);
 /**
  * @guard CUDA_VERSION >= 12030
  * @routingkey FUNCTION hfunc
+ * @retain name hfunc
  * @param name RECV_ONLY NULL_TERMINATED
  * @param hfunc SEND_ONLY
  */

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2606,6 +2606,13 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
 CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
                                 CUdevice dev);
 /**
+ * @guard CUDA_VERSION >= 12030
+ * @routingkey FUNCTION hfunc
+ * @param name RECV_ONLY NULL_TERMINATED
+ * @param hfunc SEND_ONLY
+ */
+CUresult cuKernelGetName(const char **name, CUkernel hfunc);
+/**
  * @routingkey CURRENT_CONTEXT
  * @param free SEND_RECV
  * @param total SEND_RECV
@@ -3939,6 +3946,13 @@ CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config);
  * @param hfunc SEND_ONLY
  */
 CUresult cuFuncGetModule(CUmodule *hmod, CUfunction hfunc);
+/**
+ * @guard CUDA_VERSION >= 12030
+ * @routingkey FUNCTION hfunc
+ * @param name RECV_ONLY NULL_TERMINATED
+ * @param hfunc SEND_ONLY
+ */
+CUresult cuFuncGetName(const char **name, CUfunction hfunc);
 
 /**
  * @disabled

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -22,7 +22,6 @@ from ops import (
     NullableArrayOperation,
     DeepStructOperation,
     NullTerminatedOperation,
-    ReturnedStringOperation,
     OpaqueTypeOperation,
     DereferenceOperation,
     Operation,
@@ -616,23 +615,14 @@ def parse_annotation(
                                 "received NULL_TERMINATED parameters must be "
                                 "RECV_ONLY const char **"
                             )
-                        operations.append(
-                            ReturnedStringOperation(
-                                send=send,
-                                recv=recv,
-                                parameter=param,
-                                ptr=param.type,
-                            )
+                    operations.append(
+                        NullTerminatedOperation(
+                            send=send,
+                            recv=recv,
+                            parameter=param,
+                            ptr=param.type,
                         )
-                    else:
-                        operations.append(
-                            NullTerminatedOperation(
-                                send=send,
-                                recv=recv,
-                                parameter=param,
-                                ptr=param.type,
-                            )
-                        )
+                    )
                 elif nullable:
                     # if it's nullable, it's a nullable operation
                     operations.append(
@@ -1720,25 +1710,20 @@ def main():
                     isinstance(operation, InOutCountOperation)
                     or isinstance(operation, NullableArrayOperation)
                     or isinstance(operation, DeepStructOperation)
-                    or isinstance(operation, ReturnedStringOperation)
+                    or (
+                        isinstance(operation, NullTerminatedOperation)
+                        and operation.recv
+                    )
                 ):
                     f.write(operation.client_declaration())
 
-            # compute the strlen's for null-terminated operations.
             for operation in operations:
-                if isinstance(operation, NullTerminatedOperation):
-                    if operation.send:
-                        f.write(
-                            "    std::size_t {param_name}_len = std::strlen({param_name}) + 1;\n".format(
-                                param_name=operation.parameter.name
-                            )
+                if isinstance(operation, NullTerminatedOperation) and operation.send:
+                    f.write(
+                        "    std::size_t {param_name}_len = std::strlen({param_name}) + 1;\n".format(
+                            param_name=operation.parameter.name
                         )
-                    else:
-                        f.write(
-                            "    std::size_t {param_name}_len;\n".format(
-                                param_name=operation.parameter.name
-                            )
-                        )
+                    )
                 if isinstance(operation, NullableOperation) and operation.recv:
                     f.write(
                         "    {server_type} {param_name}_null_check;\n".format(
@@ -1756,7 +1741,10 @@ def main():
                     operation.client_preflight(
                         f, invalid_argument_const(function.return_type.format())
                     )
-                elif isinstance(operation, ReturnedStringOperation):
+                elif (
+                    isinstance(operation, NullTerminatedOperation)
+                    and operation.recv
+                ):
                     operation.client_preflight(
                         f, invalid_argument_const(function.return_type.format())
                     )
@@ -1818,7 +1806,7 @@ def main():
             )
 
             for operation in operations:
-                if isinstance(operation, ReturnedStringOperation):
+                if isinstance(operation, NullTerminatedOperation) and operation.recv:
                     operation.client_post_rpc(f, "CUDA_SUCCESS")
 
             write_client_post_call(f, function, metadata)
@@ -1910,7 +1898,6 @@ def main():
             "#include <cuda.h>\n"
             '#include "cuda_compat.h"\n'
             "\n"
-            "#include <cstdint>\n"
             "#include <cstring>\n"
             "#include <string>\n"
             '#include "gen_rpc_ids.h"\n\n'

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -27,6 +27,8 @@ from ops import (
     Operation,
     OwnerAnnotation,
     RetainAnnotation,
+    ReleaseAnnotation,
+    ParentAnnotation,
     CrossServerCopyAnnotation,
     DevicePtrTranslationAnnotation,
     FunctionAnnotationMetadata,
@@ -481,6 +483,31 @@ def parse_annotation(
                 RetainAnnotation(
                     parameter=annotation_param(params, parts[1]),
                     handle=annotation_param(params, parts[2]),
+                )
+            )
+            continue
+        if line.startswith("@release"):
+            parts = line.split()
+            if len(parts) != 3:
+                raise RuntimeError("@release requires a handle kind and parameter")
+            metadata.releases.append(
+                ReleaseAnnotation(
+                    kind=parts[1].upper(),
+                    parameter=annotation_param(params, parts[2]),
+                )
+            )
+            continue
+        if line.startswith("@recordparent"):
+            parts = line.split()
+            if len(parts) != 4:
+                raise RuntimeError(
+                    "@recordparent requires a parent kind, child, and parent"
+                )
+            metadata.parents.append(
+                ParentAnnotation(
+                    kind=parts[1].upper(),
+                    child=annotation_param(params, parts[2]),
+                    parent=annotation_param(params, parts[3]),
                 )
             )
             continue
@@ -983,6 +1010,30 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
 
     for owner in metadata.record_owners:
         f.write(client_record_owner_stmt(owner))
+    for parent in metadata.parents:
+        if parent.kind != "LIBRARY":
+            raise NotImplementedError(
+                f"Unsupported recorded parent kind: {parent.kind}"
+            )
+        f.write(
+            f"    if (return_value == CUDA_SUCCESS && "
+            f"{parent.child.name} != nullptr) "
+            f"lupine_record_library_module(*{parent.child.name}, "
+            f"{parent.parent.name});\n"
+        )
+    for release in metadata.releases:
+        if release.kind == "MODULE":
+            release_fn = "lupine_release_module_retained_strings"
+        elif release.kind == "LIBRARY":
+            release_fn = "lupine_release_library_retained_strings"
+        else:
+            raise NotImplementedError(
+                f"Unsupported retained-string release kind: {release.kind}"
+            )
+        f.write(
+            f"    if (return_value == CUDA_SUCCESS) "
+            f"{release_fn}({release.parameter.name});\n"
+        )
 
     if function.name.format() == "cuMemAlloc_v2":
         f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr) lupine_note_deviceptr_allocation_route(*dptr, bytesize, route);\n")
@@ -1562,6 +1613,9 @@ def main():
             'extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);\n\n'
             'extern "C" void lupine_forget_stream_owner(CUstream stream);\n\n'
             'extern "C" const char *lupine_retain_returned_string(const void *handle, const char *data, size_t size);\n\n'
+            'extern "C" void lupine_release_module_retained_strings(CUmodule module);\n'
+            'extern "C" void lupine_release_library_retained_strings(CUlibrary library);\n\n'
+            'extern "C" void lupine_record_library_module(CUmodule module, CUlibrary library);\n\n'
             'extern "C" CUresult lupine_record_library_kernel(CUkernel kernel, CUlibrary library, const char *name, lupine_route route);\n\n'
             'extern "C" CUresult lupine_record_module_function(CUfunction function, CUmodule module, const char *name, lupine_route route);\n\n'
             'extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first, CUdeviceptr second);\n'

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -22,6 +22,7 @@ from ops import (
     NullableArrayOperation,
     DeepStructOperation,
     NullTerminatedOperation,
+    ReturnedStringOperation,
     OpaqueTypeOperation,
     DereferenceOperation,
     Operation,
@@ -606,18 +607,32 @@ def parse_annotation(
                     )
                 elif null_terminated:
                     if recv:
-                        raise NotImplementedError(
-                            "NULL_TERMINATED parameters cannot be received; use LENGTH or SIZE for output buffers"
+                        if (
+                            send
+                            or not isinstance(param.type.ptr_to, Pointer)
+                            or param.type.ptr_to.ptr_to.format() != "const char"
+                        ):
+                            raise NotImplementedError(
+                                "received NULL_TERMINATED parameters must be "
+                                "RECV_ONLY const char **"
+                            )
+                        operations.append(
+                            ReturnedStringOperation(
+                                send=send,
+                                recv=recv,
+                                parameter=param,
+                                ptr=param.type,
+                            )
                         )
-                    # if it's null terminated, it's a null terminated operation
-                    operations.append(
-                        NullTerminatedOperation(
-                            send=send,
-                            recv=recv,
-                            parameter=param,
-                            ptr=param.type,
+                    else:
+                        operations.append(
+                            NullTerminatedOperation(
+                                send=send,
+                                recv=recv,
+                                parameter=param,
+                                ptr=param.type,
+                            )
                         )
-                    )
                 elif nullable:
                     # if it's nullable, it's a nullable operation
                     operations.append(
@@ -850,6 +865,8 @@ def client_routing_key_expr(
     if kind == "LIBRARY":
         return f"lupine_route_for_library({name})"
     if kind == "FUNCTION":
+        if param.type.format() == "CUkernel":
+            name = f"reinterpret_cast<CUfunction>({name})"
         return f"lupine_route_for_function({name})"
     if kind == "STREAM":
         if metadata.routing_fallback is not None:
@@ -1493,8 +1510,10 @@ def main():
             "#include <cstdint>\n"
             "#include <cstdio>\n"
             "#include <cstring>\n"
+            "#include <mutex>\n"
             "#include <string>\n"
             "#include <unordered_map>\n"
+            "#include <unordered_set>\n"
             "#include <vector>\n\n"
             '#include "gen_rpc_ids.h"\n\n'
             '#include "client_routing.h"\n'
@@ -1548,6 +1567,12 @@ def main():
             'extern "C" int lupine_forward_remote_stdout(conn_t *conn);\n'
             'extern "C" CUresult lupine_sync_mapped_device_to_host();\n'
             'extern "C" const void *lupine_mapped_host_read_source(const void *host, size_t size);\n\n'
+            'static const char *lupine_intern_returned_string(const std::string &value) {\n'
+            '    static auto *mutex = new std::mutex();\n'
+            '    static auto *strings = new std::unordered_set<std::string>();\n'
+            '    std::lock_guard<std::mutex> lock(*mutex);\n'
+            '    return strings->insert(value).first->c_str();\n'
+            '}\n\n'
         )
         for function, annotation, operations, metadata in functions_with_annotations:
             # We don't generate client function definitions for client-disabled
@@ -1695,6 +1720,7 @@ def main():
                     isinstance(operation, InOutCountOperation)
                     or isinstance(operation, NullableArrayOperation)
                     or isinstance(operation, DeepStructOperation)
+                    or isinstance(operation, ReturnedStringOperation)
                 ):
                     f.write(operation.client_declaration())
 
@@ -1727,6 +1753,10 @@ def main():
             # themselves are allowed to fail the builder.
             for operation in operations:
                 if isinstance(operation, ArrayOperation):
+                    operation.client_preflight(
+                        f, invalid_argument_const(function.return_type.format())
+                    )
+                elif isinstance(operation, ReturnedStringOperation):
                     operation.client_preflight(
                         f, invalid_argument_const(function.return_type.format())
                     )
@@ -1786,6 +1816,10 @@ def main():
                     error_return=error_const(function.return_type.format())
                 )
             )
+
+            for operation in operations:
+                if isinstance(operation, ReturnedStringOperation):
+                    operation.client_post_rpc(f, "CUDA_SUCCESS")
 
             write_client_post_call(f, function, metadata)
             f.write("    return return_value;\n")
@@ -1876,6 +1910,7 @@ def main():
             "#include <cuda.h>\n"
             '#include "cuda_compat.h"\n'
             "\n"
+            "#include <cstdint>\n"
             "#include <cstring>\n"
             "#include <string>\n"
             '#include "gen_rpc_ids.h"\n\n'

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -26,6 +26,7 @@ from ops import (
     DereferenceOperation,
     Operation,
     OwnerAnnotation,
+    RetainAnnotation,
     CrossServerCopyAnnotation,
     DevicePtrTranslationAnnotation,
     FunctionAnnotationMetadata,
@@ -472,6 +473,17 @@ def parse_annotation(
             param = annotation_param(params, parts[2])
             metadata.record_owners.append(OwnerAnnotation(parts[1].upper(), param))
             continue
+        if line.startswith("@retain"):
+            parts = line.split()
+            if len(parts) != 3:
+                raise RuntimeError("@retain requires an output parameter and a handle")
+            metadata.retains.append(
+                RetainAnnotation(
+                    parameter=annotation_param(params, parts[1]),
+                    handle=annotation_param(params, parts[2]),
+                )
+            )
+            continue
         if line.startswith("@crossservercopy"):
             parts = line.split()
             if len(parts) < 4:
@@ -818,6 +830,20 @@ def parse_annotation(
         )
         if source is not None and source > i:
             operations.insert(i, operations.pop(source))
+
+    retained_names = set()
+    for retain in metadata.retains:
+        name = retain.parameter.name
+        if name in retained_names:
+            raise RuntimeError(f"Duplicate @retain for parameter {name}")
+        retained_names.add(name)
+        operation = next(
+            (op for op in operations if op.parameter.name == name), None
+        )
+        if not isinstance(operation, NullTerminatedOperation) or not operation.recv:
+            raise NotImplementedError(
+                "@retain currently requires a RECV_ONLY NULL_TERMINATED parameter"
+            )
 
     if metadata.routing_kind is None:
         metadata.routing_kind, metadata.routing_parameter = infer_routing_key(params)
@@ -1500,10 +1526,8 @@ def main():
             "#include <cstdint>\n"
             "#include <cstdio>\n"
             "#include <cstring>\n"
-            "#include <mutex>\n"
             "#include <string>\n"
             "#include <unordered_map>\n"
-            "#include <unordered_set>\n"
             "#include <vector>\n\n"
             '#include "gen_rpc_ids.h"\n\n'
             '#include "client_routing.h"\n'
@@ -1537,6 +1561,7 @@ def main():
             'extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size, conn_t *conn);\n\n'
             'extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);\n\n'
             'extern "C" void lupine_forget_stream_owner(CUstream stream);\n\n'
+            'extern "C" const char *lupine_retain_returned_string(const void *handle, const char *data, size_t size);\n\n'
             'extern "C" CUresult lupine_record_library_kernel(CUkernel kernel, CUlibrary library, const char *name, lupine_route route);\n\n'
             'extern "C" CUresult lupine_record_module_function(CUfunction function, CUmodule module, const char *name, lupine_route route);\n\n'
             'extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first, CUdeviceptr second);\n'
@@ -1557,12 +1582,6 @@ def main():
             'extern "C" int lupine_forward_remote_stdout(conn_t *conn);\n'
             'extern "C" CUresult lupine_sync_mapped_device_to_host();\n'
             'extern "C" const void *lupine_mapped_host_read_source(const void *host, size_t size);\n\n'
-            'static const char *lupine_intern_returned_string(const std::string &value) {\n'
-            '    static auto *mutex = new std::mutex();\n'
-            '    static auto *strings = new std::unordered_set<std::string>();\n'
-            '    std::lock_guard<std::mutex> lock(*mutex);\n'
-            '    return strings->insert(value).first->c_str();\n'
-            '}\n\n'
         )
         for function, annotation, operations, metadata in functions_with_annotations:
             # We don't generate client function definitions for client-disabled
@@ -1807,7 +1826,24 @@ def main():
 
             for operation in operations:
                 if isinstance(operation, NullTerminatedOperation) and operation.recv:
-                    operation.client_post_rpc(f, "CUDA_SUCCESS")
+                    retain = next(
+                        (
+                            item
+                            for item in metadata.retains
+                            if item.parameter.name == operation.parameter.name
+                        ),
+                        None,
+                    )
+                    if retain is None:
+                        raise RuntimeError(
+                            f"{function.name.format()}: returned string requires @retain"
+                        )
+                    operation.client_post_rpc(
+                        f,
+                        "CUDA_SUCCESS",
+                        "CUDA_ERROR_OUT_OF_MEMORY",
+                        retain.handle.name,
+                    )
 
             write_client_post_call(f, function, metadata)
             f.write("    return return_value;\n")

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -1057,14 +1057,14 @@ CUresult cuKernelGetName(const char **name, CUkernel hfunc) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  std::uint32_t name_len = 0;
+  std::size_t name_len = 0;
   std::string name_result;
   if (name == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (rpc_write_start_request(conn, RPC_cuKernelGetName) < 0 ||
       rpc_write(conn, &hfunc, sizeof(CUkernel)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &name_len, sizeof(std::uint32_t)) < 0 ||
+      rpc_read(conn, &name_len, sizeof(std::size_t)) < 0 ||
       name_len > (1U << 20) || (name_result.resize(name_len), false) ||
       (name_len != 0 && rpc_read(conn, name_result.data(), name_len) < 0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3574,7 +3574,7 @@ CUresult cuFuncGetName(const char **name, CUfunction hfunc) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  std::uint32_t name_len = 0;
+  std::size_t name_len = 0;
   std::string name_result;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (name == nullptr)
@@ -3582,7 +3582,7 @@ CUresult cuFuncGetName(const char **name, CUfunction hfunc) {
   if (rpc_write_start_request(conn, RPC_cuFuncGetName) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &name_len, sizeof(std::uint32_t)) < 0 ||
+      rpc_read(conn, &name_len, sizeof(std::size_t)) < 0 ||
       name_len > (1U << 20) || (name_result.resize(name_len), false) ||
       (name_len != 0 && rpc_read(conn, name_result.data(), name_len) < 0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -8,10 +8,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <mutex>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "gen_rpc_ids.h"
@@ -54,6 +52,10 @@ extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);
 
 extern "C" void lupine_forget_stream_owner(CUstream stream);
 
+extern "C" const char *lupine_retain_returned_string(const void *handle,
+                                                     const char *data,
+                                                     size_t size);
+
 extern "C" CUresult lupine_record_library_kernel(CUkernel kernel,
                                                  CUlibrary library,
                                                  const char *name,
@@ -86,13 +88,6 @@ extern "C" int lupine_forward_remote_stdout(conn_t *conn);
 extern "C" CUresult lupine_sync_mapped_device_to_host();
 extern "C" const void *lupine_mapped_host_read_source(const void *host,
                                                       size_t size);
-
-static const char *lupine_intern_returned_string(const std::string &value) {
-  static auto *mutex = new std::mutex();
-  static auto *strings = new std::unordered_set<std::string>();
-  std::lock_guard<std::mutex> lock(*mutex);
-  return strings->insert(value).first->c_str();
-}
 
 CUresult cuDriverGetVersion(int *driverVersion) {
   lupine_route route = lupine_route_for_default();
@@ -1061,7 +1056,7 @@ CUresult cuKernelGetName(const char **name, CUkernel hfunc) {
   std::string name_result;
   if (name == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuKernelGetName) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuKernelGetName) < 0 ||
       rpc_write(conn, &hfunc, sizeof(CUkernel)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &name_len, sizeof(std::size_t)) < 0 ||
@@ -1070,8 +1065,14 @@ CUresult cuKernelGetName(const char **name, CUkernel hfunc) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS)
-    *name = lupine_intern_returned_string(name_result);
+  if (return_value == CUDA_SUCCESS) {
+    const char *name_stored =
+        lupine_retain_returned_string(reinterpret_cast<const void *>(hfunc),
+                                      name_result.data(), name_result.size());
+    if (name_stored == nullptr)
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    *name = name_stored;
+  }
   return return_value;
 }
 
@@ -3579,7 +3580,7 @@ CUresult cuFuncGetName(const char **name, CUfunction hfunc) {
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (name == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuFuncGetName) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuFuncGetName) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &name_len, sizeof(std::size_t)) < 0 ||
@@ -3588,8 +3589,14 @@ CUresult cuFuncGetName(const char **name, CUfunction hfunc) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS)
-    *name = lupine_intern_returned_string(name_result);
+  if (return_value == CUDA_SUCCESS) {
+    const char *name_stored =
+        lupine_retain_returned_string(reinterpret_cast<const void *>(hfunc),
+                                      name_result.data(), name_result.size());
+    if (name_stored == nullptr)
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    *name = name_stored;
+  }
   return return_value;
 }
 

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -8,8 +8,10 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "gen_rpc_ids.h"
@@ -84,6 +86,13 @@ extern "C" int lupine_forward_remote_stdout(conn_t *conn);
 extern "C" CUresult lupine_sync_mapped_device_to_host();
 extern "C" const void *lupine_mapped_host_read_source(const void *host,
                                                       size_t size);
+
+static const char *lupine_intern_returned_string(const std::string &value) {
+  static auto *mutex = new std::mutex();
+  static auto *strings = new std::unordered_set<std::string>();
+  std::lock_guard<std::mutex> lock(*mutex);
+  return strings->insert(value).first->c_str();
+}
 
 CUresult cuDriverGetVersion(int *driverVersion) {
   lupine_route route = lupine_route_for_default();
@@ -1036,6 +1045,37 @@ CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   return return_value;
 }
+
+#if CUDA_VERSION >= 12030
+CUresult cuKernelGetName(const char **name, CUkernel hfunc) {
+  lupine_route route =
+      lupine_route_for_function(reinterpret_cast<CUfunction>(hfunc));
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(const char **, CUkernel);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuKernelGetName",
+                                                  &return_value, name, hfunc)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  std::uint32_t name_len = 0;
+  std::string name_result;
+  if (name == nullptr)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (rpc_write_start_request(conn, RPC_cuKernelGetName) < 0 ||
+      rpc_write(conn, &hfunc, sizeof(CUkernel)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &name_len, sizeof(std::uint32_t)) < 0 ||
+      name_len > (1U << 20) || (name_result.resize(name_len), false) ||
+      (name_len != 0 && rpc_read(conn, name_result.data(), name_len) < 0) ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    *name = lupine_intern_returned_string(name_result);
+  return return_value;
+}
+
+#endif
 
 CUresult cuMemGetInfo_v2(size_t *free, size_t *total) {
   lupine_route route = lupine_route_for_current_context();
@@ -3523,6 +3563,37 @@ CUresult cuFuncGetModule(CUmodule *hmod, CUfunction hfunc) {
   }
   return return_value;
 }
+
+#if CUDA_VERSION >= 12030
+CUresult cuFuncGetName(const char **name, CUfunction hfunc) {
+  lupine_route route = lupine_route_for_function(hfunc);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(const char **, CUfunction);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuFuncGetName",
+                                                  &return_value, name, hfunc)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  std::uint32_t name_len = 0;
+  std::string name_result;
+  CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
+  if (name == nullptr)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (rpc_write_start_request(conn, RPC_cuFuncGetName) < 0 ||
+      rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &name_len, sizeof(std::uint32_t)) < 0 ||
+      name_len > (1U << 20) || (name_result.resize(name_len), false) ||
+      (name_len != 0 && rpc_read(conn, name_result.data(), name_len) < 0) ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    *name = lupine_intern_returned_string(name_result);
+  return return_value;
+}
+
+#endif
 
 CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
   lupine_route route = lupine_route_for_function(hfunc);
@@ -7233,6 +7304,9 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuKernelGetAttribute", (void *)cuKernelGetAttribute},
     {"cuKernelSetAttribute", (void *)cuKernelSetAttribute},
     {"cuKernelSetCacheConfig", (void *)cuKernelSetCacheConfig},
+#if CUDA_VERSION >= 12030
+    {"cuKernelGetName", (void *)cuKernelGetName},
+#endif
     {"cuKernelGetParamInfo", (void *)cuKernelGetParamInfo},
     {"cuMemGetInfo_v2", (void *)cuMemGetInfo_v2},
     {"cuMemAlloc_v2", (void *)cuMemAlloc_v2},
@@ -7356,6 +7430,9 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuFuncSetAttribute", (void *)cuFuncSetAttribute},
     {"cuFuncSetCacheConfig", (void *)cuFuncSetCacheConfig},
     {"cuFuncGetModule", (void *)cuFuncGetModule},
+#if CUDA_VERSION >= 12030
+    {"cuFuncGetName", (void *)cuFuncGetName},
+#endif
     {"cuFuncGetParamInfo", (void *)cuFuncGetParamInfo},
     {"cuLaunchCooperativeKernel", (void *)cuLaunchCooperativeKernel},
     {"cuFuncSetBlockShape", (void *)cuFuncSetBlockShape},

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -56,6 +56,12 @@ extern "C" const char *lupine_retain_returned_string(const void *handle,
                                                      const char *data,
                                                      size_t size);
 
+extern "C" void lupine_release_module_retained_strings(CUmodule module);
+extern "C" void lupine_release_library_retained_strings(CUlibrary library);
+
+extern "C" void lupine_record_library_module(CUmodule module,
+                                             CUlibrary library);
+
 extern "C" CUresult lupine_record_library_kernel(CUkernel kernel,
                                                  CUlibrary library,
                                                  const char *name,
@@ -662,6 +668,8 @@ CUresult cuModuleUnload(CUmodule hmod) {
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuModuleUnload",
                                                   &return_value, hmod)) {
     if (return_value == CUDA_SUCCESS)
+      lupine_release_module_retained_strings(hmod);
+    if (return_value == CUDA_SUCCESS)
       lupine_invalidate_function_caches();
     return return_value;
   }
@@ -672,6 +680,8 @@ CUresult cuModuleUnload(CUmodule hmod) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    lupine_release_module_retained_strings(hmod);
   if (return_value == CUDA_SUCCESS)
     lupine_invalidate_function_caches();
   return return_value;
@@ -841,6 +851,8 @@ CUresult cuLibraryUnload(CUlibrary library) {
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryUnload",
                                                   &return_value, library)) {
     if (return_value == CUDA_SUCCESS)
+      lupine_release_library_retained_strings(library);
+    if (return_value == CUDA_SUCCESS)
       lupine_invalidate_function_caches();
     return return_value;
   }
@@ -851,6 +863,8 @@ CUresult cuLibraryUnload(CUlibrary library) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   return_value = CUDA_SUCCESS;
+  if (return_value == CUDA_SUCCESS)
+    lupine_release_library_retained_strings(library);
   if (return_value == CUDA_SUCCESS)
     lupine_invalidate_function_caches();
   return return_value;
@@ -865,6 +879,8 @@ CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
     if (return_value == CUDA_SUCCESS && pMod != nullptr) {
       lupine_note_module_owner_route(*pMod, route);
     }
+    if (return_value == CUDA_SUCCESS && pMod != nullptr)
+      lupine_record_library_module(*pMod, library);
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -878,6 +894,8 @@ CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
   if (return_value == CUDA_SUCCESS && pMod != nullptr) {
     lupine_note_module_owner_route(*pMod, route);
   }
+  if (return_value == CUDA_SUCCESS && pMod != nullptr)
+    lupine_record_library_module(*pMod, library);
   return return_value;
 }
 
@@ -6527,7 +6545,7 @@ CUresult cuGreenCtxCreate(CUgreenCtx *phCtx, CUdevResourceDesc desc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGreenCtxCreate) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGreenCtxCreate) < 0 ||
       rpc_write(conn, &desc, sizeof(CUdevResourceDesc)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
@@ -6553,7 +6571,7 @@ CUresult cuGreenCtxDestroy(CUgreenCtx hCtx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuGreenCtxDestroy) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuGreenCtxDestroy) < 0 ||
       rpc_write(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6581,7 +6599,7 @@ CUresult cuCtxFromGreenCtx(CUcontext *pContext, CUgreenCtx hCtx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxFromGreenCtx) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxFromGreenCtx) < 0 ||
       rpc_write(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pContext, sizeof(CUcontext)) < 0 ||
@@ -6612,7 +6630,7 @@ CUresult cuDeviceGetDevResource(CUdevice device, CUdevResource *resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuDeviceGetDevResource) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetDevResource) < 0 ||
       rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &type, sizeof(CUdevResourceType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6636,7 +6654,7 @@ CUresult cuCtxGetDevResource(CUcontext hCtx, CUdevResource *resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuCtxGetDevResource) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetDevResource) < 0 ||
       rpc_write(conn, &hCtx, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &type, sizeof(CUdevResourceType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6693,7 +6711,7 @@ CUresult cuDevSmResourceSplitByCount(
   unsigned int nbGroups_requested = (result != nullptr) ? *nbGroups : 0;
   uint8_t result_null = result == nullptr ? 1 : 0;
   CUdevResource *remainder_null_check;
-  if (rpc_write_start_request(conn, RPC_cuDevSmResourceSplitByCount) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDevSmResourceSplitByCount) < 0 ||
       rpc_write(conn, &nbGroups_requested, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &result_null, sizeof(uint8_t)) < 0 ||
       rpc_write(conn, input, sizeof(const CUdevResource)) < 0 ||
@@ -6739,7 +6757,7 @@ CUresult cuDevSmResourceSplit(CUdevResource *result, unsigned int nbGroups,
   if (nbGroups * sizeof(CU_DEV_SM_RESOURCE_GROUP_PARAMS) != 0 &&
       groupParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuDevSmResourceSplit) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDevSmResourceSplit) < 0 ||
       rpc_write(conn, &nbGroups, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &result_null, sizeof(uint8_t)) < 0 ||
       rpc_write(conn, input, sizeof(const CUdevResource)) < 0 ||
@@ -6780,7 +6798,7 @@ CUresult cuDevResourceGenerateDesc(CUdevResourceDesc *phDesc,
   conn_t *conn = lupine_route_remote_conn(route);
   if (nbResources * sizeof(CUdevResource) != 0 && resources == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (rpc_write_start_request(conn, RPC_cuDevResourceGenerateDesc) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuDevResourceGenerateDesc) < 0 ||
       rpc_write(conn, &nbResources, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, resources, nbResources * sizeof(CUdevResource)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6861,7 +6879,7 @@ CUresult cuStreamGetDevResource(CUstream hStream, CUdevResource *resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuStreamGetDevResource) < 0 ||
+  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetDevResource) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &type, sizeof(CUdevResourceType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "gen_rpc_ids.h"
+#include <cstdint>
 #include <cstring>
 #include <string>
 
@@ -1443,6 +1444,39 @@ int handle_cuKernelSetCacheConfig(conn_t *conn) {
 ERROR_0:
   return -1;
 }
+
+#if CUDA_VERSION >= 12030
+int handle_cuKernelGetName(conn_t *conn) {
+  const char *name = nullptr;
+  std::uint32_t name_len = 0;
+  CUkernel hfunc;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hfunc, sizeof(CUkernel)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuKernelGetName(&name, hfunc);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      ((name_len = name != nullptr
+                       ? static_cast<std::uint32_t>(std::strlen(name))
+                       : 0),
+       false) ||
+      rpc_write(conn, &name_len, sizeof(std::uint32_t)) < 0 ||
+      (name_len != 0 && rpc_write(conn, name, name_len) < 0) ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
 
 int handle_cuKernelGetParamInfo(conn_t *conn) {
   CUkernel kernel;
@@ -4311,6 +4345,39 @@ int handle_cuFuncGetModule(conn_t *conn) {
 ERROR_0:
   return -1;
 }
+
+#if CUDA_VERSION >= 12030
+int handle_cuFuncGetName(conn_t *conn) {
+  const char *name = nullptr;
+  std::uint32_t name_len = 0;
+  CUfunction hfunc;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hfunc, sizeof(CUfunction)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuFuncGetName(&name, hfunc);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      ((name_len = name != nullptr
+                       ? static_cast<std::uint32_t>(std::strlen(name))
+                       : 0),
+       false) ||
+      rpc_write(conn, &name_len, sizeof(std::uint32_t)) < 0 ||
+      (name_len != 0 && rpc_write(conn, name, name_len) < 0) ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
 
 int handle_cuFuncGetParamInfo(conn_t *conn) {
   CUfunction func;

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -3,7 +3,6 @@
 #include <iostream>
 
 #include "gen_rpc_ids.h"
-#include <cstdint>
 #include <cstring>
 #include <string>
 
@@ -1448,7 +1447,7 @@ ERROR_0:
 #if CUDA_VERSION >= 12030
 int handle_cuKernelGetName(conn_t *conn) {
   const char *name = nullptr;
-  std::uint32_t name_len = 0;
+  std::size_t name_len = 0;
   CUkernel hfunc;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1461,11 +1460,10 @@ int handle_cuKernelGetName(conn_t *conn) {
   lupine_intercept_result = cuKernelGetName(&name, hfunc);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      ((name_len = name != nullptr
-                       ? static_cast<std::uint32_t>(std::strlen(name))
-                       : 0),
+      ((name_len =
+            name != nullptr ? static_cast<std::size_t>(std::strlen(name)) : 0),
        false) ||
-      rpc_write(conn, &name_len, sizeof(std::uint32_t)) < 0 ||
+      rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       (name_len != 0 && rpc_write(conn, name, name_len) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
@@ -4349,7 +4347,7 @@ ERROR_0:
 #if CUDA_VERSION >= 12030
 int handle_cuFuncGetName(conn_t *conn) {
   const char *name = nullptr;
-  std::uint32_t name_len = 0;
+  std::size_t name_len = 0;
   CUfunction hfunc;
   int request_id;
   CUresult lupine_intercept_result;
@@ -4362,11 +4360,10 @@ int handle_cuFuncGetName(conn_t *conn) {
   lupine_intercept_result = cuFuncGetName(&name, hfunc);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      ((name_len = name != nullptr
-                       ? static_cast<std::uint32_t>(std::strlen(name))
-                       : 0),
+      ((name_len =
+            name != nullptr ? static_cast<std::size_t>(std::strlen(name)) : 0),
        false) ||
-      rpc_write(conn, &name_len, sizeof(std::uint32_t)) < 0 ||
+      rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       (name_len != 0 && rpc_write(conn, name, name_len) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)

--- a/codegen/gen_rpc_ids.h
+++ b/codegen/gen_rpc_ids.h
@@ -77,6 +77,7 @@
 #define RPC_cuKernelGetAttribute 1724498758
 #define RPC_cuKernelSetAttribute 1775703493
 #define RPC_cuKernelSetCacheConfig 1572033421
+#define RPC_cuKernelGetName 1923872670
 #define RPC_cuKernelGetParamInfo 89830551
 #define RPC_cuMemGetInfo_v2 969693882
 #define RPC_cuMemAlloc_v2 892243478
@@ -216,6 +217,7 @@
 #define RPC_cuFuncSetAttribute 1296138514
 #define RPC_cuFuncSetCacheConfig 1688761246
 #define RPC_cuFuncGetModule 1933245726
+#define RPC_cuFuncGetName 1852767197
 #define RPC_cuFuncGetParamInfo 567025728
 #define RPC_cuLaunchKernel 732897317
 #define RPC_cuLaunchKernelEx 1100221233

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -1123,6 +1123,19 @@ class RetainAnnotation:
 
 
 @dataclass
+class ReleaseAnnotation:
+    kind: str
+    parameter: Parameter
+
+
+@dataclass
+class ParentAnnotation:
+    kind: str
+    child: Parameter
+    parent: Parameter
+
+
+@dataclass
 class CrossServerCopyAnnotation:
     dst: Parameter
     src: Parameter
@@ -1164,6 +1177,8 @@ class FunctionAnnotationMetadata:
     routing_fallback: Optional[RoutingFallbackAnnotation] = None
     record_owners: list[OwnerAnnotation] = None
     retains: list[RetainAnnotation] = None
+    releases: list[ReleaseAnnotation] = None
+    parents: list[ParentAnnotation] = None
     cross_server_copy: Optional[CrossServerCopyAnnotation] = None
     translate_deviceptrs: list[DevicePtrTranslationAnnotation] = None
 
@@ -1172,5 +1187,9 @@ class FunctionAnnotationMetadata:
             self.record_owners = []
         if self.retains is None:
             self.retains = []
+        if self.releases is None:
+            self.releases = []
+        if self.parents is None:
+            self.parents = []
         if self.translate_deviceptrs is None:
             self.translate_deviceptrs = []

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -786,7 +786,8 @@ class DeepStructOperation:
 @dataclass
 class NullTerminatedOperation:
     """
-    Null terminated operations are operations that are passed as a null terminated string.
+    A null-terminated input string or a driver-owned string returned through
+    ``const char **``.
     """
 
     send: bool
@@ -794,6 +795,13 @@ class NullTerminatedOperation:
     parameter: Parameter
     ptr: Pointer
     length_type: str = "std::size_t"
+
+    def client_declaration(self) -> str:
+        name = self.parameter.name
+        return (
+            f"    {self.length_type} {name}_len = 0;\n"
+            f"    std::string {name}_result;\n"
+        )
 
     def client_rpc_write(self, f):
         if not self.send:
@@ -812,9 +820,19 @@ class NullTerminatedOperation:
 
     @property
     def server_declaration(self) -> str:
+        type_ = self.ptr.ptr_to.format() if self.recv else self.ptr.format()
+        initializer = " = 0" if self.recv else ""
         return (
-            f"    {self.ptr.format()} {self.parameter.name} = nullptr;\n"
-            + f"    {self.length_type} {self.parameter.name}_len;\n"
+            f"    {type_} {self.parameter.name} = nullptr;\n"
+            + f"    {self.length_type} {self.parameter.name}_len{initializer};\n"
+        )
+
+    def client_preflight(self, f, error_return: str):
+        if not self.recv:
+            return
+        f.write(
+            f"    if ({self.parameter.name} == nullptr)\n"
+            f"        return {error_return};\n"
         )
 
     def client_unified_copy(self, f, direction, error):
@@ -851,86 +869,13 @@ class NullTerminatedOperation:
 
     @property
     def server_reference(self) -> str:
+        if self.recv:
+            return f"&{self.parameter.name}"
         return self.parameter.name
 
     def server_rpc_write(self, f):
         if not self.recv:
             return
-        f.write(
-            "        rpc_write(conn, &{param_name}_len, sizeof({length_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                length_type=self.length_type,
-            )
-        )
-        f.write(
-            "        rpc_write(conn, {param_name}, {param_name}_len) < 0 ||\n".format(
-                param_name=self.parameter.name,
-            )
-        )
-
-    def client_rpc_read(self, f):
-        if not self.recv:
-            return
-        f.write(
-            "        rpc_read(conn, &{param_name}_len, sizeof({length_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                length_type=self.length_type,
-            )
-        )
-        f.write(
-            "        rpc_read(conn, {param_name}, {param_name}_len) < 0 ||\n".format(
-                param_name=self.parameter.name
-            )
-        )
-
-
-@dataclass
-class ReturnedStringOperation:
-    """A driver-owned null-terminated string returned through ``const char **``.
-
-    The server copies the string as length-prefixed bytes. The generated client
-    interns successful results so the pointer handed to the caller remains
-    valid after the RPC wrapper returns.
-    """
-
-    send: bool
-    recv: bool
-    parameter: Parameter
-    ptr: Pointer
-    length_type: str = "std::uint32_t"
-
-    def client_declaration(self) -> str:
-        name = self.parameter.name
-        return (
-            f"    {self.length_type} {name}_len = 0;\n"
-            f"    std::string {name}_result;\n"
-        )
-
-    def client_preflight(self, f, error_return: str):
-        f.write(
-            f"    if ({self.parameter.name} == nullptr)\n"
-            f"        return {error_return};\n"
-        )
-
-    def client_rpc_write(self, f):
-        return
-
-    @property
-    def server_declaration(self) -> str:
-        name = self.parameter.name
-        return (
-            f"    {self.ptr.ptr_to.format()} {name} = nullptr;\n"
-            f"    {self.length_type} {name}_len = 0;\n"
-        )
-
-    def server_rpc_read(self, f) -> Optional[str]:
-        return None
-
-    @property
-    def server_reference(self) -> str:
-        return f"&{self.parameter.name}"
-
-    def server_rpc_write(self, f):
         name = self.parameter.name
         f.write(
             f"        (({name}_len = {name} != nullptr\n"
@@ -941,6 +886,8 @@ class ReturnedStringOperation:
         )
 
     def client_rpc_read(self, f):
+        if not self.recv:
+            return
         name = self.parameter.name
         f.write(
             f"        rpc_read(conn, &{name}_len, sizeof({self.length_type})) < 0 ||\n"
@@ -951,6 +898,8 @@ class ReturnedStringOperation:
         )
 
     def client_post_rpc(self, f, success_value: str):
+        if not self.recv:
+            return
         name = self.parameter.name
         f.write(
             f"    if (return_value == {success_value})\n"
@@ -1144,7 +1093,6 @@ Operation = Union[
     NullableOperation,
     ArrayOperation,
     NullTerminatedOperation,
-    ReturnedStringOperation,
     OpaqueTypeOperation,
     DereferenceOperation,
 ]

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -897,13 +897,25 @@ class NullTerminatedOperation:
             f"         rpc_read(conn, {name}_result.data(), {name}_len) < 0) ||\n"
         )
 
-    def client_post_rpc(self, f, success_value: str):
+    def client_post_rpc(
+        self,
+        f,
+        success_value: str,
+        allocation_error: str,
+        owner_name: str,
+    ):
         if not self.recv:
             return
         name = self.parameter.name
         f.write(
-            f"    if (return_value == {success_value})\n"
-            f"        *{name} = lupine_intern_returned_string({name}_result);\n"
+            f"    if (return_value == {success_value}) {{\n"
+            f"        const char *{name}_stored = lupine_retain_returned_string(\n"
+            f"            reinterpret_cast<const void *>({owner_name}), "
+            f"{name}_result.data(), {name}_result.size());\n"
+            f"        if ({name}_stored == nullptr)\n"
+            f"            return {allocation_error};\n"
+            f"        *{name} = {name}_stored;\n"
+            "    }\n"
         )
 
 
@@ -1105,6 +1117,12 @@ class OwnerAnnotation:
 
 
 @dataclass
+class RetainAnnotation:
+    parameter: Parameter
+    handle: Parameter
+
+
+@dataclass
 class CrossServerCopyAnnotation:
     dst: Parameter
     src: Parameter
@@ -1145,11 +1163,14 @@ class FunctionAnnotationMetadata:
     routing_parameter: Optional[Parameter] = None
     routing_fallback: Optional[RoutingFallbackAnnotation] = None
     record_owners: list[OwnerAnnotation] = None
+    retains: list[RetainAnnotation] = None
     cross_server_copy: Optional[CrossServerCopyAnnotation] = None
     translate_deviceptrs: list[DevicePtrTranslationAnnotation] = None
 
     def __post_init__(self):
         if self.record_owners is None:
             self.record_owners = []
+        if self.retains is None:
+            self.retains = []
         if self.translate_deviceptrs is None:
             self.translate_deviceptrs = []

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -885,6 +885,80 @@ class NullTerminatedOperation:
 
 
 @dataclass
+class ReturnedStringOperation:
+    """A driver-owned null-terminated string returned through ``const char **``.
+
+    The server copies the string as length-prefixed bytes. The generated client
+    interns successful results so the pointer handed to the caller remains
+    valid after the RPC wrapper returns.
+    """
+
+    send: bool
+    recv: bool
+    parameter: Parameter
+    ptr: Pointer
+    length_type: str = "std::uint32_t"
+
+    def client_declaration(self) -> str:
+        name = self.parameter.name
+        return (
+            f"    {self.length_type} {name}_len = 0;\n"
+            f"    std::string {name}_result;\n"
+        )
+
+    def client_preflight(self, f, error_return: str):
+        f.write(
+            f"    if ({self.parameter.name} == nullptr)\n"
+            f"        return {error_return};\n"
+        )
+
+    def client_rpc_write(self, f):
+        return
+
+    @property
+    def server_declaration(self) -> str:
+        name = self.parameter.name
+        return (
+            f"    {self.ptr.ptr_to.format()} {name} = nullptr;\n"
+            f"    {self.length_type} {name}_len = 0;\n"
+        )
+
+    def server_rpc_read(self, f) -> Optional[str]:
+        return None
+
+    @property
+    def server_reference(self) -> str:
+        return f"&{self.parameter.name}"
+
+    def server_rpc_write(self, f):
+        name = self.parameter.name
+        f.write(
+            f"        (({name}_len = {name} != nullptr\n"
+            f"              ? static_cast<{self.length_type}>(std::strlen({name}))\n"
+            f"              : 0), false) ||\n"
+            f"        rpc_write(conn, &{name}_len, sizeof({self.length_type})) < 0 ||\n"
+            f"        ({name}_len != 0 && rpc_write(conn, {name}, {name}_len) < 0) ||\n"
+        )
+
+    def client_rpc_read(self, f):
+        name = self.parameter.name
+        f.write(
+            f"        rpc_read(conn, &{name}_len, sizeof({self.length_type})) < 0 ||\n"
+            f"        {name}_len > (1U << 20) ||\n"
+            f"        ({name}_result.resize({name}_len), false) ||\n"
+            f"        ({name}_len != 0 &&\n"
+            f"         rpc_read(conn, {name}_result.data(), {name}_len) < 0) ||\n"
+        )
+
+    def client_post_rpc(self, f, success_value: str):
+        name = self.parameter.name
+        f.write(
+            f"    if (return_value == {success_value})\n"
+            f"        *{name} = lupine_intern_returned_string({name}_result);\n"
+        )
+
+
+@dataclass
 class OpaqueTypeOperation:
     """
     Opaque type operations are operations that are passed as an opaque type. That is, the
@@ -1070,6 +1144,7 @@ Operation = Union[
     NullableOperation,
     ArrayOperation,
     NullTerminatedOperation,
+    ReturnedStringOperation,
     OpaqueTypeOperation,
     DereferenceOperation,
 ]

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -458,12 +458,20 @@ LUPINE_DECLARE_HANDLER(RPC_cuTensorMapEncodeTiled,
 LUPINE_DECLARE_HANDLER(RPC_cuCtxGetDevice_v2, handle_cuCtxGetDevice_v2,
                        rpc_backend::cuda)
 #endif
+#if CUDA_VERSION >= 12030
+LUPINE_DECLARE_HANDLER(RPC_cuKernelGetName, handle_cuKernelGetName,
+                       rpc_backend::cuda)
+#endif
 #if CUDA_VERSION >= 12020
 LUPINE_DECLARE_HANDLER(RPC_cuMemPrefetchAsync_v2, handle_cuMemPrefetchAsync_v2,
                        rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12020
 LUPINE_DECLARE_HANDLER(RPC_cuMemAdvise_v2, handle_cuMemAdvise_v2,
+                       rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12030
+LUPINE_DECLARE_HANDLER(RPC_cuFuncGetName, handle_cuFuncGetName,
                        rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
@@ -541,95 +549,108 @@ const rpc_handler_registry &lupine_rpc_handlers() {
                                           handle_cuCtxGetDevice_v2,
                                           rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12020
-                      LUPINE_REGISTER_HANDLER(RPC_cuMemPrefetchAsync_v2,
-                                              handle_cuMemPrefetchAsync_v2,
+#if CUDA_VERSION >= 12030
+                      LUPINE_REGISTER_HANDLER(RPC_cuKernelGetName,
+                                              handle_cuKernelGetName,
                                               rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12020
-                          LUPINE_REGISTER_HANDLER(RPC_cuMemAdvise_v2,
-                                                  handle_cuMemAdvise_v2,
+                          LUPINE_REGISTER_HANDLER(RPC_cuMemPrefetchAsync_v2,
+                                                  handle_cuMemPrefetchAsync_v2,
                                                   rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12040
-                              LUPINE_REGISTER_HANDLER(RPC_cuGreenCtxCreate,
-                                                      handle_cuGreenCtxCreate,
+#if CUDA_VERSION >= 12020
+                              LUPINE_REGISTER_HANDLER(RPC_cuMemAdvise_v2,
+                                                      handle_cuMemAdvise_v2,
                                                       rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12040
-                                  LUPINE_REGISTER_HANDLER(
-                                      RPC_cuGreenCtxDestroy,
-                                      handle_cuGreenCtxDestroy,
-                                      rpc_backend::cuda)
+#if CUDA_VERSION >= 12030
+                                  LUPINE_REGISTER_HANDLER(RPC_cuFuncGetName,
+                                                          handle_cuFuncGetName,
+                                                          rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                       LUPINE_REGISTER_HANDLER(
-                                          RPC_cuCtxFromGreenCtx,
-                                          handle_cuCtxFromGreenCtx,
+                                          RPC_cuGreenCtxCreate,
+                                          handle_cuGreenCtxCreate,
                                           rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                           LUPINE_REGISTER_HANDLER(
-                                              RPC_cuDeviceGetDevResource,
-                                              handle_cuDeviceGetDevResource,
+                                              RPC_cuGreenCtxDestroy,
+                                              handle_cuGreenCtxDestroy,
                                               rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                               LUPINE_REGISTER_HANDLER(
-                                                  RPC_cuCtxGetDevResource,
-                                                  handle_cuCtxGetDevResource,
+                                                  RPC_cuCtxFromGreenCtx,
+                                                  handle_cuCtxFromGreenCtx,
                                                   rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                   LUPINE_REGISTER_HANDLER(
-                                                      RPC_cuGreenCtxGetDevResource,
-                                                      handle_cuGreenCtxGetDevResource,
+                                                      RPC_cuDeviceGetDevResource,
+                                                      handle_cuDeviceGetDevResource,
                                                       rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                       LUPINE_REGISTER_HANDLER(
-                                                          RPC_cuDevSmResourceSplitByCount,
-                                                          handle_cuDevSmResourceSplitByCount,
+                                                          RPC_cuCtxGetDevResource,
+                                                          handle_cuCtxGetDevResource,
                                                           rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 13010
+#if CUDA_VERSION >= 12040
                                                           LUPINE_REGISTER_HANDLER(
-                                                              RPC_cuDevSmResourceSplit,
-                                                              handle_cuDevSmResourceSplit,
+                                                              RPC_cuGreenCtxGetDevResource,
+                                                              handle_cuGreenCtxGetDevResource,
                                                               rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                               LUPINE_REGISTER_HANDLER(
-                                                                  RPC_cuDevResourceGenerateDesc,
-                                                                  handle_cuDevResourceGenerateDesc,
+                                                                  RPC_cuDevSmResourceSplitByCount,
+                                                                  handle_cuDevSmResourceSplitByCount,
                                                                   rpc_backend::
                                                                       cuda)
 #endif
-#if CUDA_VERSION >= 12040
+#if CUDA_VERSION >= 13010
                                                                   LUPINE_REGISTER_HANDLER(
-                                                                      RPC_cuStreamGetGreenCtx,
-                                                                      handle_cuStreamGetGreenCtx,
+                                                                      RPC_cuDevSmResourceSplit,
+                                                                      handle_cuDevSmResourceSplit,
                                                                       rpc_backend::
                                                                           cuda)
 #endif
-#if CUDA_VERSION >= 12050
+#if CUDA_VERSION >= 12040
                                                                       LUPINE_REGISTER_HANDLER(
-                                                                          RPC_cuGreenCtxStreamCreate,
-                                                                          handle_cuGreenCtxStreamCreate,
+                                                                          RPC_cuDevResourceGenerateDesc,
+                                                                          handle_cuDevResourceGenerateDesc,
                                                                           rpc_backend::
                                                                               cuda)
 #endif
-#if CUDA_VERSION >= 13010
+#if CUDA_VERSION >= 12040
                                                                           LUPINE_REGISTER_HANDLER(
-                                                                              RPC_cuStreamGetDevResource,
-                                                                              handle_cuStreamGetDevResource,
+                                                                              RPC_cuStreamGetGreenCtx,
+                                                                              handle_cuStreamGetGreenCtx,
                                                                               rpc_backend::
                                                                                   cuda)
 #endif
+#if CUDA_VERSION >= 12050
+                                                                              LUPINE_REGISTER_HANDLER(
+                                                                                  RPC_cuGreenCtxStreamCreate,
+                                                                                  handle_cuGreenCtxStreamCreate,
+                                                                                  rpc_backend::
+                                                                                      cuda)
+#endif
+#if CUDA_VERSION >= 13010
+                                                                                  LUPINE_REGISTER_HANDLER(
+                                                                                      RPC_cuStreamGetDevResource,
+                                                                                      handle_cuStreamGetDevResource,
+                                                                                      rpc_backend::
+                                                                                          cuda)
+#endif
 #endif
 #ifdef LUPINE_BUILD_NVML_BACKEND
-                                                                              LUPINE_NVML_RPC_HANDLERS(
-                                                                                  LUPINE_REGISTER_HANDLER)
+                                                                                      LUPINE_NVML_RPC_HANDLERS(
+                                                                                          LUPINE_REGISTER_HANDLER)
 
 #endif
   };

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -8267,7 +8267,6 @@ LUPINE_DEFINE_UNSUPPORTED_STUB(cuModuleLoadFatBinary)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuLibraryLoadData)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuLibraryGetKernelCount)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuLibraryEnumerateKernels)
-LUPINE_DEFINE_UNSUPPORTED_STUB(cuKernelGetName)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuLinkCreate)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuLinkAddData)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuLinkAddFile)
@@ -8380,7 +8379,6 @@ static void *lupine_get_unsupported_stub(const char *symbol) {
       LUPINE_STUB_ENTRY(cuLibraryLoadData),
       LUPINE_STUB_ENTRY(cuLibraryGetKernelCount),
       LUPINE_STUB_ENTRY(cuLibraryEnumerateKernels),
-      LUPINE_STUB_ENTRY(cuKernelGetName),
       LUPINE_STUB_ENTRY(cuLinkCreate),
       LUPINE_STUB_ENTRY(cuLinkAddData),
       LUPINE_STUB_ENTRY(cuLinkAddFile),

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <new>
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
@@ -5820,6 +5821,35 @@ lupine_validate_graph_dependencies(const CUgraphNode *dependencies,
 // all deep structs so codegen needs no per-type globals.
 static std::mutex g_deep_cache_mutex;
 static std::map<const void *, std::vector<void *>> g_deep_cache;
+static std::mutex g_retained_string_mutex;
+static std::unordered_map<const void *, std::vector<char *>>
+    g_retained_strings;
+
+extern "C" const char *lupine_retain_returned_string(const void *handle,
+                                                      const char *data,
+                                                      size_t size) {
+  if (handle == nullptr || (data == nullptr && size != 0)) {
+    return nullptr;
+  }
+
+  auto *stored = static_cast<char *>(malloc(size + 1));
+  if (stored == nullptr) {
+    return nullptr;
+  }
+  if (size != 0) {
+    memcpy(stored, data, size);
+  }
+  stored[size] = '\0';
+
+  std::lock_guard<std::mutex> guard(g_retained_string_mutex);
+  try {
+    g_retained_strings[handle].push_back(stored);
+  } catch (const std::bad_alloc &) {
+    free(stored);
+    return nullptr;
+  }
+  return stored;
+}
 
 extern "C" void lupine_deep_cache_reset(const void *key) {
   std::lock_guard<std::mutex> guard(g_deep_cache_mutex);

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -435,6 +435,16 @@ lupine_module_functions() {
   return *functions;
 }
 
+static std::unordered_map<CUfunction, CUlibrary> &lupine_library_functions() {
+  static auto *functions = new std::unordered_map<CUfunction, CUlibrary>();
+  return *functions;
+}
+
+static std::unordered_map<CUmodule, CUlibrary> &lupine_library_modules() {
+  static auto *modules = new std::unordered_map<CUmodule, CUlibrary>();
+  return *modules;
+}
+
 static libcuckoo::cuckoohash_map<lupine_device_attribute_key, int,
                                  lupine_device_attribute_key_hash> &
 lupine_device_attribute_cache() {
@@ -1079,6 +1089,28 @@ extern "C" CUresult lupine_record_library_kernel(CUkernel kernel,
     record.kernels_by_route[route_id] = kernel;
   }
   return CUDA_SUCCESS;
+}
+
+static void lupine_record_library_function(CUfunction function,
+                                           CUkernel kernel) {
+  if (function == nullptr || kernel == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_library_kernel_mutex());
+  auto kernel_record = lupine_library_kernels().find(kernel);
+  if (kernel_record != lupine_library_kernels().end() &&
+      kernel_record->second.library != nullptr) {
+    lupine_library_functions()[function] = kernel_record->second.library;
+  }
+}
+
+extern "C" void lupine_record_library_module(CUmodule module,
+                                             CUlibrary library) {
+  if (module == nullptr || library == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_library_kernel_mutex());
+  lupine_library_modules()[module] = library;
 }
 
 extern "C" CUresult lupine_record_module_function(CUfunction function,
@@ -2351,12 +2383,14 @@ extern "C" CUresult cuKernelGetFunction(CUfunction *pFunc, CUkernel kernel) {
     CUresult result = real(pFunc, route_kernel);
     if (result == CUDA_SUCCESS) {
       lupine_note_function_owner_route(*pFunc, route);
+      lupine_record_library_function(*pFunc, route_kernel);
     }
     return result;
   }
   lupine_kernel_function_key key{lupine_route_identity(route), current_context,
                                  route_kernel};
   if (lupine_kernel_function_cache().find(key, *pFunc)) {
+    lupine_record_library_function(*pFunc, route_kernel);
     return CUDA_SUCCESS;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -2377,6 +2411,7 @@ extern "C" CUresult cuKernelGetFunction(CUfunction *pFunc, CUkernel kernel) {
   if (return_value == CUDA_SUCCESS) {
     lupine_kernel_function_cache().insert_or_assign(key, function);
     *pFunc = function;
+    lupine_record_library_function(function, route_kernel);
   }
   return return_value;
 }
@@ -4781,6 +4816,9 @@ static void lupine_prefill_library_snapshot(CUlibrary library, conn_t *conn) {
     if (lupine_record_library_kernel(record.kernel, library,
                                      record.name.c_str(),
                                      remote_route) == CUDA_SUCCESS) {
+      if (record.function != nullptr) {
+        lupine_record_library_function(record.function, record.kernel);
+      }
       lupine_library_kernel_names().insert_or_assign(
           lupine_library_kernel_name_key{library, record.name}, record.kernel);
     }
@@ -5821,13 +5859,25 @@ lupine_validate_graph_dependencies(const CUgraphNode *dependencies,
 // all deep structs so codegen needs no per-type globals.
 static std::mutex g_deep_cache_mutex;
 static std::map<const void *, std::vector<void *>> g_deep_cache;
+// Release paths acquire the handle-association mutex and this mutex together;
+// no path acquires them separately in the opposite order.
 static std::mutex g_retained_string_mutex;
-static std::unordered_map<const void *, std::vector<char *>>
-    g_retained_strings;
+static std::unordered_map<const void *, std::vector<char *>> g_retained_strings;
+
+static void lupine_release_retained_strings_locked(const void *handle) {
+  auto retained = g_retained_strings.find(handle);
+  if (retained == g_retained_strings.end()) {
+    return;
+  }
+  for (char *string : retained->second) {
+    free(string);
+  }
+  g_retained_strings.erase(retained);
+}
 
 extern "C" const char *lupine_retain_returned_string(const void *handle,
-                                                      const char *data,
-                                                      size_t size) {
+                                                     const char *data,
+                                                     size_t size) {
   if (handle == nullptr || (data == nullptr && size != 0)) {
     return nullptr;
   }
@@ -5849,6 +5899,71 @@ extern "C" const char *lupine_retain_returned_string(const void *handle,
     return nullptr;
   }
   return stored;
+}
+
+extern "C" void lupine_release_module_retained_strings(CUmodule module) {
+  std::scoped_lock lock(lupine_library_kernel_mutex(), g_retained_string_mutex);
+  lupine_release_retained_strings_locked(
+      reinterpret_cast<const void *>(module));
+  auto &functions = lupine_module_functions();
+  for (auto function = functions.begin(); function != functions.end();) {
+    if (function->second.module != module) {
+      ++function;
+      continue;
+    }
+    lupine_release_retained_strings_locked(
+        reinterpret_cast<const void *>(function->first));
+    function = functions.erase(function);
+  }
+  lupine_library_modules().erase(module);
+}
+
+extern "C" void lupine_release_library_retained_strings(CUlibrary library) {
+  std::scoped_lock lock(lupine_library_kernel_mutex(), g_retained_string_mutex);
+  lupine_release_retained_strings_locked(
+      reinterpret_cast<const void *>(library));
+  auto &kernels = lupine_library_kernels();
+  for (auto kernel = kernels.begin(); kernel != kernels.end();) {
+    if (kernel->second.library != library) {
+      ++kernel;
+      continue;
+    }
+    lupine_release_retained_strings_locked(
+        reinterpret_cast<const void *>(kernel->first));
+    kernel = kernels.erase(kernel);
+  }
+  auto &module_functions = lupine_module_functions();
+  for (auto function = module_functions.begin();
+       function != module_functions.end();) {
+    auto module = lupine_library_modules().find(function->second.module);
+    if (module == lupine_library_modules().end() || module->second != library) {
+      ++function;
+      continue;
+    }
+    lupine_release_retained_strings_locked(
+        reinterpret_cast<const void *>(function->first));
+    function = module_functions.erase(function);
+  }
+  auto &functions = lupine_library_functions();
+  for (auto function = functions.begin(); function != functions.end();) {
+    if (function->second != library) {
+      ++function;
+      continue;
+    }
+    lupine_release_retained_strings_locked(
+        reinterpret_cast<const void *>(function->first));
+    function = functions.erase(function);
+  }
+  auto &modules = lupine_library_modules();
+  for (auto module = modules.begin(); module != modules.end();) {
+    if (module->second != library) {
+      ++module;
+      continue;
+    }
+    lupine_release_retained_strings_locked(
+        reinterpret_cast<const void *>(module->first));
+    module = modules.erase(module);
+  }
 }
 
 extern "C" void lupine_deep_cache_reset(const void *key) {

--- a/test/cuda-python/known_failures.txt
+++ b/test/cuda-python/known_failures.txt
@@ -36,10 +36,6 @@ test_cuda.py::test_cuda_pointer_attr
 # #583 cuCoredumpSetAttributeGlobal
 test_cuda.py::test_cuda_coredump_attr
 
-# #584 cuKernelGetName / cuFuncGetName
-test_cuda.py::test_cuKernelGetName_failure
-test_cuda.py::test_cuFuncGetName_failure
-
 # #585 cudaHostRegister(PORTABLE|DEVICEMAP) sub-range
 test_cudart.py::test_cudart_hostRegister
 

--- a/test/test_library_kernel_function_prefill.cu
+++ b/test/test_library_kernel_function_prefill.cu
@@ -43,9 +43,11 @@ int main() {
   CUcontext context = nullptr;
   CUmodule module = nullptr;
   CUlibrary library = nullptr;
+  CUmodule library_module = nullptr;
   CUkernel kernel = nullptr;
   CUfunction function = nullptr;
   CUfunction module_function = nullptr;
+  CUfunction library_module_function = nullptr;
   if (!check(cuInit(0), "cuInit") ||
       !check(cuDeviceGet(&device, 0), "cuDeviceGet") ||
       !check(cuDevicePrimaryCtxRetain(&context, device),
@@ -56,20 +58,36 @@ int main() {
              "cuLibraryLoadData") ||
       !check(cuLibraryGetKernel(&kernel, library, "parameterized"),
              "cuLibraryGetKernel") ||
-      !check(cuKernelGetFunction(&function, kernel), "cuKernelGetFunction")) {
+      !check(cuKernelGetFunction(&function, kernel), "cuKernelGetFunction") ||
+      !check(cuLibraryGetModule(&library_module, library),
+             "cuLibraryGetModule") ||
+      !check(cuModuleGetFunction(&library_module_function, library_module,
+                                 "parameterized"),
+             "cuModuleGetFunction(library)")) {
     return 1;
   }
 
   const char *kernel_name = nullptr;
   const char *function_name = nullptr;
+  const char *library_module_function_name = nullptr;
   if (!check(cuKernelGetName(&kernel_name, kernel), "cuKernelGetName") ||
       !check(cuFuncGetName(&function_name, function), "cuFuncGetName") ||
+      !check(
+          cuFuncGetName(&library_module_function_name, library_module_function),
+          "cuFuncGetName(library module)") ||
       kernel_name == nullptr || function_name == nullptr ||
+      library_module_function_name == nullptr ||
       std::strcmp(kernel_name, "parameterized") != 0 ||
-      std::strcmp(function_name, "parameterized") != 0) {
-    std::fprintf(stderr, "unexpected names: kernel=%s, function=%s\n",
+      std::strcmp(function_name, "parameterized") != 0 ||
+      std::strcmp(library_module_function_name, "parameterized") != 0) {
+    std::fprintf(stderr,
+                 "unexpected names: kernel=%s, function=%s, library "
+                 "module function=%s\n",
                  kernel_name == nullptr ? "null" : kernel_name,
-                 function_name == nullptr ? "null" : function_name);
+                 function_name == nullptr ? "null" : function_name,
+                 library_module_function_name == nullptr
+                     ? "null"
+                     : library_module_function_name);
     return 1;
   }
 
@@ -91,14 +109,19 @@ int main() {
   }
 
   int module_max_threads = 0;
+  const char *module_function_name = nullptr;
   if (!check(cuModuleLoadData(&module, kParameterizedPtx),
              "cuModuleLoadData") ||
       !check(cuModuleGetFunction(&module_function, module, "parameterized"),
              "cuModuleGetFunction") ||
+      !check(cuFuncGetName(&module_function_name, module_function),
+             "cuFuncGetName(module)") ||
       !check(cuFuncGetAttribute(&module_max_threads,
                                 CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
                                 module_function),
              "cuFuncGetAttribute(module)") ||
+      module_function_name == nullptr ||
+      std::strcmp(module_function_name, "parameterized") != 0 ||
       module_max_threads != function_max_threads) {
     std::fprintf(stderr,
                  "module and library function attributes differ: module=%d, "

--- a/test/test_library_kernel_function_prefill.cu
+++ b/test/test_library_kernel_function_prefill.cu
@@ -3,6 +3,7 @@
 #include <cuda.h>
 
 #include <cstdio>
+#include <cstring>
 
 #if !defined(CUDA_VERSION) || CUDA_VERSION < 12040
 int main() {
@@ -56,6 +57,19 @@ int main() {
       !check(cuLibraryGetKernel(&kernel, library, "parameterized"),
              "cuLibraryGetKernel") ||
       !check(cuKernelGetFunction(&function, kernel), "cuKernelGetFunction")) {
+    return 1;
+  }
+
+  const char *kernel_name = nullptr;
+  const char *function_name = nullptr;
+  if (!check(cuKernelGetName(&kernel_name, kernel), "cuKernelGetName") ||
+      !check(cuFuncGetName(&function_name, function), "cuFuncGetName") ||
+      kernel_name == nullptr || function_name == nullptr ||
+      std::strcmp(kernel_name, "parameterized") != 0 ||
+      std::strcmp(function_name, "parameterized") != 0) {
+    std::fprintf(stderr, "unexpected names: kernel=%s, function=%s\n",
+                 kernel_name == nullptr ? "null" : kernel_name,
+                 function_name == nullptr ? "null" : function_name);
     return 1;
   }
 


### PR DESCRIPTION
Stacked on #586.

Closes #584.

- generate cuKernelGetName and cuFuncGetName forwarding
- extend the existing NULL_TERMINATED operation to support RECV_ONLY const char ** outputs
- add @retain <output-arg> <owner-handle> metadata for handle-owned returned storage
- add @release and @recordparent metadata so module/library unload frees retained buffers for direct and derived handles
- keep each returned buffer in a handle-to-vector backing map instead of process-wide string interning
- route CUkernel handles through the existing function-owner map
- remove the #584 cuda-python exclusions
- extend the library/kernel/function integration test with name lookups across kernel, module, and library-owned module lifetimes

Validation:
- cmake --build build -j2
- ctest --test-dir build --output-on-failure (9/9 passed)
- cuda-python 13.3.1 test_cuda.py: 41 passed
- custom GPU tests: 29/29 passed
- regeneration from CUDA 13.3.1 is byte-for-byte stable