### PR TITLE
test: re-enable cuBLAS zgemm_fixed sample

### DIFF
--- a/test/cuda-library-samples/known_failures.txt
+++ b/test/cuda-library-samples/known_failures.txt
@@ -20,9 +20,6 @@ cuSPARSE/dense2sparse_csr/dense2sparse_csr_example
 cuSPARSE/spsv_sell/spsv_sell_example
 cuSPARSE/spvv/spvv_example
 
-# #594 cuBLAS zgemm_fixed emulation
-cuBLAS/Emulation/zgemm_fixed/cublas_zgemm_fixed_example
-
 # #595 cuFFT multi-GPU c2c wrong results
 cuFFT/1d_mgpu_c2c/bin/1d_mgpu_c2c_example
 cuFFT/3d_mgpu_c2c/bin/3d_mgpu_c2c_example


### PR DESCRIPTION
## Summary

- remove the `zgemm_fixed` cuBLAS emulation sample from the known-failure quarantine
- run the existing NVIDIA sample as an end-to-end regression again

Current `main` passes the reported CUDA 13.1 path against `inferable-node-008`, including with only its RTX 4090 exposed. I could not reproduce the original cuBLAS error in 22 runs, so no shim code change is required.

## Validation

- `ctest --test-dir build --output-on-failure` (9/9 configured tests passed; 2 expected skips)
- `BUILD_SAMPLES=0 ./test/run_cuda_library_samples.sh cuBLAS/Emulation/zgemm_fixed` (PASS)
- 20 consecutive manual runs with `CUDA_VISIBLE_DEVICES=1` on the RTX 4090 (20/20 PASS)

Closes #594