### PR TITLE
Remove launch-time pointer scanning

### DIFF
--- a/client_routing.h
+++ b/client_routing.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <vector>
 
 #define LUPINE_CUDA_COMPAT_TYPES_ONLY
 #include "cuda_compat.h"
@@ -24,10 +23,6 @@ struct lupine_route {
 lupine_route lupine_remote_route_for_conn(conn_t *conn);
 int lupine_route_identity(lupine_route route);
 lupine_route lupine_route_from_identity(int route_id);
-int lupine_known_deviceptr_route_id(CUdeviceptr ptr);
-lupine_route lupine_route_from_known_kernel_deviceptr_args(
-    void *const *kernel_params, const std::vector<size_t> &param_sizes,
-    lupine_route fallback);
 conn_t *lupine_thread_conn_by_index(unsigned int index);
 CUresult lupine_virtual_device_count(int *count);
 CUresult lupine_virtual_device_for_ordinal(CUdevice *device, int ordinal);

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -5064,6 +5064,17 @@ static CUresult lupine_read_kernel_param_sizes(CUkernel kernel,
   }
 }
 
+static std::vector<rpc_write_cursor>
+lupine_kernel_param_cursors(void *const *kernel_params,
+                            const std::vector<size_t> &sizes) {
+  std::vector<rpc_write_cursor> cursors;
+  cursors.reserve(sizes.size());
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    cursors.push_back(rpc_write_cursor::plain(kernel_params[i], sizes[i]));
+  }
+  return cursors;
+}
+
 static CUresult lupine_warm_func_param_info(CUfunction function) {
   for (size_t i = 0;; ++i) {
     size_t offset = 0;
@@ -5185,44 +5196,10 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
     }
   }
 
-  lupine_route arg_route = lupine_route_from_known_kernel_deviceptr_args(
-      kernelParams, param_sizes, launch_route);
-  if (lupine_route_identity(arg_route) != lupine_route_identity(launch_route)) {
-    launch_route = arg_route;
-    status = lupine_resolve_launch_function_for_route(
-        requested_function, launch_route, &route_function, &f);
-    if (status != CUDA_SUCCESS) {
-      return status;
-    }
-    route = lupine_route_for_function(f);
-
-    status = kernel_handle ? lupine_read_kernel_param_sizes(
-                                 reinterpret_cast<CUkernel>(f), &param_sizes)
-                           : lupine_read_func_param_sizes(f, &param_sizes);
-    if (status != CUDA_SUCCESS) {
-      return status;
-    }
-    for (size_t i = 0; i < param_sizes.size(); ++i) {
-      if (kernelParams == nullptr || kernelParams[i] == nullptr) {
-        return CUDA_ERROR_INVALID_VALUE;
-      }
-    }
-    LUPINE_TRACE_LOG("LUPINE cuLaunchKernel rerouted by args f="
-                     << f << " route=" << lupine_route_identity(route));
-  }
-
-  bool used_managed_mapping = false;
   uint32_t param_count = static_cast<uint32_t>(param_sizes.size());
-  std::vector<CUdeviceptr> translated_params(param_count);
-  std::vector<rpc_write_cursor> rpc_params(param_count);
-  status = lupine_sync_mapped_host_to_device_for_launch(
-      kernelParams, param_sizes.data(), param_count, translated_params.data(),
-      rpc_params.data(), &used_managed_mapping);
-  if (status != CUDA_SUCCESS) {
-    return status;
-  }
+  std::vector<rpc_write_cursor> rpc_params =
+      lupine_kernel_param_cursors(kernelParams, param_sizes);
   bool sync_after_launch =
-      used_managed_mapping &&
       (lupine_managed_kernel_requires_launch_sync(requested_function) ||
        lupine_managed_kernel_requires_launch_sync(route_function) ||
        lupine_managed_kernel_requires_launch_sync(f));
@@ -5301,42 +5278,10 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
     }
   }
 
-  lupine_route arg_route = lupine_route_from_known_kernel_deviceptr_args(
-      kernelParams, param_sizes, launch_route);
-  if (lupine_route_identity(arg_route) != lupine_route_identity(launch_route)) {
-    launch_route = arg_route;
-    status = lupine_resolve_launch_function_for_route(
-        requested_function, launch_route, &route_function, &f);
-    if (status != CUDA_SUCCESS) {
-      return status;
-    }
-    route = lupine_route_for_function(f);
-
-    status = kernel_handle ? lupine_read_kernel_param_sizes(
-                                 reinterpret_cast<CUkernel>(f), &param_sizes)
-                           : lupine_read_func_param_sizes(f, &param_sizes);
-    if (status != CUDA_SUCCESS) {
-      return status;
-    }
-    for (size_t i = 0; i < param_sizes.size(); ++i) {
-      if (kernelParams == nullptr || kernelParams[i] == nullptr) {
-        return CUDA_ERROR_INVALID_VALUE;
-      }
-    }
-  }
-
-  bool used_managed_mapping = false;
   uint32_t param_count = static_cast<uint32_t>(param_sizes.size());
-  std::vector<CUdeviceptr> translated_params(param_count);
-  std::vector<rpc_write_cursor> rpc_params(param_count);
-  status = lupine_sync_mapped_host_to_device_for_launch(
-      kernelParams, param_sizes.data(), param_count, translated_params.data(),
-      rpc_params.data(), &used_managed_mapping);
-  if (status != CUDA_SUCCESS) {
-    return status;
-  }
+  std::vector<rpc_write_cursor> rpc_params =
+      lupine_kernel_param_cursors(kernelParams, param_sizes);
   bool sync_after_launch =
-      used_managed_mapping &&
       (lupine_managed_kernel_requires_launch_sync(requested_function) ||
        lupine_managed_kernel_requires_launch_sync(route_function) ||
        lupine_managed_kernel_requires_launch_sync(f));
@@ -5419,14 +5364,8 @@ cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX,
   }
 
   uint32_t param_count = static_cast<uint32_t>(param_sizes.size());
-  std::vector<CUdeviceptr> translated_params(param_count);
-  std::vector<rpc_write_cursor> rpc_params(param_count);
-  status = lupine_sync_mapped_host_to_device_for_launch(
-      kernelParams, param_sizes.data(), param_count, translated_params.data(),
-      rpc_params.data());
-  if (status != CUDA_SUCCESS) {
-    return status;
-  }
+  std::vector<rpc_write_cursor> rpc_params =
+      lupine_kernel_param_cursors(kernelParams, param_sizes);
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -1024,24 +1024,6 @@ lupine_drain_retiring_dirty_ranges(lupine_host_allocation *allocation) {
   return CUDA_SUCCESS;
 }
 
-static bool lupine_device_ptr_in_mapping(CUdeviceptr ptr,
-                                         const lupine_mapped_host_snapshot &m) {
-  return ptr >= m.device_ptr && ptr < m.device_ptr + m.size;
-}
-
-static bool lupine_host_ptr_in_mapping(CUdeviceptr ptr,
-                                       const lupine_mapped_host_snapshot &m,
-                                       CUdeviceptr *translated) {
-  uintptr_t host = reinterpret_cast<uintptr_t>(m.host);
-  if (ptr < host || ptr >= host + m.size) {
-    return false;
-  }
-  if (translated != nullptr) {
-    *translated = m.device_ptr + (ptr - host);
-  }
-  return true;
-}
-
 // A managed allocation's client host alias is mapped at the server device VA
 // (identity arenas are reserve-or-fail at connect), so alias addresses go on
 // the wire unchanged; callers only need to know whether ptr is one.
@@ -1206,56 +1188,6 @@ extern "C" CUresult cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src,
 extern "C" CUresult cuMemcpyAsync_ptsz(CUdeviceptr dst, CUdeviceptr src,
                                        size_t ByteCount, CUstream hStream) {
   return cuMemcpyAsync(dst, src, ByteCount, hStream);
-}
-
-CUresult lupine_sync_mapped_host_to_device_for_launch(
-    void *const *kernel_params, const size_t *sizes, uint32_t count,
-    CUdeviceptr *translated_params, rpc_write_cursor *rpc_params,
-    bool *used_managed_mapping) {
-  if (kernel_params == nullptr || sizes == nullptr ||
-      translated_params == nullptr || rpc_params == nullptr) {
-    return count == 0 ? CUDA_SUCCESS : CUDA_ERROR_INVALID_VALUE;
-  }
-  for (uint32_t i = 0; i < count; ++i) {
-    rpc_params[i] = rpc_write_cursor::plain(kernel_params[i], sizes[i]);
-  }
-  if (used_managed_mapping != nullptr) {
-    *used_managed_mapping = false;
-  }
-  std::vector<lupine_mapped_host_snapshot> snapshots =
-      lupine_mapped_host_snapshots();
-  bool used_managed = false;
-  for (const auto &mapping : snapshots) {
-    bool mapping_used = false;
-    for (uint32_t i = 0; i < count; ++i) {
-      if (sizes[i] != sizeof(CUdeviceptr)) {
-        continue;
-      }
-      CUdeviceptr arg = 0;
-      memcpy(&arg, kernel_params[i], sizeof(arg));
-      CUdeviceptr translated = 0;
-      if (lupine_host_ptr_in_mapping(arg, mapping, &translated)) {
-        translated_params[i] = translated;
-        rpc_params[i].data =
-            reinterpret_cast<const unsigned char *>(&translated_params[i]);
-        used_managed = used_managed || mapping.managed;
-        mapping_used = true;
-        break;
-      }
-      if (lupine_device_ptr_in_mapping(arg, mapping)) {
-        used_managed = used_managed || mapping.managed;
-        mapping_used = true;
-        break;
-      }
-    }
-    if (mapping_used) {
-      lupine_mark_device_mapping_used(mapping.host, mapping.managed);
-    }
-  }
-  if (used_managed_mapping != nullptr) {
-    *used_managed_mapping = used_managed;
-  }
-  return CUDA_SUCCESS;
 }
 
 // Wire-fetch [offset, offset + bytes) of the backing. Handler-safe: must

--- a/memcpy.h
+++ b/memcpy.h
@@ -1,18 +1,8 @@
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
-
 #define LUPINE_CUDA_COMPAT_TYPES_ONLY
 #include "cuda_compat.h"
 #undef LUPINE_CUDA_COMPAT_TYPES_ONLY
 
-struct rpc_write_cursor;
-
 extern "C" bool lupine_is_managed_host_alias(CUdeviceptr ptr);
 extern "C" CUresult lupine_sync_mapped_device_to_host();
-
-CUresult lupine_sync_mapped_host_to_device_for_launch(
-    void *const *kernel_params, const size_t *sizes, uint32_t count,
-    CUdeviceptr *translated_params, rpc_write_cursor *rpc_params,
-    bool *used_managed_mapping = nullptr);

--- a/routing.cpp
+++ b/routing.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -143,56 +142,6 @@ lupine_route lupine_route_from_identity(int route_id) {
         lupine_thread_conn_by_index(static_cast<unsigned int>(route_id)));
   }
   return lupine_route{LUPINE_ROUTE_INVALID, nullptr};
-}
-
-int lupine_known_deviceptr_route_id(CUdeviceptr ptr) {
-  if (ptr == 0) {
-    return -2;
-  }
-  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
-  auto it = lupine_owners<CUdeviceptr>().find(ptr);
-  if (it != lupine_owners<CUdeviceptr>().end()) {
-    return it->second.route_id;
-  }
-  for (const auto &entry : lupine_deviceptr_allocations()) {
-    const auto &allocation = entry.second;
-    if (allocation.base == 0 || allocation.size == 0 || ptr < allocation.base) {
-      continue;
-    }
-    uint64_t offset = static_cast<uint64_t>(ptr - allocation.base);
-    if (offset < allocation.size) {
-      return allocation.route_id;
-    }
-  }
-  return -2;
-}
-
-lupine_route lupine_route_from_known_kernel_deviceptr_args(
-    void *const *kernel_params, const std::vector<size_t> &param_sizes,
-    lupine_route fallback) {
-  int route_id = -2;
-  for (size_t i = 0; i < param_sizes.size(); ++i) {
-    if (param_sizes[i] != sizeof(CUdeviceptr) || kernel_params == nullptr ||
-        kernel_params[i] == nullptr) {
-      continue;
-    }
-    CUdeviceptr ptr = 0;
-    memcpy(&ptr, kernel_params[i], sizeof(ptr));
-    int ptr_route_id = lupine_known_deviceptr_route_id(ptr);
-    if (ptr_route_id == -2) {
-      continue;
-    }
-    if (route_id == -2) {
-      route_id = ptr_route_id;
-    } else if (route_id != ptr_route_id) {
-      return fallback;
-    }
-  }
-  if (route_id == -2 || route_id == lupine_route_identity(fallback)) {
-    return fallback;
-  }
-  lupine_route route = lupine_route_from_identity(route_id);
-  return route.kind == LUPINE_ROUTE_INVALID ? fallback : route;
 }
 
 static CUresult lupine_remote_cuDeviceGetCount(conn_t *conn, int *count) {


### PR DESCRIPTION
## Summary

- send kernel parameter bytes unchanged for `cuLaunchKernel`, `cuLaunchKernelEx`, and `cuLaunchCooperativeKernel`
- remove launch-time mapped-host translation/use detection and device-pointer route inference
- keep the stream/context/function route authoritative
- rely on the existing `lupine_prepare_rpc()` path to flush dirty managed pages before the launch RPC
- preserve the `systemWideAtomics` compatibility sync by identifying that kernel directly instead of discovering a managed pointer argument

With identity VA, managed pointers already have the server-visible value. Non-managed memory continues to use the CUDA copy/mapped-memory APIs; launch argument bytes are not interpreted by the client.

## Validation

- CUDA 13.3 client/server build
- `ctest --test-dir build --output-on-failure` — 8/8 passed (2 configured skips; NVML disabled because its header is not installed in the local CUDA 13.3 toolkit)
- remote custom suite on `inferable-node-008` — 29/29 passed
- remote CUDA 13.3 samples — `UnifiedMemoryStreams` and `systemWideAtomics` both passed