### PR TITLE
Run codegen in a pinned CUDA container

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -19,20 +19,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install CUDA toolkit
-        uses: Jimver/cuda-toolkit@v0.2.36
-        with:
-          cuda: "13.3.1"
-          method: network
-          sub-packages: '["nvcc"]'
-
       - name: Regenerate checked-in sources
-        run: |
-          sudo ln -sfn "$CUDA_PATH" /usr/local/cuda
-          uv run codegen/codegen.py
+        run: ./codegen/run.sh
 
       - name: Verify generated files are current
         run: git diff --exit-code -- codegen

--- a/README.md
+++ b/README.md
@@ -295,27 +295,14 @@ microgpt_train: PASS
 
 ## Local development
 
-Building the binaries requires running codegen first. Lupine codegen reads the cuda dependency header files in order to generate rpc calls.
-
-To ensure codegen works properly, the proper cuda packages need to be installed on your OS. Take a look at our [Dockerfile](./Dockerfile) to see an example.
-
-Take a look [here to install CUDA Toolkit](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_network) (choose your system)
-
-Codegen requires [cuBLAS](https://developer.nvidia.com/hpc-sdk-downloads), [cuDNN](https://developer.nvidia.com/cudnn-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=24.04&target_type=deb_network), [NVML](https://developer.nvidia.com/management-library-nvml), etc:
-
-```py
-cudnn_graph_header = find_header_file("cudnn_graph.h")
-cudnn_ops_header   = find_header_file("cudnn_ops.h")
-cuda_header        = find_header_file("cuda.h")
-cublas_header      = find_header_file("cublas_api.h")
-cudart_header      = find_header_file("cuda_runtime_api.h")
-annotations_header = find_header_file("annotations.h")
-```
+Building the binaries requires running codegen first. The repository provides a
+containerized runner so local development and CI use the same CUDA headers,
+Python, parser, and formatter versions. Docker is the only host dependency.
 
 ### Run codegen
 
 ```bash
-uv run codegen/codegen.py
+./codegen/run.sh
 ```
 
 Ensure there are no errors in the output of the codegen.

--- a/codegen/Dockerfile
+++ b/codegen/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/astral-sh/uv:0.9.18@sha256:5713fa8217f92b80223bc83aac7db36ec80a84437dbc0d04bbc659cae030d8c9 AS uv
+
+FROM nvidia/cuda:13.3.1-devel-ubuntu24.04@sha256:4ff859525f99de5782aa73607ce24219b07dddd48d12b97c1c301d7e1cfb0a87
+
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+ENV UV_PYTHON=3.12.3 \
+    UV_PYTHON_INSTALL_DIR=/tmp/uv-python \
+    UV_CACHE_DIR=/tmp/uv-cache
+
+WORKDIR /workspace
+
+ENTRYPOINT ["uv", "run", "codegen/codegen.py"]

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -78,6 +78,9 @@ waits, manual client/server wire framing, and server-side deferred-copy queue
 management.
 
 With the annotations in place, `codegen.py` reads in the annotations and generates the RPC server and client.
+Run it through `./codegen/run.sh` from the repository root. The runner uses the
+same pinned CUDA 13.3.1 container as CI so generated output does not depend on
+the host's installed toolkit or Python packages.
 
 The motivation for this approach is grounded in codegen being very good at ensuring that the RPC server and client
 match in behavior but not very good at determining the specifics of what should be sent and received. Humans, on

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["clang-format==18.1.3", "cxxheaderparser"]
+# dependencies = ["clang-format==18.1.3", "cxxheaderparser==1.9.2"]
 # ///
 from cxxheaderparser.simple import parse_file, ParsedData, ParserOptions
 from cxxheaderparser.preprocessor import make_gcc_preprocessor

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -3722,34 +3722,6 @@ CUresult cuFuncGetName(const char **name, CUfunction hfunc) {
 
 #endif
 
-CUresult
-cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
-                                     unsigned int numDevices,
-                                     unsigned int flags) {
-  lupine_route route = lupine_route_for_default();
-  CUresult return_value;
-  using real_fn_t =
-      CUresult (*)(CUDA_LAUNCH_PARAMS *, unsigned int, unsigned int);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuLaunchCooperativeKernelMultiDevice", &return_value,
-          launchParamsList, numDevices, flags)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
-          0 ||
-      rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
-      rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
-      rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
   lupine_route route = lupine_route_for_function(hfunc);
   CUresult return_value;
@@ -3919,6 +3891,34 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height,
       rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+CUresult
+cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
+                                     unsigned int numDevices,
+                                     unsigned int flags) {
+  lupine_route route = lupine_route_for_default();
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUDA_LAUNCH_PARAMS *, unsigned int, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLaunchCooperativeKernelMultiDevice", &return_value,
+          launchParamsList, numDevices, flags)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
+          0 ||
+      rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
+      rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
+      rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -7696,8 +7696,6 @@ std::unordered_map<std::string, void *> functionMap = {
 #endif
     {"cuFuncGetParamInfo", (void *)cuFuncGetParamInfo},
     {"cuLaunchCooperativeKernel", (void *)cuLaunchCooperativeKernel},
-    {"cuLaunchCooperativeKernelMultiDevice",
-     (void *)cuLaunchCooperativeKernelMultiDevice},
     {"cuFuncSetBlockShape", (void *)cuFuncSetBlockShape},
     {"cuFuncSetSharedSize", (void *)cuFuncSetSharedSize},
     {"cuParamSetSize", (void *)cuParamSetSize},
@@ -7706,6 +7704,8 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuLaunch", (void *)cuLaunch},
     {"cuLaunchGrid", (void *)cuLaunchGrid},
     {"cuLaunchGridAsync", (void *)cuLaunchGridAsync},
+    {"cuLaunchCooperativeKernelMultiDevice",
+     (void *)cuLaunchCooperativeKernelMultiDevice},
     {"cuParamSetTexRef", (void *)cuParamSetTexRef},
     {"cuFuncSetSharedMemConfig", (void *)cuFuncSetSharedMemConfig},
     {"cuGraphCreate", (void *)cuGraphCreate},

--- a/codegen/run.sh
+++ b/codegen/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/.." && pwd)
+image_name=lupine-codegen:cuda-13.3.1
+
+docker build --file "$script_dir/Dockerfile" --tag "$image_name" "$script_dir"
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --volume "$repo_root:/workspace" \
+  --workdir /workspace \
+  "$image_name" "$@"


### PR DESCRIPTION
Use one reproducible codegen environment locally and in CI.

- pins the CUDA 13.3.1 and uv images by digest
- pins Python 3.12.3, cxxheaderparser 1.9.2, and clang-format 18.1.3
- adds `./codegen/run.sh` as the canonical local/CI command
- regenerates the CUDA client using that environment

This removes host-toolkit ambiguity. PRs that carry stale generated files will still fail deterministically and can be repaired by running the same script.

Tested locally:
- `./codegen/run.sh`
- `git diff --exit-code -- codegen`