### PR TITLE
Accept unaligned mapped host registrations

### DIFF
--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -2234,14 +2234,6 @@ static CUresult lupine_register_host(void *p, size_t bytesize,
   }
 
   size_t page_size = lupine_page_size();
-  // Eager synchronization owns the whole registered page range. An unaligned
-  // device mapping would include unrelated bytes on its edge pages, so retain
-  // the existing rejection and let callers use their fallback path.
-  if (lupine_host_flags_request_mapping(Flags) &&
-      ((reinterpret_cast<uintptr_t>(p) % page_size) != 0 ||
-       (bytesize % page_size) != 0)) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
   void *tracked = reinterpret_cast<void *>(covering_base);
 
   void *server_host = nullptr;
@@ -2323,13 +2315,12 @@ extern "C" CUresult cuMemHostUnregister(void *p) {
     std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
     auto &allocations = lupine_mutable_host_allocations_locked();
     auto it = lupine_find_host_allocation_locked(p);
-    if (it != allocations.end() && it->second.owned) {
-      // Never registered, so the driver reports an invalid argument.
-      return CUDA_ERROR_INVALID_VALUE;
-    }
-    if (it == allocations.end() ||
-        it->second.user_base != reinterpret_cast<uintptr_t>(p)) {
+    if (it == allocations.end()) {
       return CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED;
+    }
+    if (it->second.owned ||
+        it->second.user_base != reinterpret_cast<uintptr_t>(p)) {
+      return CUDA_ERROR_INVALID_VALUE;
     }
     tracked = it->first;
     local_cuda = it->second.local_cuda;

--- a/test/cuda-python/known_failures.txt
+++ b/test/cuda-python/known_failures.txt
@@ -40,9 +40,6 @@ test_cuda.py::test_cuda_coredump_attr
 test_cuda.py::test_cuKernelGetName_failure
 test_cuda.py::test_cuFuncGetName_failure
 
-# #585 cudaHostRegister(PORTABLE|DEVICEMAP) sub-range
-test_cudart.py::test_cudart_hostRegister
-
 # #599 CUDA 11 cuGraphInstantiate_v2 with a log buffer (11.8 lane)
 test_cuda.py::test_cuda_graphMem_attr
 test_cudart.py::test_cudart_cudaGraphAddMemcpyNode1D

--- a/test/test_mapped_host_registration.cu
+++ b/test/test_mapped_host_registration.cu
@@ -70,9 +70,39 @@ int main() {
     return 1;
   }
   unsigned char *unaligned = block + 64;
-  if (!cu_is(cuMemHostRegister(unaligned, page_size * 2 + 17,
+  if (!cu_ok(cuMemHostRegister(unaligned, page_size * 2 + 17,
+                               CU_MEMHOSTREGISTER_PORTABLE |
+                                   CU_MEMHOSTREGISTER_DEVICEMAP),
+             "unaligned cuMemHostRegister")) {
+    return 1;
+  }
+  if (!cu_is(cuMemHostRegister(block + page_size, page_size,
                                CU_MEMHOSTREGISTER_DEVICEMAP),
-             CUDA_ERROR_INVALID_VALUE, "unaligned cuMemHostRegister")) {
+             CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED,
+             "overlapping unaligned cuMemHostRegister")) {
+    return 1;
+  }
+
+  CUdeviceptr unaligned_mapped = 0;
+  if (!cu_ok(cuMemHostGetDevicePointer(&unaligned_mapped, unaligned, 0),
+             "unaligned cuMemHostGetDevicePointer")) {
+    return 1;
+  }
+  unaligned[0] = 41;
+  increment_byte<<<1, 1>>>(reinterpret_cast<unsigned char *>(unaligned_mapped));
+  if (cudaGetLastError() != cudaSuccess ||
+      cudaDeviceSynchronize() != cudaSuccess || unaligned[0] != 42) {
+    std::fprintf(stderr,
+                 "direct unaligned device access produced %u, expected 42\n",
+                 static_cast<unsigned int>(unaligned[0]));
+    return 1;
+  }
+  if (!cu_is(cuMemHostUnregister(unaligned + page_size),
+             CUDA_ERROR_INVALID_VALUE,
+             "interior unaligned cuMemHostUnregister")) {
+    return 1;
+  }
+  if (!cu_ok(cuMemHostUnregister(unaligned), "unaligned cuMemHostUnregister")) {
     return 1;
   }
 


### PR DESCRIPTION
## Summary

- accept unaligned `cuMemHostRegister` ranges with `PORTABLE | DEVICEMAP` by using the existing page-covering mirror
- return `CUDA_ERROR_INVALID_VALUE` when unregister is called with an interior pointer while preserving `CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED` for unknown memory
- cover registration, overlap detection, mapped device access, and unregister behavior in the custom GPU test, and re-enable NVIDIA cuda-python's host-register test

## Testing

- `cmake --build build --parallel --target lupine_cuda_client lupine_driver_server`
- targeted `test/run_custom_tests.sh`: `test_mapped_host_registration` passed
- NVIDIA cuda-bindings v13.3.1 `test_cudart.py`: 45 passed, 12 unrelated tests deselected
- `test/run_unit_tests.sh`: 6 passed, 2 environment-dependent tests skipped

Fixes #585