### PR TITLE
Split CUDA RPC preparation from request start

### DIFF
--- a/client_routing.h
+++ b/client_routing.h
@@ -62,11 +62,13 @@ extern "C" conn_t *lupine_rpc_conn_for_function(CUfunction function);
 extern "C" conn_t *lupine_rpc_conn_for_stream(CUstream stream);
 extern "C" conn_t *lupine_rpc_conn_for_event(CUevent event);
 extern "C" conn_t *lupine_rpc_conn_for_deviceptr(CUdeviceptr ptr);
-extern "C" int lupine_cuda_rpc_start(conn_t *conn, int op);
+// Flushes work that must precede the caller's next CUDA RPC without starting
+// that request.
+extern "C" int lupine_prepare_rpc(conn_t *conn);
 
 extern "C" bool lupine_route_is_local(lupine_route route);
-// May return null for local/invalid routes; rpc_write_start_request absorbs
-// the null, so callers need not re-check before starting a request chain.
+// May return null for local/invalid routes; lupine_prepare_rpc absorbs the
+// null, so callers need not re-check before preparing a request chain.
 extern "C" conn_t *lupine_route_remote_conn(lupine_route route);
 extern "C" bool lupine_routes_share_server(lupine_route first,
                                            lupine_route second);

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1805,10 +1805,11 @@ def main():
                         )
                     )
 
-            # Reject invalid send buffers before lupine_cuda_rpc_start()
-            # acquires the connection's call/write locks. Conditions in the
-            # builder below may skip optional writes, but only rpc_write* calls
-            # themselves are allowed to fail the builder.
+            # Reject invalid send buffers before lupine_prepare_rpc() flushes
+            # pending writes and rpc_write_start_request() acquires the
+            # connection's call/write locks. Conditions in the builder below
+            # may skip optional writes, but only rpc_write* calls themselves
+            # are allowed to fail the builder.
             for operation in operations:
                 if isinstance(operation, ArrayOperation):
                     operation.client_preflight(
@@ -1825,7 +1826,8 @@ def main():
             if metadata.async_fire_forget:
                 error_return = error_const(function.return_type.format())
                 f.write(
-                    "    if (lupine_cuda_rpc_start(conn, RPC_{name}) < 0 ||\n".format(
+                    "    if (lupine_prepare_rpc(conn) < 0 ||\n"
+                    "        rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
                         name=function.name.format()
                     )
                 )
@@ -1848,7 +1850,8 @@ def main():
                 continue
 
             f.write(
-                "    if (lupine_cuda_rpc_start(conn, RPC_{name}) < 0 ||\n".format(
+                "    if (lupine_prepare_rpc(conn) < 0 ||\n"
+                "        rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
                     name=function.name.format()
                 )
             )

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -109,7 +109,8 @@ CUresult cuDriverGetVersion(int *driverVersion) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDriverGetVersion) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, driverVersion, sizeof(int)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -135,7 +136,8 @@ CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetLuid) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetLuid) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       (8 != 0 && rpc_read(conn, luid, 8) < 0) ||
@@ -161,7 +163,9 @@ CUresult cuDeviceGetTexture1DLinearMaxWidth(size_t *maxWidthInElements,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetTexture1DLinearMaxWidth) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetTexture1DLinearMaxWidth) <
+          0 ||
       rpc_write(conn, &format, sizeof(CUarray_format)) < 0 ||
       rpc_write(conn, &numChannels, sizeof(unsigned)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -184,7 +188,8 @@ CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceSetMemPool) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceSetMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -208,7 +213,8 @@ CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetMemPool) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pool, sizeof(CUmemoryPool)) < 0 ||
@@ -235,7 +241,8 @@ CUresult cuDeviceGetDefaultMemPool(CUmemoryPool *pool_out, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetDefaultMemPool) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetDefaultMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pool_out, sizeof(CUmemoryPool)) < 0 ||
@@ -261,7 +268,8 @@ CUresult cuDeviceGetExecAffinitySupport(int *pi, CUexecAffinityType type,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetExecAffinitySupport) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetExecAffinitySupport) < 0 ||
       rpc_write(conn, &type, sizeof(CUexecAffinityType)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 || rpc_read(conn, pi, sizeof(int)) < 0 ||
@@ -282,7 +290,8 @@ CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
       rpc_write(conn, &target, sizeof(CUflushGPUDirectRDMAWritesTarget)) < 0 ||
       rpc_write(conn, &scope, sizeof(CUflushGPUDirectRDMAWritesScope)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -303,7 +312,8 @@ CUresult cuDeviceGetProperties(CUdevprop *prop, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetProperties) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetProperties) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, prop, sizeof(CUdevprop)) < 0 ||
@@ -325,7 +335,8 @@ CUresult cuDeviceComputeCapability(int *major, int *minor, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceComputeCapability) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceComputeCapability) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, major, sizeof(int)) < 0 ||
@@ -354,7 +365,8 @@ CUresult cuCtxDestroy_v2(CUcontext ctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxDestroy_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxDestroy_v2) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -376,7 +388,8 @@ CUresult cuCtxGetFlags(unsigned int *flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetFlags) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetFlags) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, flags, sizeof(unsigned int)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -394,7 +407,8 @@ CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetId) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetId) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, ctxId, sizeof(unsigned long long)) < 0 ||
@@ -415,7 +429,8 @@ CUresult cuCtxSynchronize() {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSynchronize) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxSynchronize) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
       lupine_forward_remote_stdout(conn) < 0 ||
@@ -439,7 +454,8 @@ CUresult cuCtxSynchronize_v2(CUcontext ctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSynchronize_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxSynchronize_v2) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -463,7 +479,8 @@ CUresult cuCtxSetLimit(CUlimit limit, size_t value) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSetLimit) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxSetLimit) < 0 ||
       rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
       rpc_write(conn, &value, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -482,7 +499,8 @@ CUresult cuCtxGetLimit(size_t *pvalue, CUlimit limit) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetLimit) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetLimit) < 0 ||
       rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pvalue, sizeof(size_t)) < 0 ||
@@ -501,7 +519,8 @@ CUresult cuCtxGetCacheConfig(CUfunc_cache *pconfig) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetCacheConfig) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetCacheConfig) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pconfig, sizeof(CUfunc_cache)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -519,7 +538,8 @@ CUresult cuCtxSetCacheConfig(CUfunc_cache config) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSetCacheConfig) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxSetCacheConfig) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -537,7 +557,8 @@ CUresult cuCtxGetApiVersion(CUcontext ctx, unsigned int *version) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetApiVersion) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetApiVersion) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, version, sizeof(unsigned int)) < 0 ||
@@ -556,7 +577,8 @@ CUresult cuCtxResetPersistingL2Cache() {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -574,7 +596,8 @@ CUresult cuCtxGetExecAffinity(CUexecAffinityParam *pExecAffinity,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetExecAffinity) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetExecAffinity) < 0 ||
       rpc_write(conn, &type, sizeof(CUexecAffinityType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pExecAffinity, sizeof(CUexecAffinityParam)) < 0 ||
@@ -593,7 +616,8 @@ CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxAttach) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxAttach) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pctx, sizeof(CUcontext)) < 0 ||
@@ -614,7 +638,8 @@ CUresult cuCtxDetach(CUcontext ctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxDetach) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxDetach) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -634,7 +659,8 @@ CUresult cuCtxGetSharedMemConfig(CUsharedconfig *pConfig) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pConfig, sizeof(CUsharedconfig)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -652,7 +678,8 @@ CUresult cuCtxSetSharedMemConfig(CUsharedconfig config) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
       rpc_write(conn, &config, sizeof(CUsharedconfig)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -674,7 +701,8 @@ CUresult cuModuleUnload(CUmodule hmod) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuModuleUnload) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleUnload) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -696,7 +724,8 @@ CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode *mode) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetLoadingMode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleGetLoadingMode) < 0 ||
       rpc_write(conn, mode, sizeof(CUmoduleLoadingMode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, mode, sizeof(CUmoduleLoadingMode)) < 0 ||
@@ -726,7 +755,8 @@ CUresult cuModuleGetGlobal_v2(CUdeviceptr *dptr, size_t *bytes, CUmodule hmod,
   CUdeviceptr *dptr_null_check;
   size_t *bytes_null_check;
   std::size_t name_len = std::strlen(name) + 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetGlobal_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleGetGlobal_v2) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
@@ -757,7 +787,8 @@ CUresult cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod, const char *name) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetTexRef) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleGetTexRef) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -779,7 +810,8 @@ CUresult cuModuleGetSurfRef(CUsurfref *pSurfRef, CUmodule hmod,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetSurfRef) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleGetSurfRef) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -822,7 +854,8 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
     return CUDA_ERROR_INVALID_VALUE;
   if (numLibraryOptions * sizeof(void *) != 0 && libraryOptionValues == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryLoadFromFile) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLibraryLoadFromFile) < 0 ||
       rpc_write(conn, &fileName_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, fileName, fileName_len) < 0 ||
       rpc_write(conn, &numJitOptions, sizeof(unsigned int)) < 0 ||
@@ -857,7 +890,8 @@ CUresult cuLibraryUnload(CUlibrary library) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryUnload) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -884,7 +918,8 @@ CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetModule) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLibraryGetModule) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pMod, sizeof(CUmodule)) < 0 ||
@@ -919,7 +954,8 @@ CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
   CUdeviceptr *dptr_null_check;
   size_t *bytes_null_check;
   std::size_t name_len = std::strlen(name) + 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetGlobal) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLibraryGetGlobal) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
@@ -960,7 +996,8 @@ CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
   CUdeviceptr *dptr_null_check;
   size_t *bytes_null_check;
   std::size_t name_len = std::strlen(name) + 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetManaged) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLibraryGetManaged) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr *)) < 0 ||
       rpc_write(conn, &bytes, sizeof(size_t *)) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
@@ -993,7 +1030,8 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t symbol_len = std::strlen(symbol) + 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &symbol_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, symbol, symbol_len) < 0 ||
@@ -1021,7 +1059,8 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuKernelSetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
       rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_write(conn, &val, sizeof(int)) < 0 ||
       rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
@@ -1048,7 +1087,8 @@ CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuKernelSetCacheConfig) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuKernelSetCacheConfig) < 0 ||
       rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -1074,7 +1114,8 @@ CUresult cuKernelGetName(const char **name, CUkernel hfunc) {
   std::string name_result;
   if (name == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuKernelGetName) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuKernelGetName) < 0 ||
       rpc_write(conn, &hfunc, sizeof(CUkernel)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &name_len, sizeof(std::size_t)) < 0 ||
@@ -1105,7 +1146,8 @@ CUresult cuMemGetInfo_v2(size_t *free, size_t *total) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetInfo_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemGetInfo_v2) < 0 ||
       rpc_write(conn, free, sizeof(size_t)) < 0 ||
       rpc_write(conn, total, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1131,7 +1173,8 @@ CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemAlloc_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemAlloc_v2) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1171,7 +1214,8 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr *dptr, size_t *pPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemAllocPitch_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemAllocPitch_v2) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, pPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &WidthInBytes, sizeof(size_t)) < 0 ||
@@ -1208,7 +1252,8 @@ CUresult cuMemGetAddressRange_v2(CUdeviceptr *pbase, size_t *psize,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetAddressRange_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemGetAddressRange_v2) < 0 ||
       rpc_write(conn, pbase, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, psize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -1237,7 +1282,8 @@ CUresult cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId) {
         conn_t *conn = lupine_route_remote_conn(route);
         CUdevice *dev_null_check;
         std::size_t pciBusId_len = std::strlen(pciBusId) + 1;
-        if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
+        if (lupine_prepare_rpc(conn) < 0 ||
+            rpc_write_start_request(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
             rpc_write(conn, &dev, sizeof(CUdevice *)) < 0 ||
             rpc_write(conn, &pciBusId_len, sizeof(std::size_t)) < 0 ||
             rpc_write(conn, pciBusId, pciBusId_len) < 0 ||
@@ -1262,7 +1308,8 @@ CUresult cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetPCIBusId) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetPCIBusId) < 0 ||
       rpc_write(conn, &len, sizeof(int)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1283,7 +1330,8 @@ CUresult cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuIpcGetEventHandle) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuIpcGetEventHandle) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUipcEventHandle)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1303,7 +1351,8 @@ CUresult cuIpcOpenEventHandle(CUevent *phEvent, CUipcEventHandle handle) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuIpcOpenEventHandle) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuIpcOpenEventHandle) < 0 ||
       rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &handle, sizeof(CUipcEventHandle)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1323,7 +1372,8 @@ CUresult cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuIpcGetMemHandle) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuIpcGetMemHandle) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUipcMemHandle)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1345,7 +1395,8 @@ CUresult cuIpcOpenMemHandle_v2(CUdeviceptr *pdptr, CUipcMemHandle handle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
       rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &handle, sizeof(CUipcMemHandle)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -1366,7 +1417,8 @@ CUresult cuIpcCloseMemHandle(CUdeviceptr dptr) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuIpcCloseMemHandle) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuIpcCloseMemHandle) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -1392,7 +1444,8 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyPeer) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyPeer) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstContext, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1423,7 +1476,8 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
   if (ByteCount != 0 && srcHost == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   srcHost = lupine_mapped_host_read_source(srcHost, ByteCount);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyHtoD_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyHtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
       rpc_write_payload(conn, srcHost, ByteCount) < 0 ||
@@ -1457,7 +1511,8 @@ CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
@@ -1481,7 +1536,8 @@ CUresult cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoA_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyDtoA_v2) < 0 ||
       rpc_write(conn, &dstArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &dstOffset, sizeof(size_t)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1504,7 +1560,8 @@ CUresult cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyAtoD_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyAtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &srcOffset, sizeof(size_t)) < 0 ||
@@ -1527,7 +1584,8 @@ CUresult cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
       rpc_write(conn, &dstArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &dstOffset, sizeof(size_t)) < 0 ||
       rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
@@ -1557,7 +1615,8 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyPeerAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyPeerAsync) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstContext, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1590,7 +1649,8 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
@@ -1614,7 +1674,8 @@ CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD8_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD8_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1640,7 +1701,8 @@ CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD16_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD16_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1666,7 +1728,8 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD32_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD32_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1695,7 +1758,8 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D8_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD2D8_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
@@ -1726,7 +1790,8 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D16_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD2D16_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
@@ -1757,7 +1822,8 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D32_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD2D32_v2) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
@@ -1785,7 +1851,8 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD8Async) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1809,7 +1876,8 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD16Async) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1833,7 +1901,8 @@ CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD32Async) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1859,7 +1928,8 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D8Async) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
@@ -1887,7 +1957,8 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D16Async) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
@@ -1915,7 +1986,8 @@ CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemsetD2D32Async) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
       rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
@@ -1938,7 +2010,8 @@ CUresult cuArrayCreate_v2(CUarray *pHandle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuArrayCreate_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuArrayCreate_v2) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUarray)) < 0 ||
       rpc_write(conn, pAllocateArray, sizeof(const CUDA_ARRAY_DESCRIPTOR)) <
           0 ||
@@ -1961,7 +2034,8 @@ CUresult cuArrayGetDescriptor_v2(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
       rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY_DESCRIPTOR)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1984,7 +2058,8 @@ cuArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES *sparseProperties,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuArrayGetSparseProperties) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuArrayGetSparseProperties) < 0 ||
       rpc_write(conn, sparseProperties, sizeof(CUDA_ARRAY_SPARSE_PROPERTIES)) <
           0 ||
       rpc_write(conn, &array, sizeof(CUarray)) < 0 ||
@@ -2009,7 +2084,8 @@ CUresult cuMipmappedArrayGetSparseProperties(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayGetSparseProperties) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMipmappedArrayGetSparseProperties) <
           0 ||
       rpc_write(conn, sparseProperties, sizeof(CUDA_ARRAY_SPARSE_PROPERTIES)) <
           0 ||
@@ -2038,7 +2114,8 @@ cuArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS *memoryRequirements,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
       rpc_write(conn, memoryRequirements,
                 sizeof(CUDA_ARRAY_MEMORY_REQUIREMENTS)) < 0 ||
       rpc_write(conn, &array, sizeof(CUarray)) < 0 ||
@@ -2067,7 +2144,8 @@ CUresult cuMipmappedArrayGetMemoryRequirements(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayGetMemoryRequirements) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMipmappedArrayGetMemoryRequirements) <
           0 ||
       rpc_write(conn, memoryRequirements,
                 sizeof(CUDA_ARRAY_MEMORY_REQUIREMENTS)) < 0 ||
@@ -2093,7 +2171,8 @@ CUresult cuArrayGetPlane(CUarray *pPlaneArray, CUarray hArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuArrayGetPlane) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuArrayGetPlane) < 0 ||
       rpc_write(conn, pPlaneArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &planeIdx, sizeof(unsigned int)) < 0 ||
@@ -2114,7 +2193,8 @@ CUresult cuArrayDestroy(CUarray hArray) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuArrayDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuArrayDestroy) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2134,7 +2214,8 @@ CUresult cuArray3DCreate_v2(CUarray *pHandle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuArray3DCreate_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuArray3DCreate_v2) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUarray)) < 0 ||
       rpc_write(conn, pAllocateArray, sizeof(const CUDA_ARRAY3D_DESCRIPTOR)) <
           0 ||
@@ -2157,7 +2238,8 @@ CUresult cuArray3DGetDescriptor_v2(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
       rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY3D_DESCRIPTOR)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2182,7 +2264,8 @@ cuMipmappedArrayCreate(CUmipmappedArray *pHandle,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMipmappedArrayCreate) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, pMipmappedArrayDesc,
                 sizeof(const CUDA_ARRAY3D_DESCRIPTOR)) < 0 ||
@@ -2207,7 +2290,8 @@ CUresult cuMipmappedArrayGetLevel(CUarray *pLevelArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
       rpc_write(conn, pLevelArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &level, sizeof(unsigned int)) < 0 ||
@@ -2228,7 +2312,8 @@ CUresult cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2249,7 +2334,8 @@ CUresult cuMemAddressReserve(CUdeviceptr *ptr, size_t size, size_t alignment,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemAddressReserve) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemAddressReserve) < 0 ||
       rpc_write(conn, ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &alignment, sizeof(size_t)) < 0 ||
@@ -2272,7 +2358,8 @@ CUresult cuMemAddressFree(CUdeviceptr ptr, size_t size) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemAddressFree) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemAddressFree) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2295,7 +2382,8 @@ CUresult cuMemCreate(CUmemGenericAllocationHandle *handle, size_t size,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemCreate) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned long long)) < 0 ||
@@ -2316,7 +2404,8 @@ CUresult cuMemRelease(CUmemGenericAllocationHandle handle) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemRelease) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemRelease) < 0 ||
       rpc_write(conn, &handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2338,7 +2427,8 @@ CUresult cuMemMap(CUdeviceptr ptr, size_t size, size_t offset,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemMap) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemMap) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &offset, sizeof(size_t)) < 0 ||
@@ -2363,7 +2453,8 @@ CUresult cuMemMapArrayAsync(CUarrayMapInfo *mapInfoList, unsigned int count,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemMapArrayAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemMapArrayAsync) < 0 ||
       rpc_write(conn, mapInfoList, sizeof(CUarrayMapInfo)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -2384,7 +2475,8 @@ CUresult cuMemUnmap(CUdeviceptr ptr, size_t size) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemUnmap) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemUnmap) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2407,7 +2499,8 @@ CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(const CUmemAccessDesc) != 0 && desc == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemSetAccess) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemSetAccess) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &count, sizeof(size_t)) < 0 ||
@@ -2430,7 +2523,8 @@ CUresult cuMemGetAccess(unsigned long long *flags,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetAccess) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemGetAccess) < 0 ||
       rpc_write(conn, location, sizeof(const CUmemLocation)) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2455,7 +2549,8 @@ cuMemGetAllocationGranularity(size_t *granularity,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
       rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
       rpc_write(conn, &option, sizeof(CUmemAllocationGranularity_flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2479,8 +2574,9 @@ cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp *prop,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemGetAllocationPropertiesFromHandle) <
-          0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn,
+                              RPC_cuMemGetAllocationPropertiesFromHandle) < 0 ||
       rpc_write(conn, prop, sizeof(CUmemAllocationProp)) < 0 ||
       rpc_write(conn, &handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2502,7 +2598,8 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemFreeAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemFreeAsync) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2529,7 +2626,8 @@ CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemAllocAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemAllocAsync) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -2555,7 +2653,8 @@ CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolTrimTo) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolTrimTo) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, &minBytesToKeep, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2577,7 +2676,8 @@ CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc *map,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(const CUmemAccessDesc) != 0 && map == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolSetAccess) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolSetAccess) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, &count, sizeof(size_t)) < 0 ||
       rpc_write(conn, map, count * sizeof(const CUmemAccessDesc)) < 0 ||
@@ -2600,7 +2700,8 @@ CUresult cuMemPoolGetAccess(CUmemAccess_flags *flags, CUmemoryPool memPool,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolGetAccess) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolGetAccess) < 0 ||
       rpc_write(conn, flags, sizeof(CUmemAccess_flags)) < 0 ||
       rpc_write(conn, &memPool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, location, sizeof(CUmemLocation)) < 0 ||
@@ -2625,7 +2726,8 @@ CUresult cuMemPoolCreate(CUmemoryPool *pool, const CUmemPoolProps *poolProps) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolCreate) < 0 ||
       rpc_write(conn, pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, poolProps, sizeof(const CUmemPoolProps)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2648,7 +2750,8 @@ CUresult cuMemPoolDestroy(CUmemoryPool pool) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolDestroy) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2674,7 +2777,8 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t bytesize,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
@@ -2702,7 +2806,8 @@ CUresult cuMemPoolExportPointer(CUmemPoolPtrExportData *shareData_out,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolExportPointer) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolExportPointer) < 0 ||
       rpc_write(conn, shareData_out, sizeof(CUmemPoolPtrExportData)) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2725,7 +2830,8 @@ CUresult cuMemPoolImportPointer(CUdeviceptr *ptr_out, CUmemoryPool pool,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolImportPointer) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolImportPointer) < 0 ||
       rpc_write(conn, ptr_out, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
       rpc_write(conn, shareData, sizeof(CUmemPoolPtrExportData)) < 0 ||
@@ -2752,7 +2858,8 @@ CUresult cuMemRangeGetAttributes(void **data, size_t *dataSizes,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemRangeGetAttributes) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
       rpc_write(conn, data, sizeof(void *)) < 0 ||
       rpc_write(conn, dataSizes, sizeof(size_t)) < 0 ||
       rpc_write(conn, attributes, sizeof(CUmem_range_attribute)) < 0 ||
@@ -2781,7 +2888,8 @@ CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamCreate) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2809,7 +2917,8 @@ CUresult cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamCreateWithPriority) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamCreateWithPriority) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &priority, sizeof(int)) < 0 ||
@@ -2834,7 +2943,8 @@ CUresult cuStreamGetPriority(CUstream hStream, int *priority) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetPriority) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamGetPriority) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, priority, sizeof(int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2855,7 +2965,8 @@ CUresult cuStreamGetFlags(CUstream hStream, unsigned int *flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetFlags) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamGetFlags) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2876,7 +2987,8 @@ CUresult cuStreamGetId(CUstream hStream, unsigned long long *streamId) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetId) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamGetId) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, streamId, sizeof(unsigned long long)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2897,7 +3009,8 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetCtx) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamGetCtx) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, pctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2917,7 +3030,9 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuThreadExchangeStreamCaptureMode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuThreadExchangeStreamCaptureMode) <
+          0 ||
       rpc_write(conn, mode, sizeof(CUstreamCaptureMode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, mode, sizeof(CUstreamCaptureMode)) < 0 ||
@@ -2942,7 +3057,8 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamAttachMemAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &dptr_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &length, sizeof(size_t)) < 0 ||
@@ -2966,7 +3082,8 @@ CUresult cuStreamQuery(CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamQuery) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamQuery) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2989,7 +3106,8 @@ CUresult cuStreamSynchronize(CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamSynchronize) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamSynchronize) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -3014,7 +3132,8 @@ CUresult cuStreamDestroy_v2(CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamDestroy_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamDestroy_v2) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3035,7 +3154,8 @@ CUresult cuStreamCopyAttributes(CUstream dst, CUstream src) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamCopyAttributes) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamCopyAttributes) < 0 ||
       rpc_write(conn, &dst, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &src, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3057,7 +3177,8 @@ CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamGetAttribute) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
       rpc_write(conn, value_out, sizeof(CUstreamAttrValue)) < 0 ||
@@ -3081,7 +3202,8 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamSetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamSetAttribute) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
       rpc_write(conn, value, sizeof(const CUstreamAttrValue)) < 0 ||
@@ -3104,7 +3226,8 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuEventCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuEventCreate) < 0 ||
       rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3129,7 +3252,8 @@ CUresult cuEventSynchronize(CUevent hEvent) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuEventSynchronize) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuEventSynchronize) < 0 ||
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -3153,7 +3277,8 @@ CUresult cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuEventElapsedTime_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuEventElapsedTime_v2) < 0 ||
       rpc_write(conn, pMilliseconds, sizeof(float)) < 0 ||
       rpc_write(conn, &hStart, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &hEnd, sizeof(CUevent)) < 0 ||
@@ -3178,7 +3303,8 @@ cuImportExternalMemory(CUexternalMemory *extMem_out,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuImportExternalMemory) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuImportExternalMemory) < 0 ||
       rpc_write(conn, extMem_out, sizeof(CUexternalMemory)) < 0 ||
       rpc_write(conn, memHandleDesc,
                 sizeof(const CUDA_EXTERNAL_MEMORY_HANDLE_DESC)) < 0 ||
@@ -3203,7 +3329,8 @@ CUresult cuExternalMemoryGetMappedBuffer(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
       rpc_write(conn, devPtr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
       rpc_write(conn, bufferDesc,
@@ -3230,8 +3357,9 @@ CUresult cuExternalMemoryGetMappedMipmappedArray(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuExternalMemoryGetMappedMipmappedArray) <
-          0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
+          conn, RPC_cuExternalMemoryGetMappedMipmappedArray) < 0 ||
       rpc_write(conn, mipmap, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
       rpc_write(conn, mipmapDesc,
@@ -3253,7 +3381,8 @@ CUresult cuDestroyExternalMemory(CUexternalMemory extMem) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDestroyExternalMemory) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDestroyExternalMemory) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3275,7 +3404,8 @@ CUresult cuImportExternalSemaphore(
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuImportExternalSemaphore) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuImportExternalSemaphore) < 0 ||
       rpc_write(conn, extSem_out, sizeof(CUexternalSemaphore)) < 0 ||
       rpc_write(conn, semHandleDesc,
                 sizeof(const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC)) < 0 ||
@@ -3309,7 +3439,8 @@ CUresult cuSignalExternalSemaphoresAsync(
   if (numExtSems * sizeof(const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS) != 0 &&
       paramsArray == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
       rpc_write(conn, &numExtSems, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, extSemArray,
                 numExtSems * sizeof(const CUexternalSemaphore)) < 0 ||
@@ -3346,7 +3477,8 @@ CUresult cuWaitExternalSemaphoresAsync(
   if (numExtSems * sizeof(const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS) != 0 &&
       paramsArray == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
       rpc_write(conn, &numExtSems, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, extSemArray,
                 numExtSems * sizeof(const CUexternalSemaphore)) < 0 ||
@@ -3370,7 +3502,8 @@ CUresult cuDestroyExternalSemaphore(CUexternalSemaphore extSem) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
       rpc_write(conn, &extSem, sizeof(CUexternalSemaphore)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3392,7 +3525,8 @@ CUresult cuStreamWaitValue32_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint32_t)) < 0 ||
@@ -3417,7 +3551,8 @@ CUresult cuStreamWaitValue64_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint64_t)) < 0 ||
@@ -3442,7 +3577,8 @@ CUresult cuStreamWriteValue32_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint32_t)) < 0 ||
@@ -3467,7 +3603,8 @@ CUresult cuStreamWriteValue64_v2(CUstream stream, CUdeviceptr addr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &value, sizeof(cuuint64_t)) < 0 ||
@@ -3493,7 +3630,8 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, paramArray, sizeof(CUstreamBatchMemOpParams)) < 0 ||
@@ -3521,7 +3659,8 @@ CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuFuncSetAttribute) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_write(conn, &value, sizeof(int)) < 0 ||
@@ -3546,7 +3685,8 @@ CUresult cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetCacheConfig) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuFuncSetCacheConfig) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3569,7 +3709,8 @@ CUresult cuFuncGetModule(CUmodule *hmod, CUfunction hfunc) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuFuncGetModule) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuFuncGetModule) < 0 ||
       rpc_write(conn, hmod, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3598,7 +3739,8 @@ CUresult cuFuncGetName(const char **name, CUfunction hfunc) {
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (name == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuFuncGetName) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuFuncGetName) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &name_len, sizeof(std::size_t)) < 0 ||
@@ -3630,7 +3772,8 @@ CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetBlockShape) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuFuncSetBlockShape) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &x, sizeof(int)) < 0 ||
       rpc_write(conn, &y, sizeof(int)) < 0 ||
@@ -3651,7 +3794,8 @@ CUresult cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetSharedSize) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuFuncSetSharedSize) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &bytes, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3671,7 +3815,8 @@ CUresult cuParamSetSize(CUfunction hfunc, unsigned int numbytes) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuParamSetSize) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuParamSetSize) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &numbytes, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3691,7 +3836,8 @@ CUresult cuParamSeti(CUfunction hfunc, int offset, unsigned int value) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuParamSeti) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuParamSeti) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &offset, sizeof(int)) < 0 ||
       rpc_write(conn, &value, sizeof(unsigned int)) < 0 ||
@@ -3712,7 +3858,8 @@ CUresult cuParamSetf(CUfunction hfunc, int offset, float value) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuParamSetf) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuParamSetf) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &offset, sizeof(int)) < 0 ||
       rpc_write(conn, &value, sizeof(float)) < 0 ||
@@ -3733,7 +3880,8 @@ CUresult cuLaunch(CUfunction f) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
-  if (lupine_cuda_rpc_start(conn, RPC_cuLaunch) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunch) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3752,7 +3900,8 @@ CUresult cuLaunchGrid(CUfunction f, int grid_width, int grid_height) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
-  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchGrid) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchGrid) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &grid_width, sizeof(int)) < 0 ||
       rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
@@ -3775,7 +3924,8 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
-  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchGridAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchGridAsync) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &grid_width, sizeof(int)) < 0 ||
       rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
@@ -3801,7 +3951,8 @@ cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
           0 ||
       rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
       rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
@@ -3824,7 +3975,8 @@ CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuParamSetTexRef) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuParamSetTexRef) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &texunit, sizeof(int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -3845,7 +3997,8 @@ CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &config, sizeof(CUsharedconfig)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3867,7 +4020,8 @@ CUresult cuGraphCreate(CUgraph *phGraph, unsigned int flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphCreate) < 0 ||
       rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3892,7 +4046,8 @@ CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(CUDA_MEMCPY3D)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3914,7 +4069,8 @@ CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(const CUDA_MEMCPY3D)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3935,7 +4091,8 @@ CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(CUDA_MEMSET_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3957,7 +4114,8 @@ CUresult cuGraphMemsetNodeSetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(const CUDA_MEMSET_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3986,7 +4144,8 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4017,7 +4176,8 @@ CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph *phGraph) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4050,7 +4210,8 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddEmptyNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddEmptyNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4086,7 +4247,8 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4114,7 +4276,8 @@ CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, event_out, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4135,7 +4298,8 @@ CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4164,7 +4328,8 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4192,7 +4357,8 @@ CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, event_out, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4212,7 +4378,8 @@ CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4244,8 +4411,9 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddExternalSemaphoresSignalNode) <
-          0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn,
+                              RPC_cuGraphAddExternalSemaphoresSignalNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4283,7 +4451,8 @@ CUresult cuGraphExternalSemaphoresSignalNodeGetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (params_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
           conn, RPC_cuGraphExternalSemaphoresSignalNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4335,7 +4504,8 @@ CUresult cuGraphExternalSemaphoresSignalNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
           conn, RPC_cuGraphExternalSemaphoresSignalNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -4373,7 +4543,8 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddExternalSemaphoresWaitNode) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresWaitNode) <
           0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
@@ -4411,7 +4582,8 @@ CUresult cuGraphExternalSemaphoresWaitNodeGetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (params_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
           conn, RPC_cuGraphExternalSemaphoresWaitNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4463,7 +4635,8 @@ CUresult cuGraphExternalSemaphoresWaitNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
           conn, RPC_cuGraphExternalSemaphoresWaitNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -4501,7 +4674,8 @@ CUresult cuGraphAddBatchMemOpNode(
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddBatchMemOpNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddBatchMemOpNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4535,7 +4709,8 @@ cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode,
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphBatchMemOpNodeGetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       (lupine_deep_cache_reset((const void *)nodeParams_out), false) ||
@@ -4573,7 +4748,8 @@ CUresult cuGraphBatchMemOpNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphBatchMemOpNodeSetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       rpc_write(conn, nodeParams->paramArray,
@@ -4600,7 +4776,9 @@ CUresult cuGraphExecBatchMemOpNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecBatchMemOpNodeSetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecBatchMemOpNodeSetParams) <
+          0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -4633,7 +4811,8 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4663,7 +4842,8 @@ CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, params_out, sizeof(CUDA_MEM_ALLOC_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4693,7 +4873,8 @@ CUresult cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (numDependencies * sizeof(const CUgraphNode) != 0 &&
       dependencies == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
@@ -4721,7 +4902,8 @@ CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr *dptr_out) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, dptr_out, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4743,7 +4925,8 @@ CUresult cuDeviceGraphMemTrim(CUdevice device) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
       rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4764,7 +4947,8 @@ CUresult cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphClone) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphClone) < 0 ||
       rpc_write(conn, phGraphClone, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &originalGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4792,7 +4976,8 @@ CUresult cuGraphNodeFindInClone(CUgraphNode *phNode, CUgraphNode hOriginalNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphNodeFindInClone) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphNodeFindInClone) < 0 ||
       rpc_write(conn, phNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hOriginalNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hClonedGraph, sizeof(CUgraph)) < 0 ||
@@ -4816,7 +5001,8 @@ CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphNodeGetType) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphNodeGetType) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, type, sizeof(CUgraphNodeType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4838,7 +5024,8 @@ CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
   conn_t *conn = lupine_route_remote_conn(route);
   size_t numNodes_requested = (nodes != nullptr) ? *numNodes : 0;
   uint8_t nodes_null = nodes == nullptr ? 1 : 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphGetNodes) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphGetNodes) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numNodes_requested, sizeof(size_t)) < 0 ||
       rpc_write(conn, &nodes_null, sizeof(uint8_t)) < 0 ||
@@ -4868,7 +5055,8 @@ CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
   conn_t *conn = lupine_route_remote_conn(route);
   size_t numRootNodes_requested = (rootNodes != nullptr) ? *numRootNodes : 0;
   uint8_t rootNodes_null = rootNodes == nullptr ? 1 : 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphGetRootNodes) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphGetRootNodes) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numRootNodes_requested, sizeof(size_t)) < 0 ||
       rpc_write(conn, &rootNodes_null, sizeof(uint8_t)) < 0 ||
@@ -4896,7 +5084,8 @@ CUresult cuGraphDestroyNode(CUgraphNode hNode) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphDestroyNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphDestroyNode) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4919,7 +5108,8 @@ CUresult cuGraphInstantiateWithFlags(CUgraphExec *phGraphExec, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
       rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned long long)) < 0 ||
@@ -4950,7 +5140,8 @@ cuGraphInstantiateWithParams(CUgraphExec *phGraphExec, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
       rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, instantiateParams,
@@ -4977,7 +5168,8 @@ CUresult cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t *flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecGetFlags) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecGetFlags) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, flags, sizeof(cuuint64_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5002,7 +5194,8 @@ CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, copyParams, sizeof(const CUDA_MEMCPY3D)) < 0 ||
@@ -5028,7 +5221,8 @@ cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, memsetParams, sizeof(const CUDA_MEMSET_NODE_PARAMS)) <
@@ -5053,7 +5247,9 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecChildGraphNodeSetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecChildGraphNodeSetParams) <
+          0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &childGraph, sizeof(CUgraph)) < 0 ||
@@ -5075,7 +5271,9 @@ CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecEventRecordNodeSetEvent) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecEventRecordNodeSetEvent) <
+          0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
@@ -5097,7 +5295,8 @@ CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
@@ -5123,7 +5322,8 @@ CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
           conn, RPC_cuGraphExecExternalSemaphoresSignalNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5156,7 +5356,8 @@ CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
           conn, RPC_cuGraphExecExternalSemaphoresWaitNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5185,7 +5386,8 @@ CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &isEnabled, sizeof(unsigned int)) < 0 ||
@@ -5207,7 +5409,8 @@ CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, isEnabled, sizeof(unsigned int)) < 0 ||
@@ -5228,7 +5431,8 @@ CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphUpload) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphUpload) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5247,7 +5451,8 @@ CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphLaunch) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphLaunch) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5266,7 +5471,8 @@ CUresult cuGraphExecDestroy(CUgraphExec hGraphExec) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecDestroy) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -5284,7 +5490,8 @@ CUresult cuGraphDestroy(CUgraph hGraph) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphDestroy) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -5305,7 +5512,8 @@ CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, resultInfo, sizeof(CUgraphExecUpdateResultInfo)) < 0 ||
@@ -5326,7 +5534,8 @@ CUresult cuGraphKernelNodeCopyAttributes(CUgraphNode dst, CUgraphNode src) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
       rpc_write(conn, &dst, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &src, sizeof(CUgraphNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5349,7 +5558,8 @@ CUresult cuGraphKernelNodeGetAttribute(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUkernelNodeAttrID)) < 0 ||
       rpc_write(conn, value_out, sizeof(CUkernelNodeAttrValue)) < 0 ||
@@ -5374,7 +5584,8 @@ CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &attr, sizeof(CUkernelNodeAttrID)) < 0 ||
       rpc_write(conn, value, sizeof(const CUkernelNodeAttrValue)) < 0 ||
@@ -5396,7 +5607,8 @@ CUresult cuGraphDebugDotPrint(CUgraph hGraph, const char *path,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t path_len = std::strlen(path) + 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphDebugDotPrint) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphDebugDotPrint) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &path_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, path, path_len) < 0 ||
@@ -5417,7 +5629,8 @@ CUresult cuUserObjectRetain(CUuserObject object, unsigned int count) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuUserObjectRetain) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuUserObjectRetain) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5436,7 +5649,8 @@ CUresult cuUserObjectRelease(CUuserObject object, unsigned int count) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuUserObjectRelease) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuUserObjectRelease) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5458,7 +5672,8 @@ CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphRetainUserObject) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphRetainUserObject) < 0 ||
       rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -5481,7 +5696,8 @@ CUresult cuGraphReleaseUserObject(CUgraph graph, CUuserObject object,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphReleaseUserObject) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphReleaseUserObject) < 0 ||
       rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -5505,8 +5721,9 @@ CUresult cuOccupancyAvailableDynamicSMemPerBlock(size_t *dynamicSmemSize,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
-  if (lupine_cuda_rpc_start(conn, RPC_cuOccupancyAvailableDynamicSMemPerBlock) <
-          0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
+          conn, RPC_cuOccupancyAvailableDynamicSMemPerBlock) < 0 ||
       rpc_write(conn, dynamicSmemSize, sizeof(size_t)) < 0 ||
       rpc_write(conn, &func_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &numBlocks, sizeof(int)) < 0 ||
@@ -5533,7 +5750,9 @@ CUresult cuOccupancyMaxPotentialClusterSize(int *clusterSize, CUfunction func,
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
   if (config == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuOccupancyMaxPotentialClusterSize) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuOccupancyMaxPotentialClusterSize) <
+          0 ||
       rpc_write(conn, clusterSize, sizeof(int)) < 0 ||
       rpc_write(conn, &func_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, config, sizeof(*config)) < 0 ||
@@ -5561,7 +5780,8 @@ CUresult cuOccupancyMaxActiveClusters(int *numClusters, CUfunction func,
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
   if (config == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
       rpc_write(conn, numClusters, sizeof(int)) < 0 ||
       rpc_write(conn, &func_rpc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, config, sizeof(*config)) < 0 ||
@@ -5585,7 +5805,8 @@ CUresult cuTexRefSetArray(CUtexref hTexRef, CUarray hArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetArray) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetArray) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -5608,7 +5829,8 @@ CUresult cuTexRefSetMipmappedArray(CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -5630,7 +5852,8 @@ CUresult cuTexRefSetAddress_v2(size_t *ByteOffset, CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
       rpc_write(conn, ByteOffset, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -5656,7 +5879,8 @@ CUresult cuTexRefSetAddress2D_v3(CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, desc, sizeof(const CUDA_ARRAY_DESCRIPTOR)) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -5679,7 +5903,8 @@ CUresult cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetFormat) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetFormat) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &fmt, sizeof(CUarray_format)) < 0 ||
       rpc_write(conn, &NumPackedComponents, sizeof(int)) < 0 ||
@@ -5699,7 +5924,8 @@ CUresult cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetAddressMode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetAddressMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &dim, sizeof(int)) < 0 ||
       rpc_write(conn, &am, sizeof(CUaddress_mode)) < 0 ||
@@ -5719,7 +5945,8 @@ CUresult cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetFilterMode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetFilterMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &fm, sizeof(CUfilter_mode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5738,7 +5965,8 @@ CUresult cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &fm, sizeof(CUfilter_mode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5757,7 +5985,8 @@ CUresult cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &bias, sizeof(float)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5779,7 +6008,8 @@ CUresult cuTexRefSetMipmapLevelClamp(CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &minMipmapLevelClamp, sizeof(float)) < 0 ||
       rpc_write(conn, &maxMipmapLevelClamp, sizeof(float)) < 0 ||
@@ -5800,7 +6030,8 @@ CUresult cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &maxAniso, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5820,7 +6051,8 @@ CUresult cuTexRefSetBorderColor(CUtexref hTexRef, float *pBorderColor) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetBorderColor) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetBorderColor) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, pBorderColor, sizeof(float)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5840,7 +6072,8 @@ CUresult cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefSetFlags) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefSetFlags) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5859,7 +6092,8 @@ CUresult cuTexRefGetAddress_v2(CUdeviceptr *pdptr, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
       rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5879,7 +6113,8 @@ CUresult cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetArray) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetArray) < 0 ||
       rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5901,7 +6136,8 @@ CUresult cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
       rpc_write(conn, phMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5922,7 +6158,8 @@ CUresult cuTexRefGetAddressMode(CUaddress_mode *pam, CUtexref hTexRef,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetAddressMode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetAddressMode) < 0 ||
       rpc_write(conn, pam, sizeof(CUaddress_mode)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &dim, sizeof(int)) < 0 ||
@@ -5943,7 +6180,8 @@ CUresult cuTexRefGetFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetFilterMode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetFilterMode) < 0 ||
       rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -5965,7 +6203,8 @@ CUresult cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetFormat) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetFormat) < 0 ||
       rpc_write(conn, pFormat, sizeof(CUarray_format)) < 0 ||
       rpc_write(conn, pNumChannels, sizeof(int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -5987,7 +6226,8 @@ CUresult cuTexRefGetMipmapFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
       rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6007,7 +6247,8 @@ CUresult cuTexRefGetMipmapLevelBias(float *pbias, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
       rpc_write(conn, pbias, sizeof(float)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6030,7 +6271,8 @@ CUresult cuTexRefGetMipmapLevelClamp(float *pminMipmapLevelClamp,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
       rpc_write(conn, pminMipmapLevelClamp, sizeof(float)) < 0 ||
       rpc_write(conn, pmaxMipmapLevelClamp, sizeof(float)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6053,7 +6295,8 @@ CUresult cuTexRefGetMaxAnisotropy(int *pmaxAniso, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
       rpc_write(conn, pmaxAniso, sizeof(int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6074,7 +6317,8 @@ CUresult cuTexRefGetBorderColor(float *pBorderColor, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetBorderColor) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetBorderColor) < 0 ||
       rpc_write(conn, pBorderColor, sizeof(float)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6094,7 +6338,8 @@ CUresult cuTexRefGetFlags(unsigned int *pFlags, CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefGetFlags) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefGetFlags) < 0 ||
       rpc_write(conn, pFlags, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6114,7 +6359,8 @@ CUresult cuTexRefCreate(CUtexref *pTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefCreate) < 0 ||
       rpc_write(conn, pTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pTexRef, sizeof(CUtexref)) < 0 ||
@@ -6133,7 +6379,8 @@ CUresult cuTexRefDestroy(CUtexref hTexRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexRefDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexRefDestroy) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6152,7 +6399,8 @@ CUresult cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuSurfRefSetArray) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuSurfRefSetArray) < 0 ||
       rpc_write(conn, &hSurfRef, sizeof(CUsurfref)) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -6172,7 +6420,8 @@ CUresult cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuSurfRefGetArray) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuSurfRefGetArray) < 0 ||
       rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &hSurfRef, sizeof(CUsurfref)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6198,7 +6447,8 @@ CUresult cuTexObjectCreate(CUtexObject *pTexObject,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexObjectCreate) < 0 ||
       rpc_write(conn, pTexObject, sizeof(CUtexObject)) < 0 ||
       rpc_write(conn, pResDesc, sizeof(const CUDA_RESOURCE_DESC)) < 0 ||
       rpc_write(conn, &pTexDesc, sizeof(const CUDA_TEXTURE_DESC *)) < 0 ||
@@ -6226,7 +6476,8 @@ CUresult cuTexObjectDestroy(CUtexObject texObject) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexObjectDestroy) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6246,7 +6497,8 @@ CUresult cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
       rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6268,7 +6520,8 @@ CUresult cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
       rpc_write(conn, pTexDesc, sizeof(CUDA_TEXTURE_DESC)) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6290,7 +6543,8 @@ CUresult cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC *pResViewDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
       rpc_write(conn, pResViewDesc, sizeof(CUDA_RESOURCE_VIEW_DESC)) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6311,7 +6565,8 @@ CUresult cuSurfObjectCreate(CUsurfObject *pSurfObject,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuSurfObjectCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuSurfObjectCreate) < 0 ||
       rpc_write(conn, pSurfObject, sizeof(CUsurfObject)) < 0 ||
       rpc_write(conn, pResDesc, sizeof(const CUDA_RESOURCE_DESC)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6331,7 +6586,8 @@ CUresult cuSurfObjectDestroy(CUsurfObject surfObject) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuSurfObjectDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuSurfObjectDestroy) < 0 ||
       rpc_write(conn, &surfObject, sizeof(CUsurfObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6351,7 +6607,8 @@ CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
       rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
       rpc_write(conn, &surfObject, sizeof(CUsurfObject)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6371,7 +6628,8 @@ CUresult cuGraphicsUnregisterResource(CUgraphicsResource resource) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6394,7 +6652,8 @@ CUresult cuGraphicsSubResourceGetMappedArray(CUarray *pArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsSubResourceGetMappedArray) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphicsSubResourceGetMappedArray) <
           0 ||
       rpc_write(conn, pArray, sizeof(CUarray)) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
@@ -6420,7 +6679,8 @@ cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray *pMipmappedArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
           conn, RPC_cuGraphicsResourceGetMappedMipmappedArray) < 0 ||
       rpc_write(conn, pMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
@@ -6444,7 +6704,8 @@ CUresult cuGraphicsResourceGetMappedPointer_v2(CUdeviceptr *pDevPtr,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) <
           0 ||
       rpc_write(conn, pDevPtr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, pSize, sizeof(size_t)) < 0 ||
@@ -6469,7 +6730,8 @@ CUresult cuGraphicsResourceSetMapFlags_v2(CUgraphicsResource resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6494,7 +6756,8 @@ CUresult cuGraphicsMapResources(unsigned int count,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(CUgraphicsResource) != 0 && resources == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsMapResources) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphicsMapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, resources, count * sizeof(CUgraphicsResource)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -6520,7 +6783,8 @@ CUresult cuGraphicsUnmapResources(unsigned int count,
   conn_t *conn = lupine_route_remote_conn(route);
   if (count * sizeof(CUgraphicsResource) != 0 && resources == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphicsUnmapResources) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphicsUnmapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, resources, count * sizeof(CUgraphicsResource)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -6545,7 +6809,8 @@ CUresult cuGreenCtxCreate(CUgreenCtx *phCtx, CUdevResourceDesc desc,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGreenCtxCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGreenCtxCreate) < 0 ||
       rpc_write(conn, &desc, sizeof(CUdevResourceDesc)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
@@ -6571,7 +6836,8 @@ CUresult cuGreenCtxDestroy(CUgreenCtx hCtx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGreenCtxDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGreenCtxDestroy) < 0 ||
       rpc_write(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6599,7 +6865,8 @@ CUresult cuCtxFromGreenCtx(CUcontext *pContext, CUgreenCtx hCtx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxFromGreenCtx) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxFromGreenCtx) < 0 ||
       rpc_write(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pContext, sizeof(CUcontext)) < 0 ||
@@ -6630,7 +6897,8 @@ CUresult cuDeviceGetDevResource(CUdevice device, CUdevResource *resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetDevResource) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetDevResource) < 0 ||
       rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &type, sizeof(CUdevResourceType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6654,7 +6922,8 @@ CUresult cuCtxGetDevResource(CUcontext hCtx, CUdevResource *resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetDevResource) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetDevResource) < 0 ||
       rpc_write(conn, &hCtx, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &type, sizeof(CUdevResourceType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6680,7 +6949,8 @@ CUresult cuGreenCtxGetDevResource(CUgreenCtx hCtx, CUdevResource *resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGreenCtxGetDevResource) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGreenCtxGetDevResource) < 0 ||
       rpc_write(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
       rpc_write(conn, &type, sizeof(CUdevResourceType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6711,7 +6981,8 @@ CUresult cuDevSmResourceSplitByCount(
   unsigned int nbGroups_requested = (result != nullptr) ? *nbGroups : 0;
   uint8_t result_null = result == nullptr ? 1 : 0;
   CUdevResource *remainder_null_check;
-  if (lupine_cuda_rpc_start(conn, RPC_cuDevSmResourceSplitByCount) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDevSmResourceSplitByCount) < 0 ||
       rpc_write(conn, &nbGroups_requested, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &result_null, sizeof(uint8_t)) < 0 ||
       rpc_write(conn, input, sizeof(const CUdevResource)) < 0 ||
@@ -6757,7 +7028,8 @@ CUresult cuDevSmResourceSplit(CUdevResource *result, unsigned int nbGroups,
   if (nbGroups * sizeof(CU_DEV_SM_RESOURCE_GROUP_PARAMS) != 0 &&
       groupParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuDevSmResourceSplit) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDevSmResourceSplit) < 0 ||
       rpc_write(conn, &nbGroups, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &result_null, sizeof(uint8_t)) < 0 ||
       rpc_write(conn, input, sizeof(const CUdevResource)) < 0 ||
@@ -6798,7 +7070,8 @@ CUresult cuDevResourceGenerateDesc(CUdevResourceDesc *phDesc,
   conn_t *conn = lupine_route_remote_conn(route);
   if (nbResources * sizeof(CUdevResource) != 0 && resources == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuDevResourceGenerateDesc) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDevResourceGenerateDesc) < 0 ||
       rpc_write(conn, &nbResources, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, resources, nbResources * sizeof(CUdevResource)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6822,7 +7095,8 @@ CUresult cuStreamGetGreenCtx(CUstream hStream, CUgreenCtx *phCtx) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetGreenCtx) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamGetGreenCtx) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phCtx, sizeof(CUgreenCtx)) < 0 ||
@@ -6849,7 +7123,8 @@ CUresult cuGreenCtxStreamCreate(CUstream *phStream, CUgreenCtx greenCtx,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuGreenCtxStreamCreate) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGreenCtxStreamCreate) < 0 ||
       rpc_write(conn, &greenCtx, sizeof(CUgreenCtx)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &priority, sizeof(int)) < 0 ||
@@ -6879,7 +7154,8 @@ CUresult cuStreamGetDevResource(CUstream hStream, CUdevResource *resource,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamGetDevResource) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamGetDevResource) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &type, sizeof(CUdevResourceType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||

--- a/copy_pipeline.cpp
+++ b/copy_pipeline.cpp
@@ -28,7 +28,8 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
   conn_t *conn = lupine_route_remote_conn(route);
   CUdeviceptr src_rpc = srcDevice;
   lupine_translate_managed_host_ptr(srcDevice, &src_rpc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
       rpc_write(conn, &src_rpc, sizeof(src_rpc)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -90,7 +91,8 @@ extern "C" CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
   conn_t *conn = lupine_route_remote_conn(route);
   CUdeviceptr dst_rpc = dstDevice;
   lupine_translate_managed_host_ptr(dstDevice, &dst_rpc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
       rpc_write(conn, &dst_rpc, sizeof(dst_rpc)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -793,7 +793,8 @@ static bool lupine_cuda_is_initialized() {
 
 static CUresult lupine_remote_cuInit(conn_t *conn, unsigned int flags) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuInit) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuInit) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -877,7 +878,8 @@ extern "C" CUresult cuDeviceGetP2PAttribute(int *value,
 
   conn_t *conn = lupine_route_remote_conn(src_route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
       rpc_write(conn, value, sizeof(*value)) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
@@ -922,7 +924,8 @@ extern "C" CUresult cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev,
   }
 
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceCanAccessPeer) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceCanAccessPeer) < 0 ||
       rpc_write(conn, canAccessPeer, sizeof(*canAccessPeer)) < 0 ||
       rpc_write(conn, &dev, sizeof(dev)) < 0 ||
       rpc_write(conn, &peerDev, sizeof(peerDev)) < 0 ||
@@ -950,7 +953,8 @@ extern "C" CUresult cuCtxEnablePeerAccess(CUcontext peerContext,
   }
   conn_t *conn = lupine_route_remote_conn(current_route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxEnablePeerAccess) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxEnablePeerAccess) < 0 ||
       rpc_write(conn, &peerContext, sizeof(peerContext)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -974,7 +978,8 @@ extern "C" CUresult cuCtxDisablePeerAccess(CUcontext peerContext) {
   }
   conn_t *conn = lupine_route_remote_conn(current_route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxDisablePeerAccess) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxDisablePeerAccess) < 0 ||
       rpc_write(conn, &peerContext, sizeof(peerContext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -1050,7 +1055,8 @@ extern "C" CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t name_len = std::strlen(name) + 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetKernel) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -1140,8 +1146,9 @@ static void lupine_prefetch_function_param_layout(CUfunction function,
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn,
-                            LUPINE_RPC_lupineFunctionParamLayoutSnapshot) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(
+          conn, LUPINE_RPC_lupineFunctionParamLayoutSnapshot) < 0 ||
       rpc_write(conn, &function, sizeof(function)) < 0 ||
       rpc_wait_for_response(conn) < 0) {
     return;
@@ -1181,8 +1188,9 @@ static void lupine_prefill_function_attribute_snapshot(CUfunction function,
     return;
   }
 
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineFunctionAttributeSnapshot) <
-          0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn,
+                              LUPINE_RPC_lupineFunctionAttributeSnapshot) < 0 ||
       rpc_write(conn, &function, sizeof(function)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_function_attributes(conn, route, function) < 0 ||
@@ -1210,7 +1218,8 @@ extern "C" CUresult cuModuleGetFunction(CUfunction *function, CUmodule module,
 
   conn_t *conn = lupine_route_remote_conn(route);
   size_t name_len = std::strlen(name) + 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetFunction) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleGetFunction) < 0 ||
       rpc_write(conn, &module, sizeof(module)) < 0 ||
       rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
       rpc_write(conn, name, name_len) < 0 || rpc_wait_for_response(conn) < 0 ||
@@ -1275,7 +1284,8 @@ static CUresult lupine_load_recorded_module_on_route(CUmodule source_module,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     size_t image_size = record.image.size();
-    if (lupine_cuda_rpc_start(conn, RPC_cuModuleLoadData) < 0 ||
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
         rpc_write(conn, &record.kind, sizeof(record.kind)) < 0 ||
         rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
         rpc_write_payload(conn, record.image.data(), image_size) < 0 ||
@@ -1349,7 +1359,8 @@ extern "C" CUresult cuModuleLoad(CUmodule *module, const char *fname) {
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
 
-  bool failed = lupine_cuda_rpc_start(conn, RPC_cuModuleLoad) < 0 ||
+  bool failed = lupine_prepare_rpc(conn) < 0 ||
+                rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
                 rpc_write(conn, &mapped_size, sizeof(mapped_size)) < 0 ||
                 rpc_write_payload(conn, mapping, mapped_size) < 0 ||
                 rpc_wait_for_response(conn) < 0 ||
@@ -1416,7 +1427,8 @@ static CUresult lupine_load_recorded_library_on_route(CUlibrary source_library,
     conn_t *conn = lupine_route_remote_conn(route);
     size_t image_size = record.image.size();
     unsigned int zero_options = 0;
-    if (lupine_cuda_rpc_start(conn, RPC_cuLibraryLoadData) < 0 ||
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
         rpc_write(conn, &record.kind, sizeof(record.kind)) < 0 ||
         rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
         rpc_write_payload(conn, record.image.data(), image_size) < 0 ||
@@ -1494,7 +1506,8 @@ static CUresult lupine_resolve_library_kernel_for_route(CUfunction function,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     std::size_t name_len = record.name.size() + 1;
-    if (lupine_cuda_rpc_start(conn, RPC_cuLibraryGetKernel) < 0 ||
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
         rpc_write(conn, &library, sizeof(library)) < 0 ||
         rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
         rpc_write(conn, record.name.c_str(), name_len) < 0 ||
@@ -1573,7 +1586,8 @@ static CUresult lupine_resolve_module_function_for_route(CUfunction function,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     std::size_t name_len = record.name.size() + 1;
-    if (lupine_cuda_rpc_start(conn, RPC_cuModuleGetFunction) < 0 ||
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuModuleGetFunction) < 0 ||
         rpc_write(conn, &module, sizeof(module)) < 0 ||
         rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
         rpc_write(conn, record.name.c_str(), name_len) < 0 ||
@@ -1879,7 +1893,8 @@ static void lupine_prefill_device_snapshot(conn_t *conn) {
     return;
   }
   CUresult result = CUDA_ERROR_UNKNOWN;
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineDeviceSnapshot) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_lupineDeviceSnapshot) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0) {
     return;
@@ -1960,7 +1975,8 @@ extern "C" CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib,
   }
   CUresult return_value;
   int value = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetAttribute) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(remote_dev)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2004,7 +2020,8 @@ extern "C" CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
     }
   }
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetName) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetName) < 0 ||
       rpc_write(conn, &len, sizeof(int)) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2040,7 +2057,8 @@ extern "C" CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev) {
     return CUDA_SUCCESS;
   }
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 || rpc_read(conn, uuid, 16) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2073,7 +2091,8 @@ extern "C" CUresult cuDeviceTotalMem_v2(size_t *bytes, CUdevice dev) {
     return CUDA_SUCCESS;
   }
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, bytes, sizeof(size_t)) < 0 ||
@@ -2115,7 +2134,8 @@ extern "C" CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxRetain) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRetain) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pctx, sizeof(CUcontext)) < 0 ||
@@ -2146,7 +2166,8 @@ extern "C" CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxRelease_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRelease_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2175,7 +2196,8 @@ extern "C" CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxSetFlags_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxSetFlags_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2209,7 +2231,8 @@ cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags, int *active) {
     }
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxGetState) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxGetState) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, flags, sizeof(unsigned int)) < 0 ||
@@ -2242,7 +2265,8 @@ extern "C" CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuDevicePrimaryCtxReset_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxReset_v2) < 0 ||
       rpc_write(conn, &remote_dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2322,7 +2346,7 @@ static CUresult lupine_cuGetParamInfo_cached(uintptr_t handle,
   size_t size = 0;
   conn_t *conn = lupine_route_remote_conn(route);
   int rpc = kernel ? RPC_cuKernelGetParamInfo : RPC_cuFuncGetParamInfo;
-  if (lupine_cuda_rpc_start(conn, rpc) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 || rpc_write_start_request(conn, rpc) < 0 ||
       rpc_write(conn, &handle, sizeof(handle)) < 0 ||
       rpc_write(conn, &param_index, sizeof(param_index)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2396,7 +2420,8 @@ extern "C" CUresult cuKernelGetFunction(CUfunction *pFunc, CUkernel kernel) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUfunction function = nullptr;
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuKernelGetFunction) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuKernelGetFunction) < 0 ||
       rpc_write(conn, &route_kernel, sizeof(route_kernel)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &function, sizeof(function)) < 0 ||
@@ -2441,7 +2466,8 @@ extern "C" CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   int value = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuKernelGetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuKernelGetAttribute) < 0 ||
       rpc_write(conn, &value, sizeof(value)) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &kernel, sizeof(kernel)) < 0 ||
@@ -2481,7 +2507,8 @@ extern "C" CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
 
   conn_t *conn = lupine_route_remote_conn(route);
   int value = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuFuncGetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuFuncGetAttribute) < 0 ||
       rpc_write(conn, &value, sizeof(value)) < 0 ||
       rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
@@ -2555,7 +2582,8 @@ static CUresult lupine_cuOccupancy_cached(int *numBlocks, CUfunction func,
   int opcode = with_flags
                    ? RPC_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
                    : RPC_cuOccupancyMaxActiveBlocksPerMultiprocessor;
-  if (lupine_cuda_rpc_start(conn, opcode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, opcode) < 0 ||
       rpc_write(conn, &remote_num_blocks, sizeof(remote_num_blocks)) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &blockSize, sizeof(blockSize)) < 0 ||
@@ -2622,7 +2650,8 @@ static CUresult lupine_get_remote_private_module_node(CUcontext context,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_UNKNOWN;
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuPrivateGetModuleNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_cuPrivateGetModuleNode) < 0 ||
       rpc_write(conn, &context, sizeof(context)) < 0 ||
       rpc_write(conn, &module, sizeof(module)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2978,7 +3007,8 @@ static const void *lupine_remote_private_export_table(const CUuuid *uuid) {
   uint32_t trusted = 0;
   uint64_t hashes[LUPINE_PRIVATE_EXPORT_MAX_SLOTS] = {};
 
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuGetExportTableMetadata) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_cuGetExportTableMetadata) < 0 ||
       rpc_write(conn, uuid->bytes, sizeof(uuid->bytes)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 ||
@@ -3102,7 +3132,8 @@ static CUresult lupine_error_string_lookup(int rpc_op, const char *symbol,
   constexpr uint32_t kMaxLength = 4096;
   conn_t *conn = lupine_route_remote_conn(route);
   uint32_t length = 0;
-  if (lupine_cuda_rpc_start(conn, rpc_op) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, rpc_op) < 0 ||
       rpc_write(conn, &error, sizeof(error)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &length, sizeof(length)) < 0 || length > kMaxLength) {
@@ -3164,7 +3195,8 @@ extern "C" CUresult cuEventDestroy_v2(CUevent hEvent) {
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuEventDestroy_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -3269,7 +3301,8 @@ extern "C" CUresult cuMemPoolSetAttribute(CUmemoryPool pool,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolSetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolSetAttribute) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -3339,7 +3372,8 @@ CUresult cuMemExportToShareableHandle(void *shareableHandle,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   lupine_ipc_token token = {};
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemExportToShareableHandle) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemExportToShareableHandle) < 0 ||
       rpc_write(conn, &handle, sizeof(handle)) < 0 ||
       rpc_write(conn, &handleType, sizeof(handleType)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -3381,7 +3415,8 @@ cuMemImportFromShareableHandle(CUmemGenericAllocationHandle *handle,
     return CUDA_ERROR_INVALID_VALUE;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemImportFromShareableHandle) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemImportFromShareableHandle) < 0 ||
       rpc_write(conn, &token, sizeof(token)) < 0 ||
       rpc_write(conn, &shHandleType, sizeof(shHandleType)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3407,7 +3442,8 @@ CUresult cuMemPoolExportToShareableHandle(void *handle_out, CUmemoryPool pool,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   lupine_ipc_token token = {};
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolExportToShareableHandle) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolExportToShareableHandle) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &handleType, sizeof(handleType)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -3452,7 +3488,9 @@ cuMemPoolImportFromShareableHandle(CUmemoryPool *pool_out, void *handle,
     return CUDA_ERROR_INVALID_VALUE;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolImportFromShareableHandle) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolImportFromShareableHandle) <
+          0 ||
       rpc_write(conn, &token, sizeof(token)) < 0 ||
       rpc_write(conn, &handleType, sizeof(handleType)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -3614,7 +3652,8 @@ extern "C" CUresult cuCtxGetDevice(CUdevice *device) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUdevice remote_device = 0;
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetDevice) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetDevice) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &remote_device, sizeof(remote_device)) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -3656,7 +3695,8 @@ extern "C" CUresult cuCtxGetDevice_v2(CUdevice *device, CUcontext ctx) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUdevice remote_device = 0;
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetDevice_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetDevice_v2) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &remote_device, sizeof(remote_device)) < 0 ||
@@ -3693,7 +3733,8 @@ extern "C" CUresult cuMemPoolGetAttribute(CUmemoryPool pool,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPoolGetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPoolGetAttribute) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -3770,7 +3811,8 @@ extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPrefetchAsync) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPrefetchAsync) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &route_device, sizeof(route_device)) < 0 ||
@@ -3824,7 +3866,8 @@ extern "C" CUresult cuMemAdvise(CUdeviceptr devPtr, size_t count,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemAdvise) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemAdvise) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &advice, sizeof(advice)) < 0 ||
@@ -3884,7 +3927,8 @@ extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemPrefetchAsync_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemPrefetchAsync_v2) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &route_location, sizeof(route_location)) < 0 ||
@@ -3934,7 +3978,8 @@ extern "C" CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemAdvise_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemAdvise_v2) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &advice, sizeof(advice)) < 0 ||
@@ -3963,7 +4008,8 @@ extern "C" CUresult cuCtxGetStreamPriorityRange(int *leastPriority,
   int least = 0;
   int greatest = 0;
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxGetStreamPriorityRange) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxGetStreamPriorityRange) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &least, sizeof(least)) < 0 ||
       rpc_read(conn, &greatest, sizeof(greatest)) < 0 ||
@@ -4014,7 +4060,8 @@ extern "C" CUresult cuLinkCreate_v2(unsigned int numOptions,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLinkCreate_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLinkCreate_v2) < 0 ||
       rpc_write(conn, &numOptions, sizeof(numOptions)) < 0 ||
       rpc_write(conn, options, numOptions * sizeof(*options)) < 0 ||
       rpc_write(conn, optionValues, numOptions * sizeof(*optionValues)) < 0 ||
@@ -4053,7 +4100,8 @@ extern "C" CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type,
   CUresult return_value;
   size_t name_len = name == nullptr ? 0 : strlen(name) + 1;
   size_t jit_output_length = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLinkAddData_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLinkAddData_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_write(conn, &type, sizeof(type)) < 0 ||
       rpc_write(conn, &size, sizeof(size)) < 0 ||
@@ -4125,7 +4173,8 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
   file_payload = file_mapping;
   file_size = mapped_file_size;
   has_file_data = 1;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLinkAddFile_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLinkAddFile_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_write(conn, &type, sizeof(type)) < 0 ||
       rpc_write(conn, &path_len, sizeof(path_len)) < 0 ||
@@ -4173,7 +4222,8 @@ extern "C" CUresult cuLinkComplete(CUlinkState state, void **cubinOut,
   size_t cubin_size = 0;
   std::vector<void *> option_values;
   size_t jit_output_length = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLinkComplete) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLinkComplete) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &cubin_size, sizeof(cubin_size)) < 0) {
@@ -4218,7 +4268,8 @@ extern "C" CUresult cuLinkDestroy(CUlinkState state) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLinkDestroy) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLinkDestroy) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -4316,7 +4367,8 @@ extern "C" CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamWaitEvent) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamWaitEvent) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &Flags, sizeof(Flags)) < 0 ||
@@ -4346,7 +4398,8 @@ extern "C" CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
   }
   lupine_note_event_recorded(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuEventRecord) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write_end(conn) < 0) {
@@ -4375,7 +4428,8 @@ extern "C" CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
   }
   lupine_note_event_recorded(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuEventRecordWithFlags) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 || rpc_write_end(conn) < 0) {
@@ -4406,7 +4460,8 @@ static void lupine_prefetch_event_queries(CUevent exclude, conn_t *conn) {
   }
 
   CUresult results[kLupineEventQueryBatch];
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineEventQueryBatch) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_lupineEventQueryBatch) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, events, count * sizeof(*events)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4437,7 +4492,8 @@ extern "C" CUresult cuEventQuery(CUevent hEvent) {
     return lupine_sync_mapped_device_to_host();
   }
   CUresult result = CUDA_ERROR_UNKNOWN;
-  if (lupine_cuda_rpc_start(conn, RPC_cuEventQuery) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_read_deferred_dtoh_copies(conn) < 0 ||
@@ -4478,7 +4534,8 @@ extern "C" CUresult cuCtxCreate_v2(CUcontext *pctx, unsigned int flags,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuCtxCreate_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxCreate_v2) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_write(conn, &dev, sizeof(dev)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4550,7 +4607,7 @@ static CUresult lupine_occupancy_max_potential_block_size(
   CUresult return_value;
   int op = with_flags ? RPC_cuOccupancyMaxPotentialBlockSizeWithFlags
                       : RPC_cuOccupancyMaxPotentialBlockSize;
-  if (lupine_cuda_rpc_start(conn, op) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 || rpc_write_start_request(conn, op) < 0 ||
       rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &dynamicSMemSize, sizeof(dynamicSMemSize)) < 0 ||
       rpc_write(conn, &blockSizeLimit, sizeof(blockSizeLimit)) < 0 ||
@@ -4709,7 +4766,8 @@ extern "C" CUresult cuModuleLoadData(CUmodule *module, const void *image) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t image_size = image_bytes.size();
-  if (lupine_cuda_rpc_start(conn, RPC_cuModuleLoadData) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
       rpc_write(conn, &kind, sizeof(kind)) < 0 ||
       rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
       rpc_write_payload(conn, image_bytes.data(), image_size) < 0 ||
@@ -4754,7 +4812,8 @@ static void lupine_prefill_library_snapshot(CUlibrary library, conn_t *conn) {
 
   CUresult result = CUDA_ERROR_UNKNOWN;
   uint32_t table_count = 0;
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineLibrarySnapshot) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_lupineLibrarySnapshot) < 0 ||
       rpc_write(conn, &library, sizeof(library)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 ||
@@ -4833,7 +4892,8 @@ static void lupine_prefill_library_attribute_snapshot(CUlibrary library,
 
   CUresult result = CUDA_ERROR_UNKNOWN;
   CUdevice remote_device = -1;
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_lupineLibraryAttributeSnapshot) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_lupineLibraryAttributeSnapshot) <
           0 ||
       rpc_write(conn, &library, sizeof(library)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -4942,7 +5002,8 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
   CUresult return_value;
   size_t image_size = image_bytes.size();
   size_t jit_output_length = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLibraryLoadData) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
       rpc_copy_alloc(conn, libraryOptionValues == nullptr
                                ? numLibraryOptions * sizeof(uintptr_t)
                                : 0) < 0 ||
@@ -5199,7 +5260,8 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
        lupine_managed_kernel_requires_launch_sync(f));
   conn_t *conn = lupine_route_remote_conn(route);
   // Fire-and-forget; launch errors are sticky and surface at the next sync.
-  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchKernel) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchKernel) < 0 ||
       rpc_write(conn, &f, sizeof(f)) < 0 ||
       rpc_write(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_write(conn, &gridDimY, sizeof(gridDimY)) < 0 ||
@@ -5317,7 +5379,8 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
   // cluster dimensions) are reported from the launch itself. The server
   // applies the same numAttrs rule when deciding whether to respond.
   bool fire_and_forget = config->numAttrs == 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchKernelEx) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchKernelEx) < 0 ||
       rpc_write(conn, config, sizeof(*config)) < 0 ||
       rpc_write(conn, config->attrs,
                 config->numAttrs * sizeof(*config->attrs)) < 0 ||
@@ -5399,7 +5462,8 @@ cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
       rpc_write(conn, &f, sizeof(f)) < 0 ||
       rpc_write(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_write(conn, &gridDimY, sizeof(gridDimY)) < 0 ||
@@ -5501,7 +5565,8 @@ extern "C" CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
       rpc_write(conn, &srcArray, sizeof(srcArray)) < 0 ||
       rpc_write(conn, &srcOffset, sizeof(srcOffset)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
@@ -5552,7 +5617,8 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
   CUdeviceptr src_rpc = srcDevice;
   lupine_translate_managed_host_ptr(srcDevice, &src_rpc);
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
       rpc_write(conn, &dstHost, sizeof(dstHost)) < 0 ||
       rpc_write(conn, &src_rpc, sizeof(src_rpc)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
@@ -5658,7 +5724,8 @@ static CUresult lupine_cuMemcpy2D_common(const CUDA_MEMCPY2D *pCopy,
   }
   CUresult return_value;
   size_t returned_dst_size = 0;
-  if (lupine_cuda_rpc_start(conn, lupine_memcpy2d_rpc_op(async, unaligned)) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, lupine_memcpy2d_rpc_op(async, unaligned)) <
           0 ||
       rpc_write(conn, &copy, sizeof(copy)) < 0 ||
       rpc_write(conn, &src_host_size, sizeof(src_host_size)) < 0 ||
@@ -5738,7 +5805,7 @@ static CUresult lupine_graph_mem_attribute_rpc(CUdevice device,
   CUresult result = CUDA_ERROR_UNKNOWN;
   int op =
       set ? RPC_cuDeviceSetGraphMemAttribute : RPC_cuDeviceGetGraphMemAttribute;
-  if (lupine_cuda_rpc_start(conn, op) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 || rpc_write_start_request(conn, op) < 0 ||
       rpc_write(conn, &device, sizeof(device)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       (set && rpc_write(conn, value, sizeof(*value)) < 0) ||
@@ -5812,7 +5879,8 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
   }
   CUresult return_value;
   size_t returned_dst_size = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemcpy3D_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemcpy3D_v2) < 0 ||
       rpc_write(conn, &copy, sizeof(copy)) < 0 ||
       rpc_write(conn, &src_host_size, sizeof(src_host_size)) < 0 ||
       rpc_write(conn, src_host, src_host_size) < 0 ||
@@ -6110,7 +6178,8 @@ cuGraphKernelNodeGetParams_v2(CUgraphNode hNode,
       std::make_shared<lupine_graph_kernel_node_params_storage>();
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   CUresult param_info_result = CUDA_SUCCESS;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read_buffer(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -6188,7 +6257,8 @@ cuGraphKernelNodeSetParams_v2(CUgraphNode hNode,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
       rpc_copy_alloc(conn, lupine_param_info_copy_capacity()) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0) {
@@ -6271,7 +6341,8 @@ cuGraphAddKernelNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddKernelNode_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddKernelNode_v2) < 0 ||
       rpc_copy_alloc(conn, lupine_param_info_copy_capacity()) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -6361,7 +6432,8 @@ cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddMemcpyNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddMemcpyNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6400,7 +6472,9 @@ cuGraphExecKernelNodeSetParams_v2(CUgraphExec hGraphExec, CUgraphNode hNode,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecKernelNodeSetParams_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecKernelNodeSetParams_v2) <
+          0 ||
       rpc_copy_alloc(conn, lupine_param_info_copy_capacity()) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
@@ -6477,7 +6551,8 @@ cuGraphAddMemsetNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddMemsetNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddMemsetNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6521,7 +6596,8 @@ cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphAddHostNode) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphAddHostNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6556,7 +6632,8 @@ extern "C" CUresult cuGraphConditionalHandleCreate(
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuGraphConditionalHandleCreate) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_cuGraphConditionalHandleCreate) <
           0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
@@ -6623,7 +6700,8 @@ extern "C" CUresult cuGraphAddNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
   size_t copy_size = nodeParams->type == CU_GRAPH_NODE_TYPE_KERNEL
                          ? lupine_param_info_copy_capacity()
                          : 0;
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuGraphAddNode_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_cuGraphAddNode_v2) < 0 ||
       rpc_copy_alloc(conn, copy_size) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -6746,7 +6824,8 @@ extern "C" CUresult cuGraphGetEdges_v2(CUgraph hGraph, CUgraphNode *from,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphGetEdges_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6802,7 +6881,8 @@ extern "C" CUresult cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphGetEdges_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6868,7 +6948,8 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (lupine_cuda_rpc_start(conn, rpc_id) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, rpc_id) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6960,7 +7041,8 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (lupine_cuda_rpc_start(conn, rpc_id) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, rpc_id) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -7014,7 +7096,8 @@ cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARAMS *nodeParams) {
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   CUDA_HOST_NODE_PARAMS params{};
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &params, sizeof(params)) < 0 ||
@@ -7042,7 +7125,8 @@ cuGraphHostNodeSetParams(CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -7070,7 +7154,8 @@ cuGraphExecHostNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -7105,7 +7190,8 @@ extern "C" CUresult cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuLaunchHostFunc) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchHostFunc) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &fn, sizeof(fn)) < 0 ||
       rpc_write(conn, &userData, sizeof(userData)) < 0 ||
@@ -7135,7 +7221,8 @@ extern "C" CUresult cuStreamAddCallback(CUstream hStream,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamAddCallback) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamAddCallback) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &callback, sizeof(callback)) < 0 ||
       rpc_write(conn, &userData, sizeof(userData)) < 0 ||
@@ -7259,7 +7346,8 @@ static CUresult lupine_cuStreamGetCaptureInfo(
   bool has_edge_data = false;
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuStreamGetCaptureInfo_v3) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_cuStreamGetCaptureInfo_v3) < 0 ||
       rpc_write(conn, &stream, sizeof(stream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &status, sizeof(status)) < 0 ||
@@ -7412,7 +7500,8 @@ extern "C" CUresult cuStreamIsCapturing(CUstream hStream,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamIsCapturing) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamIsCapturing) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, captureStatus, sizeof(CUstreamCaptureStatus)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -7436,7 +7525,8 @@ extern "C" CUresult cuStreamBeginCapture_v2(CUstream hStream,
     return capture_guard.complete(return_value);
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &mode, sizeof(CUstreamCaptureMode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -7461,7 +7551,8 @@ extern "C" CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUgraph *phGraph_null_check;
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamEndCapture) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &phGraph, sizeof(CUgraph *)) < 0 ||
       (phGraph != nullptr && rpc_write(conn, phGraph, sizeof(CUgraph)) < 0) ||
@@ -7574,7 +7665,9 @@ cuStreamBeginCaptureToGraph(CUstream hStream, CUgraph hGraph,
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, LUPINE_RPC_cuStreamBeginCaptureToGraph) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_cuStreamBeginCaptureToGraph) <
+          0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -7612,7 +7705,8 @@ extern "C" CUresult cuStreamUpdateCaptureDependencies_v2(
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuStreamUpdateCaptureDependencies_v2) <
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamUpdateCaptureDependencies_v2) <
           0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
@@ -8499,7 +8593,8 @@ extern "C" CUresult cuKernelGetLibrary(CUlibrary *pLib, CUkernel kernel) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuKernelGetLibrary) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuKernelGetLibrary) < 0 ||
       rpc_write(conn, &kernel, sizeof(kernel)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, pLib, sizeof(*pLib)) < 0 ||
@@ -8749,7 +8844,8 @@ extern "C" CUresult cuTensorMapEncodeTiled(
   const size_t stride_bytes = (tensorRank - 1) * sizeof(cuuint64_t);
   const size_t rank_bytes_u32 = tensorRank * sizeof(cuuint32_t);
 
-  if (lupine_cuda_rpc_start(conn, RPC_cuTensorMapEncodeTiled) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuTensorMapEncodeTiled) < 0 ||
       rpc_write(conn, &tensorDataType, sizeof(tensorDataType)) < 0 ||
       rpc_write(conn, &tensorRank, sizeof(tensorRank)) < 0 ||
       rpc_write(conn, &remote_address, sizeof(remote_address)) < 0 ||

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -926,7 +926,7 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
     if (count == 0) {
       return CUDA_SUCCESS;
     }
-    // This is the flush performed by lupine_cuda_rpc_start(), so it must use
+    // This is the flush performed by lupine_prepare_rpc(), so it must use
     // the raw transport primitive.
     if (rpc_write_start_request(conn, LUPINE_RPC_lupineManagedHostFlush) < 0 ||
         rpc_write(conn, &count, sizeof(count)) < 0 ||
@@ -985,7 +985,7 @@ static CUresult lupine_flush_dirty_host_pages_to_server() {
   return CUDA_SUCCESS;
 }
 
-extern "C" int lupine_cuda_rpc_start(conn_t *conn, int op) {
+extern "C" int lupine_prepare_rpc(conn_t *conn) {
   if (conn == nullptr) {
     return -1;
   }
@@ -1003,7 +1003,7 @@ extern "C" int lupine_cuda_rpc_start(conn_t *conn, int op) {
     }
     lupine_flushed_host_epoch.store(dirty_epoch, std::memory_order_release);
   }
-  return rpc_write_start_request(conn, op);
+  return 0;
 }
 
 static CUresult
@@ -1689,7 +1689,8 @@ static CUresult lupine_remote_cuMemHostAlloc(void **remote_host,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   *remote_host = nullptr;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemHostAlloc) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemHostAlloc) < 0 ||
       rpc_write(conn, remote_host, sizeof(*remote_host)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(bytesize)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -1717,7 +1718,8 @@ static CUresult lupine_remote_cuMemFreeHost(void *remote_host,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemFreeHost) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemFreeHost) < 0 ||
       rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -1744,7 +1746,8 @@ static CUresult lupine_remote_cuMemHostGetDevicePointer(CUdeviceptr *device_ptr,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   *device_ptr = 0;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemHostGetDevicePointer_v2) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemHostGetDevicePointer_v2) < 0 ||
       rpc_write(conn, device_ptr, sizeof(*device_ptr)) < 0 ||
       rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -1772,7 +1775,8 @@ static CUresult lupine_remote_cuMemHostGetFlags(unsigned int *flags,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemHostGetFlags) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemHostGetFlags) < 0 ||
       rpc_write(conn, flags, sizeof(*flags)) < 0 ||
       rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2401,7 +2405,8 @@ extern "C" CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
   size_t backing_size = std::max(bytesize, LUPINE_MANAGED_ALLOCATION_MIN_BYTES);
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_cuda_rpc_start(conn, RPC_cuMemAllocManaged) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemAllocManaged) < 0 ||
       rpc_write(conn, &device_alloc_base, sizeof(device_alloc_base)) < 0 ||
       rpc_write(conn, &backing_size, sizeof(backing_size)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -2498,7 +2503,8 @@ extern "C" CUresult cuMemFree_v2(CUdeviceptr dptr) {
     }
     conn_t *conn = lupine_route_remote_conn(route);
     CUresult return_value;
-    if (lupine_cuda_rpc_start(conn, RPC_cuMemFree_v2) < 0 ||
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemFree_v2) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2595,7 +2601,8 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuPointerGetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuPointerGetAttribute) < 0 ||
       rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
       rpc_write(conn, &query_ptr, sizeof(query_ptr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -2659,7 +2666,8 @@ extern "C" CUresult cuPointerSetAttribute(const void *value,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_cuda_rpc_start(conn, RPC_cuPointerSetAttribute) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuPointerSetAttribute) < 0 ||
       rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
       rpc_write(conn, &target_ptr, sizeof(target_ptr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -2856,7 +2864,8 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_cuda_rpc_start(conn, RPC_cuPointerGetAttributes) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuPointerGetAttributes) < 0 ||
       rpc_write(conn, &numAttributes, sizeof(numAttributes)) < 0 ||
       rpc_write(conn, rpc_attributes,
                 numAttributes * sizeof(CUpointer_attribute)) < 0 ||

--- a/routing.cpp
+++ b/routing.cpp
@@ -197,8 +197,8 @@ lupine_route lupine_route_from_known_kernel_deviceptr_args(
 
 static CUresult lupine_remote_cuDeviceGetCount(conn_t *conn, int *count) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (count == nullptr ||
-      lupine_cuda_rpc_start(conn, RPC_cuDeviceGetCount) < 0 ||
+  if (count == nullptr || lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetCount) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, count, sizeof(*count)) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -210,7 +210,8 @@ static CUresult lupine_remote_cuDeviceGetCount(conn_t *conn, int *count) {
 static CUresult lupine_remote_cuDeviceGet(conn_t *conn, CUdevice *device,
                                           int ordinal) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (device == nullptr || lupine_cuda_rpc_start(conn, RPC_cuDeviceGet) < 0 ||
+  if (device == nullptr || lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuDeviceGet) < 0 ||
       rpc_write(conn, &ordinal, sizeof(ordinal)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, device, sizeof(*device)) < 0 ||
@@ -774,7 +775,8 @@ CUresult lupine_set_current_context_on_route(lupine_route route,
     result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(ctx);
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
-    if (lupine_cuda_rpc_start(conn, RPC_cuCtxSetCurrent) < 0 ||
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
         rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {


### PR DESCRIPTION
## Summary

- replace the combined CUDA RPC start helper with lupine_prepare_rpc
- start each CUDA request explicitly with rpc_write_start_request after preparation
- update codegen templates and checked-in CUDA client output, including the stale main-branch call sites that broke Codegen Test

## Validation

- built lupine_cuda_client with CUDA 13.1 headers
- ran codegen backend-boundary verification
- verified generator round-trip (only expected CUDA 13.1 vs 13.3 header-order differences)
- clang-format-diff clean
- ctest: 7/7 passed