### PR TITLE
feat: generate green context event and id APIs

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2258,6 +2258,18 @@ CUresult cuCtxGetFlags(unsigned int *flags);
  */
 CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId);
 /**
+ * @guard CUDA_VERSION >= 12050
+ * @param hCtx SEND_ONLY
+ * @param hEvent SEND_ONLY
+ */
+CUresult cuCtxRecordEvent(CUcontext hCtx, CUevent hEvent);
+/**
+ * @guard CUDA_VERSION >= 12050
+ * @param hCtx SEND_ONLY
+ * @param hEvent SEND_ONLY
+ */
+CUresult cuCtxWaitEvent(CUcontext hCtx, CUevent hEvent);
+/**
  * @disabled server
  * @synchronize DEFERRED_DTOH STDOUT
  * @routingkey CURRENT_CONTEXT
@@ -3639,6 +3651,27 @@ CUresult cuGreenCtxDestroy(CUgreenCtx hCtx);
  */
 CUresult cuGreenCtxStreamCreate(CUstream *phStream, CUgreenCtx greenCtx,
                                 unsigned int flags, int priority);
+/**
+ * @guard CUDA_VERSION >= 13000
+ * @routingkey CURRENT_CONTEXT
+ * @param greenCtx SEND_ONLY
+ * @param greenCtxId RECV_ONLY
+ */
+CUresult cuGreenCtxGetId(CUgreenCtx greenCtx, unsigned long long *greenCtxId);
+/**
+ * @guard CUDA_VERSION >= 12040
+ * @routingkey CURRENT_CONTEXT
+ * @param hCtx SEND_ONLY
+ * @param hEvent SEND_ONLY
+ */
+CUresult cuGreenCtxRecordEvent(CUgreenCtx hCtx, CUevent hEvent);
+/**
+ * @guard CUDA_VERSION >= 12040
+ * @routingkey CURRENT_CONTEXT
+ * @param hCtx SEND_ONLY
+ * @param hEvent SEND_ONLY
+ */
+CUresult cuGreenCtxWaitEvent(CUgreenCtx hCtx, CUevent hEvent);
 /**
  * @disabled - manual client handles cross-server event waits
  * @routingkey STREAM hStream

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -556,6 +556,46 @@ CUresult cuCtxGetExecAffinity(CUexecAffinityParam *pExecAffinity,
   return return_value;
 }
 
+#if CUDA_VERSION >= 12050
+CUresult cuCtxRecordEvent(CUcontext hCtx, CUevent hEvent) {
+  lupine_route route = lupine_route_for_context(hCtx);
+  CUresult return_value;
+  if (lupine_route_is_local(route))
+    return lupine_call_real_cuda_fn("cuCtxRecordEvent", hCtx, hEvent);
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxRecordEvent) < 0 ||
+      rpc_write(conn, &hCtx, sizeof(CUcontext)) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
+#if CUDA_VERSION >= 12050
+CUresult cuCtxWaitEvent(CUcontext hCtx, CUevent hEvent) {
+  lupine_route route = lupine_route_for_context(hCtx);
+  CUresult return_value;
+  if (lupine_route_is_local(route))
+    return lupine_call_real_cuda_fn("cuCtxWaitEvent", hCtx, hEvent);
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCtxWaitEvent) < 0 ||
+      rpc_write(conn, &hCtx, sizeof(CUcontext)) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
 CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags) {
   lupine_route route = lupine_route_for_default();
   CUresult return_value;
@@ -6473,6 +6513,46 @@ CUresult cuDevResourceGenerateDesc(CUdevResourceDesc *phDesc,
 #endif
 
 #if CUDA_VERSION >= 12040
+CUresult cuGreenCtxRecordEvent(CUgreenCtx hCtx, CUevent hEvent) {
+  lupine_route route = lupine_route_for_current_context();
+  CUresult return_value;
+  if (lupine_route_is_local(route))
+    return lupine_call_real_cuda_fn("cuGreenCtxRecordEvent", hCtx, hEvent);
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGreenCtxRecordEvent) < 0 ||
+      rpc_write(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
+#if CUDA_VERSION >= 12040
+CUresult cuGreenCtxWaitEvent(CUgreenCtx hCtx, CUevent hEvent) {
+  lupine_route route = lupine_route_for_current_context();
+  CUresult return_value;
+  if (lupine_route_is_local(route))
+    return lupine_call_real_cuda_fn("cuGreenCtxWaitEvent", hCtx, hEvent);
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGreenCtxWaitEvent) < 0 ||
+      rpc_write(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
+#if CUDA_VERSION >= 12040
 CUresult cuStreamGetGreenCtx(CUstream hStream, CUgreenCtx *phCtx) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
@@ -6520,6 +6600,26 @@ CUresult cuGreenCtxStreamCreate(CUstream *phStream, CUgreenCtx greenCtx,
   if (return_value == CUDA_SUCCESS && phStream != nullptr) {
     lupine_note_stream_owner_route(*phStream, route);
   }
+  return return_value;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13000
+CUresult cuGreenCtxGetId(CUgreenCtx greenCtx, unsigned long long *greenCtxId) {
+  lupine_route route = lupine_route_for_current_context();
+  CUresult return_value;
+  if (lupine_route_is_local(route))
+    return lupine_call_real_cuda_fn("cuGreenCtxGetId", greenCtx, greenCtxId);
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGreenCtxGetId) < 0 ||
+      rpc_write(conn, &greenCtx, sizeof(CUgreenCtx)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, greenCtxId, sizeof(unsigned long long)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
   return return_value;
 }
 
@@ -6959,6 +7059,12 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuCtxGetStreamPriorityRange", (void *)cuCtxGetStreamPriorityRange},
     {"cuCtxResetPersistingL2Cache", (void *)cuCtxResetPersistingL2Cache},
     {"cuCtxGetExecAffinity", (void *)cuCtxGetExecAffinity},
+#if CUDA_VERSION >= 12050
+    {"cuCtxRecordEvent", (void *)cuCtxRecordEvent},
+#endif
+#if CUDA_VERSION >= 12050
+    {"cuCtxWaitEvent", (void *)cuCtxWaitEvent},
+#endif
     {"cuCtxAttach", (void *)cuCtxAttach},
     {"cuCtxDetach", (void *)cuCtxDetach},
     {"cuCtxGetSharedMemConfig", (void *)cuCtxGetSharedMemConfig},
@@ -7312,10 +7418,19 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuDevResourceGenerateDesc", (void *)cuDevResourceGenerateDesc},
 #endif
 #if CUDA_VERSION >= 12040
+    {"cuGreenCtxRecordEvent", (void *)cuGreenCtxRecordEvent},
+#endif
+#if CUDA_VERSION >= 12040
+    {"cuGreenCtxWaitEvent", (void *)cuGreenCtxWaitEvent},
+#endif
+#if CUDA_VERSION >= 12040
     {"cuStreamGetGreenCtx", (void *)cuStreamGetGreenCtx},
 #endif
 #if CUDA_VERSION >= 12050
     {"cuGreenCtxStreamCreate", (void *)cuGreenCtxStreamCreate},
+#endif
+#if CUDA_VERSION >= 13000
+    {"cuGreenCtxGetId", (void *)cuGreenCtxGetId},
 #endif
 #if CUDA_VERSION >= 13010
     {"cuStreamGetDevResource", (void *)cuStreamGetDevResource},

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -888,6 +888,60 @@ ERROR_0:
   return -1;
 }
 
+#if CUDA_VERSION >= 12050
+int handle_cuCtxRecordEvent(conn_t *conn) {
+  CUcontext hCtx;
+  CUevent hEvent;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hCtx, sizeof(CUcontext)) < 0 ||
+      rpc_read(conn, &hEvent, sizeof(CUevent)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuCtxRecordEvent(hCtx, hEvent);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
+#if CUDA_VERSION >= 12050
+int handle_cuCtxWaitEvent(conn_t *conn) {
+  CUcontext hCtx;
+  CUevent hEvent;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hCtx, sizeof(CUcontext)) < 0 ||
+      rpc_read(conn, &hEvent, sizeof(CUevent)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuCtxWaitEvent(hCtx, hEvent);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
 int handle_cuCtxGetSharedMemConfig(conn_t *conn) {
   CUsharedconfig pConfig;
   int request_id;
@@ -8432,6 +8486,60 @@ ERROR_0:
 #endif
 
 #if CUDA_VERSION >= 12040
+int handle_cuGreenCtxRecordEvent(conn_t *conn) {
+  CUgreenCtx hCtx;
+  CUevent hEvent;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
+      rpc_read(conn, &hEvent, sizeof(CUevent)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuGreenCtxRecordEvent(hCtx, hEvent);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
+#if CUDA_VERSION >= 12040
+int handle_cuGreenCtxWaitEvent(conn_t *conn) {
+  CUgreenCtx hCtx;
+  CUevent hEvent;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hCtx, sizeof(CUgreenCtx)) < 0 ||
+      rpc_read(conn, &hEvent, sizeof(CUevent)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuGreenCtxWaitEvent(hCtx, hEvent);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
+#if CUDA_VERSION >= 12040
 int handle_cuStreamGetGreenCtx(conn_t *conn) {
   CUstream hStream;
   CUgreenCtx phCtx;
@@ -8479,6 +8587,33 @@ int handle_cuGreenCtxStreamCreate(conn_t *conn) {
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &phStream, sizeof(CUstream)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13000
+int handle_cuGreenCtxGetId(conn_t *conn) {
+  CUgreenCtx greenCtx;
+  unsigned long long greenCtxId;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &greenCtx, sizeof(CUgreenCtx)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuGreenCtxGetId(greenCtx, &greenCtxId);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &greenCtxId, sizeof(unsigned long long)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;

--- a/codegen/gen_rpc_ids.h
+++ b/codegen/gen_rpc_ids.h
@@ -45,6 +45,8 @@
 #define RPC_cuCtxGetStreamPriorityRange 1782496290
 #define RPC_cuCtxResetPersistingL2Cache 1127157402
 #define RPC_cuCtxGetExecAffinity 110995246
+#define RPC_cuCtxRecordEvent 64806754
+#define RPC_cuCtxWaitEvent 1390839162
 #define RPC_cuCtxAttach 1257564665
 #define RPC_cuCtxDetach 1203357304
 #define RPC_cuCtxGetSharedMemConfig 1986889819
@@ -379,8 +381,11 @@
 #define RPC_cuDevSmResourceSplitByCount 2128109816
 #define RPC_cuDevSmResourceSplit 1230886197
 #define RPC_cuDevResourceGenerateDesc 1242809183
+#define RPC_cuGreenCtxRecordEvent 1473921838
+#define RPC_cuGreenCtxWaitEvent 1136327306
 #define RPC_cuStreamGetGreenCtx 1723357044
 #define RPC_cuGreenCtxStreamCreate 1433266945
+#define RPC_cuGreenCtxGetId 1724676806
 #define RPC_cuStreamGetDevResource 494275841
 #define RPC_cuCtxCreate_v2 804269166
 #define RPC_cuCtxCreate_v3 1492589816

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -462,6 +462,14 @@ LUPINE_DECLARE_HANDLER(RPC_cuTensorMapEncodeTiled,
 LUPINE_DECLARE_HANDLER(RPC_cuCtxGetDevice_v2, handle_cuCtxGetDevice_v2,
                        rpc_backend::cuda)
 #endif
+#if CUDA_VERSION >= 12050
+LUPINE_DECLARE_HANDLER(RPC_cuCtxRecordEvent, handle_cuCtxRecordEvent,
+                       rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12050
+LUPINE_DECLARE_HANDLER(RPC_cuCtxWaitEvent, handle_cuCtxWaitEvent,
+                       rpc_backend::cuda)
+#endif
 #if CUDA_VERSION >= 12030
 LUPINE_DECLARE_HANDLER(RPC_cuKernelGetName, handle_cuKernelGetName,
                        rpc_backend::cuda)
@@ -542,12 +550,24 @@ LUPINE_DECLARE_HANDLER(RPC_cuDevResourceGenerateDesc,
                        handle_cuDevResourceGenerateDesc, rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
+LUPINE_DECLARE_HANDLER(RPC_cuGreenCtxRecordEvent, handle_cuGreenCtxRecordEvent,
+                       rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12040
+LUPINE_DECLARE_HANDLER(RPC_cuGreenCtxWaitEvent, handle_cuGreenCtxWaitEvent,
+                       rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12040
 LUPINE_DECLARE_HANDLER(RPC_cuStreamGetGreenCtx, handle_cuStreamGetGreenCtx,
                        rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12050
 LUPINE_DECLARE_HANDLER(RPC_cuGreenCtxStreamCreate,
                        handle_cuGreenCtxStreamCreate, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 13000
+LUPINE_DECLARE_HANDLER(RPC_cuGreenCtxGetId, handle_cuGreenCtxGetId,
+                       rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 13010
 LUPINE_DECLARE_HANDLER(RPC_cuStreamGetDevResource,
@@ -577,6 +597,12 @@ const rpc_handler_registry &lupine_rpc_handlers() {
 #endif
 #if CUDA_VERSION >= 13000
       LUPINE_REGISTER_HANDLER(RPC_cuCtxGetDevice_v2, handle_cuCtxGetDevice_v2, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12050
+      LUPINE_REGISTER_HANDLER(RPC_cuCtxRecordEvent, handle_cuCtxRecordEvent, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12050
+      LUPINE_REGISTER_HANDLER(RPC_cuCtxWaitEvent, handle_cuCtxWaitEvent, rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12030
       LUPINE_REGISTER_HANDLER(RPC_cuKernelGetName, handle_cuKernelGetName, rpc_backend::cuda)
@@ -639,10 +665,19 @@ const rpc_handler_registry &lupine_rpc_handlers() {
       LUPINE_REGISTER_HANDLER(RPC_cuDevResourceGenerateDesc, handle_cuDevResourceGenerateDesc, rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
+      LUPINE_REGISTER_HANDLER(RPC_cuGreenCtxRecordEvent, handle_cuGreenCtxRecordEvent, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12040
+      LUPINE_REGISTER_HANDLER(RPC_cuGreenCtxWaitEvent, handle_cuGreenCtxWaitEvent, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12040
       LUPINE_REGISTER_HANDLER(RPC_cuStreamGetGreenCtx, handle_cuStreamGetGreenCtx, rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12050
       LUPINE_REGISTER_HANDLER(RPC_cuGreenCtxStreamCreate, handle_cuGreenCtxStreamCreate, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 13000
+      LUPINE_REGISTER_HANDLER(RPC_cuGreenCtxGetId, handle_cuGreenCtxGetId, rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 13010
       LUPINE_REGISTER_HANDLER(RPC_cuStreamGetDevResource, handle_cuStreamGetDevResource, rpc_backend::cuda)


### PR DESCRIPTION
Generates the five green-context APIs the shim was missing — `cuGreenCtxGetId`, `cuGreenCtxRecordEvent`, `cuGreenCtxWaitEvent`, `cuCtxRecordEvent`, `cuCtxWaitEvent` — with guards matching each API's toolkit introduction (12.04/12.05/13.00).

## Why

These are real driver APIs that exist natively (verified on driver 590.48), but the shim neither exports nor resolves them:

- Applications that link them directly fail at load: `undefined symbol: cuGreenCtxGetId` against main's `libcuda.so.1` (reproduced with a green-context probe; passes with this branch).
- `cuGetProcAddress` reports them `NOT_FOUND`; libnvjpeg is one such prober.

Pure codegen addition; regeneration is byte-idempotent under the pinned CUDA container.

## Scope note (why this doesn't claim #598 anymore)

This originally shipped alongside a host-mirror memory fix for #597/#598. That half was removed after review: #597's samples now pass on main independently, and the #598 root cause that remains — `read(2)` into fault-tracked pinned staging pages failing with EFAULT because kernel-originated writes cannot raise the SIGSEGV handler — is unaffected by API coverage (multi-instance decoder still fails identically with this branch). The full investigation, including the two rejected fix approaches (writable-mirrors regresses nvjpeg's encoder via a nested-pointer internal buffer; libc interposition cannot catch glibc's hidden `__read`) and the two viable designs (userfaultfd write-protection, lazy tracking), is in the comment history. The API-completeness half stands on its own and is what remains here.