### PR TITLE
Fix identity-VA managed flush timeouts

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -59,9 +59,9 @@ a generated client fallback for device-to-device copies whose source and
 destination pointers are owned by different server connections. The fallback
 routes through the client-side cross-server copy helper.
 
-`@param <name> ... TRANSLATE_DEVICEPTR` makes the generated client wrapper
-translate a client-visible managed host alias to the server-visible
-`CUdeviceptr` before routing, local CUDA forwarding, or RPC serialization.
+`CUdeviceptr` values go on the wire unchanged: identity VA arenas place every
+client-visible alias at its server address, so no per-parameter translation is
+generated (connections that cannot reserve the identity arena fail at connect).
 Client-dirty mapped pages are flushed centrally before each CUDA RPC request.
 `@routingfallback <kind> <param>` can be paired with stream routing for APIs
 that route by stream when a stream is supplied and by another object otherwise.

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2775,7 +2775,7 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
  * @disabled server - manual server pipelines large host-to-device copies
  * @synchronize
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
  * @param srcHost SEND_ONLY LENGTH:ByteCount COMPRESSIBLE
  * @server CUDA
@@ -2796,8 +2796,8 @@ CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
  * @synchronize
  * @routingkey DEVICEPTR dstDevice
  * @crossservercopy dstDevice srcDevice ByteCount
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
- * @param srcDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
+ * @param srcDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
  */
 CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
@@ -2918,8 +2918,8 @@ CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
  * @async
  * @routingkey DEVICEPTR dstDevice
  * @crossservercopy dstDevice srcDevice ByteCount STREAM:hStream ASYNC
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
- * @param srcDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
+ * @param srcDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
  * @param hStream SEND_ONLY
  */
@@ -2967,7 +2967,7 @@ CUresult cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy, CUstream hStream);
 /**
  * @synchronize
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param uc SEND_ONLY
  * @param N SEND_ONLY
  */
@@ -2975,7 +2975,7 @@ CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N);
 /**
  * @synchronize
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param us SEND_ONLY
  * @param N SEND_ONLY
  */
@@ -2983,7 +2983,7 @@ CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N);
 /**
  * @synchronize
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param ui SEND_ONLY
  * @param N SEND_ONLY
  */
@@ -2991,7 +2991,7 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N);
 /**
  * @synchronize
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param uc SEND_ONLY
  * @param Width SEND_ONLY
@@ -3002,7 +3002,7 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
 /**
  * @synchronize
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param us SEND_ONLY
  * @param Width SEND_ONLY
@@ -3013,7 +3013,7 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
 /**
  * @synchronize
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param ui SEND_ONLY
  * @param Width SEND_ONLY
@@ -3024,7 +3024,7 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
 /**
  * @async
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param uc SEND_ONLY
  * @param N SEND_ONLY
  * @param hStream SEND_ONLY
@@ -3034,7 +3034,7 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
 /**
  * @async
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param us SEND_ONLY
  * @param N SEND_ONLY
  * @param hStream SEND_ONLY
@@ -3044,7 +3044,7 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
 /**
  * @async
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param ui SEND_ONLY
  * @param N SEND_ONLY
  * @param hStream SEND_ONLY
@@ -3054,7 +3054,7 @@ CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
 /**
  * @async
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param uc SEND_ONLY
  * @param Width SEND_ONLY
@@ -3067,7 +3067,7 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
 /**
  * @async
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param us SEND_ONLY
  * @param Width SEND_ONLY
@@ -3080,7 +3080,7 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
 /**
  * @async
  * @routingkey DEVICEPTR dstDevice
- * @param dstDevice SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param ui SEND_ONLY
  * @param Width SEND_ONLY
@@ -3711,7 +3711,7 @@ CUresult cuStreamUpdateCaptureDependencies(CUstream hStream,
  * @routingkey STREAM hStream
  * @routingfallback DEVICEPTR dptr
  * @param hStream SEND_ONLY
- * @param dptr SEND_ONLY TRANSLATE_DEVICEPTR
+ * @param dptr SEND_ONLY
  * @param length SEND_ONLY
  * @param flags SEND_ONLY
  */

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -30,7 +30,6 @@ from ops import (
     ReleaseAnnotation,
     ParentAnnotation,
     CrossServerCopyAnnotation,
-    DevicePtrTranslationAnnotation,
     FunctionAnnotationMetadata,
     RoutingFallbackAnnotation,
     SynchronizeAnnotation,
@@ -547,10 +546,6 @@ def parse_annotation(
             send = parts[2] == "SEND_ONLY" or parts[2] == "SEND_RECV"
             recv = parts[2] == "RECV_ONLY" or parts[2] == "SEND_RECV"
 
-            if "TRANSLATE_DEVICEPTR" in args:
-                metadata.translate_deviceptrs.append(
-                    DevicePtrTranslationAnnotation(parameter=param)
-                )
             # if there's a length or size arg, use the type, otherwise use the ptr_to type
             length_arg = next((arg for arg in args if arg.startswith("LENGTH:")), None)
 
@@ -877,18 +872,6 @@ def parse_annotation(
     return metadata
 
 
-def client_translated_deviceptr_names(
-    metadata: FunctionAnnotationMetadata,
-) -> set[str]:
-    return {translation.parameter.name for translation in metadata.translate_deviceptrs}
-
-
-def client_param_expr(metadata: FunctionAnnotationMetadata, param: Parameter) -> str:
-    if param.name in client_translated_deviceptr_names(metadata):
-        return f"{param.name}_rpc"
-    return param.name
-
-
 def client_routing_key_expr(
     kind: Optional[str], param: Optional[Parameter], metadata: FunctionAnnotationMetadata
 ) -> str:
@@ -898,7 +881,7 @@ def client_routing_key_expr(
         return "lupine_route_for_current_context()"
     if param is None:
         raise NotImplementedError(f"Routing key {kind} requires a parameter")
-    name = client_param_expr(metadata, param)
+    name = param.name
     if kind == "DEVICE":
         return f"lupine_route_for_device(&{name})"
     if kind == "CONTEXT":
@@ -942,26 +925,10 @@ def client_routing_route_expr(metadata: FunctionAnnotationMetadata) -> str:
 
 
 def client_call_args(function: Function, metadata: FunctionAnnotationMetadata) -> list[str]:
-    return [
-        client_param_expr(metadata, param)
-        for param in function.parameters
-        if param.name
-    ]
+    return [param.name for param in function.parameters if param.name]
 
 
 def write_client_rpc_write(f, operation: Operation, metadata: FunctionAnnotationMetadata):
-    if (
-        isinstance(operation, OpaqueTypeOperation)
-        and operation.send
-        and operation.parameter.name in client_translated_deviceptr_names(metadata)
-    ):
-        f.write(
-            "        rpc_write(conn, &{param_name}_rpc, sizeof({param_type})) < 0 ||\n".format(
-                param_name=operation.parameter.name,
-                param_type=operation.type_.format(),
-            )
-        )
-        return
     operation.client_rpc_write(f)
 
 
@@ -1619,7 +1586,6 @@ def main():
             'extern "C" CUresult lupine_record_library_kernel(CUkernel kernel, CUlibrary library, const char *name, lupine_route route);\n\n'
             'extern "C" CUresult lupine_record_module_function(CUfunction function, CUmodule module, const char *name, lupine_route route);\n\n'
             'extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first, CUdeviceptr second);\n'
-            'extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr, CUdeviceptr *translated);\n'
             'extern "C" CUresult lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice,\n'
             '                                                   CUdeviceptr srcDevice,\n'
             '                                                   size_t ByteCount,\n'
@@ -1656,13 +1622,6 @@ def main():
                 )
             )
             f.write("{\n")
-
-            for translation in metadata.translate_deviceptrs:
-                name = translation.parameter.name
-                f.write(f"    CUdeviceptr {name}_rpc = {name};\n")
-                f.write(
-                    f"    lupine_translate_managed_host_ptr({name}, &{name}_rpc);\n"
-                )
 
             all_output = metadata.routing_parameter
             if metadata.routing_kind == "ALL":
@@ -1721,22 +1680,22 @@ def main():
             if metadata.cross_server_copy is not None:
                 copy = metadata.cross_server_copy
                 stream_arg = (
-                    client_param_expr(metadata, copy.stream)
+                    copy.stream.name
                     if copy.stream is not None
                     else "nullptr"
                 )
                 async_arg = "true" if copy.async_ else "false"
                 f.write(
                     "    if (!lupine_deviceptrs_share_route({dst}, {src})) {{\n".format(
-                        dst=client_param_expr(metadata, copy.dst),
-                        src=client_param_expr(metadata, copy.src),
+                        dst=copy.dst.name,
+                        src=copy.src.name,
                     )
                 )
                 f.write(
                     "        return lupine_cuMemcpyDtoD_via_client({dst}, {src}, {bytes}, {stream}, {async_});\n".format(
-                        dst=client_param_expr(metadata, copy.dst),
-                        src=client_param_expr(metadata, copy.src),
-                        bytes=client_param_expr(metadata, copy.bytes),
+                        dst=copy.dst.name,
+                        src=copy.src.name,
+                        bytes=copy.bytes.name,
                         stream=stream_arg,
                         async_=async_arg,
                     )

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -74,8 +74,6 @@ extern "C" CUresult lupine_record_module_function(CUfunction function,
 
 extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first,
                                               CUdeviceptr second);
-extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
-                                                  CUdeviceptr *translated);
 extern "C" CUresult
 lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                                size_t ByteCount, CUstream hStream, bool async);
@@ -1460,13 +1458,11 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
 
 CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
                          size_t ByteCount) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, const void *, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemcpyHtoD_v2",
-                                                  &return_value, dstDevice_rpc,
+                                                  &return_value, dstDevice,
                                                   srcHost, ByteCount)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
@@ -1478,7 +1474,7 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
   srcHost = lupine_mapped_host_read_source(srcHost, ByteCount);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemcpyHtoD_v2) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
       rpc_write_payload(conn, srcHost, ByteCount) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1492,20 +1488,16 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
 
 CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                          size_t ByteCount) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  CUdeviceptr srcDevice_rpc = srcDevice;
-  lupine_translate_managed_host_ptr(srcDevice, &srcDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
-  if (!lupine_deviceptrs_share_route(dstDevice_rpc, srcDevice_rpc)) {
-    return lupine_cuMemcpyDtoD_via_client(dstDevice_rpc, srcDevice_rpc,
-                                          ByteCount, nullptr, false);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
+  if (!lupine_deviceptrs_share_route(dstDevice, srcDevice)) {
+    return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
+                                          nullptr, false);
   }
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemcpyDtoD_v2",
-                                                  &return_value, dstDevice_rpc,
-                                                  srcDevice_rpc, ByteCount)) {
+                                                  &return_value, dstDevice,
+                                                  srcDevice, ByteCount)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
     return return_value;
@@ -1513,8 +1505,8 @@ CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
-      rpc_write(conn, &srcDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -1632,27 +1624,23 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
 
 CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                               size_t ByteCount, CUstream hStream) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  CUdeviceptr srcDevice_rpc = srcDevice;
-  lupine_translate_managed_host_ptr(srcDevice, &srcDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
-  if (!lupine_deviceptrs_share_route(dstDevice_rpc, srcDevice_rpc)) {
-    return lupine_cuMemcpyDtoD_via_client(dstDevice_rpc, srcDevice_rpc,
-                                          ByteCount, hStream, true);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
+  if (!lupine_deviceptrs_share_route(dstDevice, srcDevice)) {
+    return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
+                                          hStream, true);
   }
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t, CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemcpyDtoDAsync_v2", &return_value, dstDevice_rpc,
-          srcDevice_rpc, ByteCount, hStream)) {
+          route, "cuMemcpyDtoDAsync_v2", &return_value, dstDevice, srcDevice,
+          ByteCount, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
-      rpc_write(conn, &srcDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write_end(conn) < 0) {
@@ -1662,13 +1650,11 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
 }
 
 CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned char, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemsetD8_v2", &return_value, dstDevice_rpc, uc, N)) {
+          route, "cuMemsetD8_v2", &return_value, dstDevice, uc, N)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
     return return_value;
@@ -1676,7 +1662,7 @@ CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD8_v2) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1689,13 +1675,11 @@ CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
 }
 
 CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned short, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemsetD16_v2", &return_value, dstDevice_rpc, us, N)) {
+          route, "cuMemsetD16_v2", &return_value, dstDevice, us, N)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
     return return_value;
@@ -1703,7 +1687,7 @@ CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD16_v2) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1716,13 +1700,11 @@ CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
 }
 
 CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemsetD32_v2", &return_value, dstDevice_rpc, ui, N)) {
+          route, "cuMemsetD32_v2", &return_value, dstDevice, ui, N)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
     return return_value;
@@ -1730,7 +1712,7 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD32_v2) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1744,14 +1726,12 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
 
 CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
                          unsigned char uc, size_t Width, size_t Height) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUdeviceptr, size_t, unsigned char, size_t, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemsetD2D8_v2", &return_value, dstDevice_rpc, dstPitch, uc,
+          route, "cuMemsetD2D8_v2", &return_value, dstDevice, dstPitch, uc,
           Width, Height)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
@@ -1760,7 +1740,7 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D8_v2) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &Width, sizeof(size_t)) < 0 ||
@@ -1776,14 +1756,12 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
 
 CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
                           unsigned short us, size_t Width, size_t Height) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUdeviceptr, size_t, unsigned short, size_t, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemsetD2D16_v2", &return_value, dstDevice_rpc, dstPitch, us,
+          route, "cuMemsetD2D16_v2", &return_value, dstDevice, dstPitch, us,
           Width, Height)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
@@ -1792,7 +1770,7 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D16_v2) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &Width, sizeof(size_t)) < 0 ||
@@ -1808,14 +1786,12 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
 
 CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
                           unsigned int ui, size_t Width, size_t Height) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUdeviceptr, size_t, unsigned int, size_t, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemsetD2D32_v2", &return_value, dstDevice_rpc, dstPitch, ui,
+          route, "cuMemsetD2D32_v2", &return_value, dstDevice, dstPitch, ui,
           Width, Height)) {
     if (return_value == CUDA_SUCCESS)
       return_value = lupine_sync_mapped_device_to_host();
@@ -1824,7 +1800,7 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D32_v2) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &Width, sizeof(size_t)) < 0 ||
@@ -1840,20 +1816,17 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
 
 CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
                          CUstream hStream) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned char, size_t, CUstream);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemsetD8Async",
-                                                  &return_value, dstDevice_rpc,
-                                                  uc, N, hStream)) {
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD8Async", &return_value, dstDevice, uc, N, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -1865,20 +1838,18 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
 
 CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
                           CUstream hStream) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned short, size_t, CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemsetD16Async",
-                                                  &return_value, dstDevice_rpc,
-                                                  us, N, hStream)) {
+                                                  &return_value, dstDevice, us,
+                                                  N, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -1890,20 +1861,18 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
 
 CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
                           CUstream hStream) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t, CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemsetD32Async",
-                                                  &return_value, dstDevice_rpc,
-                                                  ui, N, hStream)) {
+                                                  &return_value, dstDevice, ui,
+                                                  N, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -1916,21 +1885,19 @@ CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
 CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
                            unsigned char uc, size_t Width, size_t Height,
                            CUstream hStream) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned char, size_t,
                                  size_t, CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemsetD2D8Async", &return_value, dstDevice_rpc, dstPitch,
-          uc, Width, Height, hStream)) {
+          route, "cuMemsetD2D8Async", &return_value, dstDevice, dstPitch, uc,
+          Width, Height, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &Width, sizeof(size_t)) < 0 ||
@@ -1945,21 +1912,19 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
                             unsigned short us, size_t Width, size_t Height,
                             CUstream hStream) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned short, size_t,
                                  size_t, CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemsetD2D16Async", &return_value, dstDevice_rpc, dstPitch,
-          us, Width, Height, hStream)) {
+          route, "cuMemsetD2D16Async", &return_value, dstDevice, dstPitch, us,
+          Width, Height, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &Width, sizeof(size_t)) < 0 ||
@@ -1974,21 +1939,19 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
                             unsigned int ui, size_t Width, size_t Height,
                             CUstream hStream) {
-  CUdeviceptr dstDevice_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dstDevice_rpc);
-  lupine_route route = lupine_route_for_deviceptr(dstDevice_rpc);
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUdeviceptr, size_t, unsigned int, size_t, size_t, CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemsetD2D32Async", &return_value, dstDevice_rpc, dstPitch,
-          ui, Width, Height, hStream)) {
+          route, "cuMemsetD2D32Async", &return_value, dstDevice, dstPitch, ui,
+          Width, Height, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
-      rpc_write(conn, &dstDevice_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &Width, sizeof(size_t)) < 0 ||
@@ -3044,23 +3007,20 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
 
 CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
                                 size_t length, unsigned int flags) {
-  CUdeviceptr dptr_rpc = dptr;
-  lupine_translate_managed_host_ptr(dptr, &dptr_rpc);
-  lupine_route route =
-      (hStream != nullptr ? lupine_route_for_stream(hStream)
-                          : lupine_route_for_deviceptr(dptr_rpc));
+  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
+                                           : lupine_route_for_deviceptr(dptr));
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUstream, CUdeviceptr, size_t, unsigned int);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuStreamAttachMemAsync", &return_value, hStream, dptr_rpc,
-          length, flags)) {
+          route, "cuStreamAttachMemAsync", &return_value, hStream, dptr, length,
+          flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_write(conn, &dptr_rpc, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &length, sizeof(size_t)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3762,6 +3722,34 @@ CUresult cuFuncGetName(const char **name, CUfunction hfunc) {
 
 #endif
 
+CUresult
+cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
+                                     unsigned int numDevices,
+                                     unsigned int flags) {
+  lupine_route route = lupine_route_for_default();
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUDA_LAUNCH_PARAMS *, unsigned int, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLaunchCooperativeKernelMultiDevice", &return_value,
+          launchParamsList, numDevices, flags)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
+          0 ||
+      rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
+      rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
+      rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
 CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
   lupine_route route = lupine_route_for_function(hfunc);
   CUresult return_value;
@@ -3931,34 +3919,6 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height,
       rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
-CUresult
-cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
-                                     unsigned int numDevices,
-                                     unsigned int flags) {
-  lupine_route route = lupine_route_for_default();
-  CUresult return_value;
-  using real_fn_t =
-      CUresult (*)(CUDA_LAUNCH_PARAMS *, unsigned int, unsigned int);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuLaunchCooperativeKernelMultiDevice", &return_value,
-          launchParamsList, numDevices, flags)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
-          0 ||
-      rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
-      rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
-      rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -7736,6 +7696,8 @@ std::unordered_map<std::string, void *> functionMap = {
 #endif
     {"cuFuncGetParamInfo", (void *)cuFuncGetParamInfo},
     {"cuLaunchCooperativeKernel", (void *)cuLaunchCooperativeKernel},
+    {"cuLaunchCooperativeKernelMultiDevice",
+     (void *)cuLaunchCooperativeKernelMultiDevice},
     {"cuFuncSetBlockShape", (void *)cuFuncSetBlockShape},
     {"cuFuncSetSharedSize", (void *)cuFuncSetSharedSize},
     {"cuParamSetSize", (void *)cuParamSetSize},
@@ -7744,8 +7706,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuLaunch", (void *)cuLaunch},
     {"cuLaunchGrid", (void *)cuLaunchGrid},
     {"cuLaunchGridAsync", (void *)cuLaunchGridAsync},
-    {"cuLaunchCooperativeKernelMultiDevice",
-     (void *)cuLaunchCooperativeKernelMultiDevice},
     {"cuParamSetTexRef", (void *)cuParamSetTexRef},
     {"cuFuncSetSharedMemConfig", (void *)cuFuncSetSharedMemConfig},
     {"cuGraphCreate", (void *)cuGraphCreate},

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -1145,11 +1145,6 @@ class CrossServerCopyAnnotation:
 
 
 @dataclass
-class DevicePtrTranslationAnnotation:
-    parameter: Parameter
-
-
-@dataclass
 class RoutingFallbackAnnotation:
     kind: str
     parameter: Parameter
@@ -1180,7 +1175,6 @@ class FunctionAnnotationMetadata:
     releases: list[ReleaseAnnotation] = None
     parents: list[ParentAnnotation] = None
     cross_server_copy: Optional[CrossServerCopyAnnotation] = None
-    translate_deviceptrs: list[DevicePtrTranslationAnnotation] = None
 
     def __post_init__(self):
         if self.record_owners is None:
@@ -1191,5 +1185,3 @@ class FunctionAnnotationMetadata:
             self.releases = []
         if self.parents is None:
             self.parents = []
-        if self.translate_deviceptrs is None:
-            self.translate_deviceptrs = []

--- a/copy_pipeline.cpp
+++ b/copy_pipeline.cpp
@@ -12,9 +12,6 @@
 
 extern "C" const void *lupine_mapped_host_read_source(const void *host,
                                                       size_t size);
-extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
-                                                  CUdeviceptr *translated);
-
 extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
                                     size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(srcDevice);
@@ -26,11 +23,9 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUdeviceptr src_rpc = srcDevice;
-  lupine_translate_managed_host_ptr(srcDevice, &src_rpc);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
-      rpc_write(conn, &src_rpc, sizeof(src_rpc)) < 0 ||
+      rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
@@ -89,11 +84,9 @@ extern "C" CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
   }
   srcHost = lupine_mapped_host_read_source(srcHost, ByteCount);
   conn_t *conn = lupine_route_remote_conn(route);
-  CUdeviceptr dst_rpc = dstDevice;
-  lupine_translate_managed_host_ptr(dstDevice, &dst_rpc);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
-      rpc_write(conn, &dst_rpc, sizeof(dst_rpc)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(dstDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write_payload(conn, srcHost, ByteCount) < 0) {

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -3762,23 +3762,9 @@ extern "C" CUresult cuMemGetInfo(size_t *free, size_t *total) {
   return cuMemGetInfo_v2(free, total);
 }
 
-static CUresult lupine_prepare_prefetch_ptr(CUdeviceptr devPtr,
-                                            CUdeviceptr *translated,
-                                            bool *managed_alias) {
-  *translated = devPtr;
-  *managed_alias = lupine_translate_managed_host_ptr(devPtr, translated);
-  return CUDA_SUCCESS;
-}
-
 extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
                                        CUdevice dstDevice, CUstream hStream) {
-  CUdeviceptr translated = devPtr;
-  bool managed_alias = false;
-  CUresult prepare_result =
-      lupine_prepare_prefetch_ptr(devPtr, &translated, &managed_alias);
-  if (prepare_result != CUDA_SUCCESS) {
-    return prepare_result;
-  }
+  bool managed_alias = lupine_is_managed_host_alias(devPtr);
 
   CUdevice route_device = dstDevice;
   lupine_route route;
@@ -3789,7 +3775,7 @@ extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
     }
   } else {
     route = hStream != nullptr ? lupine_route_for_stream(hStream)
-                               : lupine_route_for_deviceptr(translated);
+                               : lupine_route_for_deviceptr(devPtr);
   }
   if (hStream != nullptr) {
     lupine_route stream_route = lupine_route_for_stream(hStream);
@@ -3803,7 +3789,7 @@ extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
     if (real == nullptr) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
-    return real(translated, count, route_device, hStream);
+    return real(devPtr, count, route_device, hStream);
   }
   if (managed_alias) {
     return CUDA_SUCCESS;
@@ -3813,7 +3799,7 @@ extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
   CUresult return_value;
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemPrefetchAsync) < 0 ||
-      rpc_write(conn, &translated, sizeof(translated)) < 0 ||
+      rpc_write(conn, &devPtr, sizeof(devPtr)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &route_device, sizeof(route_device)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
@@ -3833,13 +3819,7 @@ extern "C" CUresult cuMemPrefetchAsync_ptsz(CUdeviceptr devPtr, size_t count,
 
 extern "C" CUresult cuMemAdvise(CUdeviceptr devPtr, size_t count,
                                 CUmem_advise advice, CUdevice device) {
-  CUdeviceptr translated = devPtr;
-  bool managed_alias = false;
-  CUresult prepare_result =
-      lupine_prepare_prefetch_ptr(devPtr, &translated, &managed_alias);
-  if (prepare_result != CUDA_SUCCESS) {
-    return prepare_result;
-  }
+  bool managed_alias = lupine_is_managed_host_alias(devPtr);
 
   CUdevice route_device = device;
   lupine_route route;
@@ -3849,13 +3829,13 @@ extern "C" CUresult cuMemAdvise(CUdeviceptr devPtr, size_t count,
       return CUDA_ERROR_INVALID_DEVICE;
     }
   } else {
-    route = lupine_route_for_deviceptr(translated);
+    route = lupine_route_for_deviceptr(devPtr);
   }
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(CUdeviceptr, size_t, CUmem_advise, CUdevice);
     auto real = lupine_real_cuda_fn<real_fn_t>("cuMemAdvise");
     return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
-                           : real(translated, count, advice, route_device);
+                           : real(devPtr, count, advice, route_device);
   }
   // Identity-VA managed allocations are device VMM mappings on the server,
   // not native managed allocations. The advice cannot be applied there, but
@@ -3868,7 +3848,7 @@ extern "C" CUresult cuMemAdvise(CUdeviceptr devPtr, size_t count,
   CUresult return_value;
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemAdvise) < 0 ||
-      rpc_write(conn, &translated, sizeof(translated)) < 0 ||
+      rpc_write(conn, &devPtr, sizeof(devPtr)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &advice, sizeof(advice)) < 0 ||
       rpc_write(conn, &route_device, sizeof(route_device)) < 0 ||
@@ -3885,13 +3865,7 @@ extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
                                           CUmemLocation location,
                                           unsigned int flags,
                                           CUstream hStream) {
-  CUdeviceptr translated = devPtr;
-  bool managed_alias = false;
-  CUresult prepare_result =
-      lupine_prepare_prefetch_ptr(devPtr, &translated, &managed_alias);
-  if (prepare_result != CUDA_SUCCESS) {
-    return prepare_result;
-  }
+  bool managed_alias = lupine_is_managed_host_alias(devPtr);
 
   CUmemLocation route_location = location;
   lupine_route route;
@@ -3904,7 +3878,7 @@ extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
     route_location.id = route_device;
   } else {
     route = hStream != nullptr ? lupine_route_for_stream(hStream)
-                               : lupine_route_for_deviceptr(translated);
+                               : lupine_route_for_deviceptr(devPtr);
   }
   if (hStream != nullptr) {
     lupine_route stream_route = lupine_route_for_stream(hStream);
@@ -3919,7 +3893,7 @@ extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
     if (real == nullptr) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
-    return real(translated, count, route_location, flags, hStream);
+    return real(devPtr, count, route_location, flags, hStream);
   }
   if (managed_alias) {
     return CUDA_SUCCESS;
@@ -3929,7 +3903,7 @@ extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
   CUresult return_value;
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemPrefetchAsync_v2) < 0 ||
-      rpc_write(conn, &translated, sizeof(translated)) < 0 ||
+      rpc_write(conn, &devPtr, sizeof(devPtr)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &route_location, sizeof(route_location)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
@@ -3945,13 +3919,7 @@ extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
 extern "C" CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count,
                                    CUmem_advise advice,
                                    CUmemLocation location) {
-  CUdeviceptr translated = devPtr;
-  bool managed_alias = false;
-  CUresult prepare_result =
-      lupine_prepare_prefetch_ptr(devPtr, &translated, &managed_alias);
-  if (prepare_result != CUDA_SUCCESS) {
-    return prepare_result;
-  }
+  bool managed_alias = lupine_is_managed_host_alias(devPtr);
 
   CUmemLocation route_location = location;
   lupine_route route;
@@ -3963,14 +3931,14 @@ extern "C" CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count,
     }
     route_location.id = route_device;
   } else {
-    route = lupine_route_for_deviceptr(translated);
+    route = lupine_route_for_deviceptr(devPtr);
   }
   if (lupine_route_is_local(route)) {
     using real_fn_t =
         CUresult (*)(CUdeviceptr, size_t, CUmem_advise, CUmemLocation);
     auto real = lupine_real_cuda_fn<real_fn_t>("cuMemAdvise_v2");
     return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
-                           : real(translated, count, advice, route_location);
+                           : real(devPtr, count, advice, route_location);
   }
   if (managed_alias) {
     return CUDA_SUCCESS;
@@ -3980,7 +3948,7 @@ extern "C" CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count,
   CUresult return_value;
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemAdvise_v2) < 0 ||
-      rpc_write(conn, &translated, sizeof(translated)) < 0 ||
+      rpc_write(conn, &devPtr, sizeof(devPtr)) < 0 ||
       rpc_write(conn, &count, sizeof(count)) < 0 ||
       rpc_write(conn, &advice, sizeof(advice)) < 0 ||
       rpc_write(conn, &route_location, sizeof(route_location)) < 0 ||
@@ -5615,12 +5583,10 @@ extern "C" CUresult cuMemcpyAtoH(void *dstHost, CUarray srcArray,
 extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
-  CUdeviceptr src_rpc = srcDevice;
-  lupine_translate_managed_host_ptr(srcDevice, &src_rpc);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
       rpc_write(conn, &dstHost, sizeof(dstHost)) < 0 ||
-      rpc_write(conn, &src_rpc, sizeof(src_rpc)) < 0 ||
+      rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write_end(conn) < 0) {
@@ -5715,12 +5681,6 @@ static CUresult lupine_cuMemcpy2D_common(const CUDA_MEMCPY2D *pCopy,
     conn = lupine_rpc_conn_for_stream(stream);
   } else {
     conn = lupine_rpc_conn_for_current_context();
-  }
-  if (copy.srcMemoryType == CU_MEMORYTYPE_DEVICE) {
-    lupine_translate_managed_host_ptr(copy.srcDevice, &copy.srcDevice);
-  }
-  if (copy.dstMemoryType == CU_MEMORYTYPE_DEVICE) {
-    lupine_translate_managed_host_ptr(copy.dstDevice, &copy.dstDevice);
   }
   CUresult return_value;
   size_t returned_dst_size = 0;
@@ -5870,12 +5830,6 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
     conn = lupine_rpc_conn_for_deviceptr(copy.dstDevice);
   } else {
     conn = lupine_rpc_conn_for_current_context();
-  }
-  if (copy.srcMemoryType == CU_MEMORYTYPE_DEVICE) {
-    lupine_translate_managed_host_ptr(copy.srcDevice, &copy.srcDevice);
-  }
-  if (copy.dstMemoryType == CU_MEMORYTYPE_DEVICE) {
-    lupine_translate_managed_host_ptr(copy.dstDevice, &copy.dstDevice);
   }
   CUresult return_value;
   size_t returned_dst_size = 0;
@@ -8822,7 +8776,6 @@ extern "C" CUresult cuTensorMapEncodeTiled(
   }
 
   CUdeviceptr address_rpc = reinterpret_cast<CUdeviceptr>(globalAddress);
-  lupine_translate_managed_host_ptr(address_rpc, &address_rpc);
   lupine_route route = lupine_route_for_deviceptr(address_rpc);
   using real_fn_t = CUresult (*)(
       CUtensorMap *, CUtensorMapDataType, cuuint32_t, void *,

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -3954,8 +3954,6 @@ int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
   return 0;
 }
 
-static bool lupine_server_managed_range(const void *pointer, size_t size);
-
 // Fire-and-forget: connection ordering already guarantees the flush is
 // applied before any later request, so no response is sent.
 int handle_lupineManagedHostFlush(conn_t *conn) {
@@ -3968,28 +3966,12 @@ int handle_lupineManagedHostFlush(conn_t *conn) {
   for (uint32_t i = 0; i < count; ++i) {
     void *server_host_ptr = nullptr;
     size_t bytes = 0;
+    // Host mappings and native identity-VA managed allocations are both CPU
+    // accessible. Reading directly avoids a context-dependent pinned
+    // allocation on this fire-and-forget RPC path.
     if (rpc_read(conn, &server_host_ptr, sizeof(server_host_ptr)) < 0 ||
-        rpc_read(conn, &bytes, sizeof(bytes)) < 0) {
-      return -1;
-    }
-    if (!lupine_server_managed_range(server_host_ptr, bytes)) {
-      if (rpc_read(conn, server_host_ptr, bytes) < 0) {
-        return -1;
-      }
-      continue;
-    }
-    void *staging = nullptr;
-    if (cuMemAllocHost(&staging, bytes) != CUDA_SUCCESS) {
-      return -1;
-    }
-    int read_result = rpc_read(conn, staging, bytes);
-    CUresult copy_result = CUDA_ERROR_UNKNOWN;
-    if (read_result >= 0) {
-      copy_result = cuMemcpyHtoD_v2(
-          reinterpret_cast<CUdeviceptr>(server_host_ptr), staging, bytes);
-    }
-    cuMemFreeHost(staging);
-    if (read_result < 0 || copy_result != CUDA_SUCCESS) {
+        rpc_read(conn, &bytes, sizeof(bytes)) < 0 ||
+        rpc_read(conn, server_host_ptr, bytes) < 0) {
       return -1;
     }
   }
@@ -4454,20 +4436,6 @@ mmap64(void *address, size_t size, int protection, int flags, int fd,
   return mmap(address, size, protection, flags, fd, static_cast<off_t>(offset));
 }
 #endif
-
-static bool lupine_server_managed_range(const void *pointer, size_t size) {
-  uintptr_t address = reinterpret_cast<uintptr_t>(pointer);
-  std::lock_guard<std::mutex> lock(lupine_server_state.mutex);
-  for (const auto &entry : lupine_server_state.allocations) {
-    if (entry.second.kind != lupine_server_allocation_kind::managed ||
-        size > entry.second.size || address < entry.first ||
-        address - entry.first > entry.second.size - size) {
-      continue;
-    }
-    return true;
-  }
-  return false;
-}
 
 // Resolve the device alias here so the client does not need a second round
 // trip for it.

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -1042,22 +1042,15 @@ static bool lupine_host_ptr_in_mapping(CUdeviceptr ptr,
   return true;
 }
 
-extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
-                                                  CUdeviceptr *translated) {
+// A managed allocation's client host alias is mapped at the server device VA
+// (identity arenas are reserve-or-fail at connect), so alias addresses go on
+// the wire unchanged; callers only need to know whether ptr is one.
+extern "C" bool lupine_is_managed_host_alias(CUdeviceptr ptr) {
   void *host = reinterpret_cast<void *>(ptr);
   std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
   auto it = lupine_find_host_allocation_locked(host);
-  if (it == lupine_mutable_host_allocations_locked().end() ||
-      !it->second.managed) {
-    return false;
-  }
-
-  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
-  uintptr_t addr = reinterpret_cast<uintptr_t>(host);
-  if (translated != nullptr) {
-    *translated = it->second.device_ptr + (addr - base);
-  }
-  return true;
+  return it != lupine_mutable_host_allocations_locked().end() &&
+         it->second.managed;
 }
 
 static bool lupine_translate_client_host_ptr_to_server(
@@ -1124,7 +1117,7 @@ static bool lupine_is_client_mapped_address(CUdeviceptr ptr) {
 }
 
 static bool lupine_copy_pointer_is_host(CUdeviceptr ptr) {
-  if (lupine_translate_managed_host_ptr(ptr, nullptr)) {
+  if (lupine_is_managed_host_alias(ptr)) {
     return false;
   }
   if (lupine_host_ptr_is_tracked(ptr)) {
@@ -2577,7 +2570,7 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
   }
 
   CUdeviceptr query_ptr = ptr;
-  bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  bool managed_alias = lupine_is_managed_host_alias(ptr);
   CUdeviceptr remote_host_base = 0;
   CUdeviceptr remote_device_base = 0;
   bool remote_host_alias = false;
@@ -2642,7 +2635,7 @@ extern "C" CUresult cuPointerSetAttribute(const void *value,
   }
 
   CUdeviceptr target_ptr = ptr;
-  if (!lupine_translate_managed_host_ptr(ptr, &target_ptr)) {
+  if (!lupine_is_managed_host_alias(ptr)) {
     lupine_translate_client_host_ptr_to_server(ptr, &target_ptr);
   }
   lupine_route route = lupine_route_for_deviceptr(target_ptr);
@@ -2734,7 +2727,7 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
   }
 
   CUdeviceptr query_ptr = ptr;
-  bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  bool managed_alias = lupine_is_managed_host_alias(ptr);
   CUdeviceptr remote_host_base = 0;
   CUdeviceptr remote_device_base = 0;
   bool remote_host_alias = false;

--- a/memcpy.h
+++ b/memcpy.h
@@ -9,8 +9,7 @@
 
 struct rpc_write_cursor;
 
-extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
-                                                  CUdeviceptr *translated);
+extern "C" bool lupine_is_managed_host_alias(CUdeviceptr ptr);
 extern "C" CUresult lupine_sync_mapped_device_to_host();
 
 CUresult lupine_sync_mapped_host_to_device_for_launch(


### PR DESCRIPTION
## Summary

- write managed host flush payloads directly into native identity-VA managed mappings
- remove the obsolete pinned staging allocation and CUDA copy from the flush handler

## Root cause

Identity VA changed server managed allocations from device-backed VMM mappings to native CUDA managed mappings, but `lupineManagedHostFlush` retained the old pinned-staging path. Under the eight-way CUDA 12.4 L4 workload, `cuMemAllocHost` intermittently returned `CUDA_ERROR_INVALID_CONTEXT` (201) while staging a 4,476,032-byte flush. The RPC is fire-and-forget, so the lane closed without a CUDA response and the client waited until the outer 600-second timeout.

Native managed mappings are CPU-accessible, so the RPC payload can be read directly into the destination. Identity VA preserves pointer values without launch-time inspection or translation.

## Validation

- exact CUDA 12.4 L4 eight-way reproduction before server fix: 3/8 timed out
- fixed CUDA 12.4 L4 stress: 20 fresh eight-way batches, 160/160 passed
- final CUDA 13.1 remote custom suite: 28/29 passed concurrently; the unrelated `CUDA_ERROR_NOT_INITIALIZED` flake passed immediately when rerun alone
- local build and CTest: 9/9 passed (2 signal-provider tests skipped as configured)
