### PR TITLE
Regenerate codegen for #546

### DIFF
--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -3722,34 +3722,6 @@ CUresult cuFuncGetName(const char **name, CUfunction hfunc) {
 
 #endif
 
-CUresult
-cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
-                                     unsigned int numDevices,
-                                     unsigned int flags) {
-  lupine_route route = lupine_route_for_default();
-  CUresult return_value;
-  using real_fn_t =
-      CUresult (*)(CUDA_LAUNCH_PARAMS *, unsigned int, unsigned int);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuLaunchCooperativeKernelMultiDevice", &return_value,
-          launchParamsList, numDevices, flags)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
-          0 ||
-      rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
-      rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
-      rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
   lupine_route route = lupine_route_for_function(hfunc);
   CUresult return_value;
@@ -3919,6 +3891,34 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height,
       rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+CUresult
+cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
+                                     unsigned int numDevices,
+                                     unsigned int flags) {
+  lupine_route route = lupine_route_for_default();
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUDA_LAUNCH_PARAMS *, unsigned int, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLaunchCooperativeKernelMultiDevice", &return_value,
+          launchParamsList, numDevices, flags)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
+          0 ||
+      rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
+      rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
+      rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -7696,8 +7696,6 @@ std::unordered_map<std::string, void *> functionMap = {
 #endif
     {"cuFuncGetParamInfo", (void *)cuFuncGetParamInfo},
     {"cuLaunchCooperativeKernel", (void *)cuLaunchCooperativeKernel},
-    {"cuLaunchCooperativeKernelMultiDevice",
-     (void *)cuLaunchCooperativeKernelMultiDevice},
     {"cuFuncSetBlockShape", (void *)cuFuncSetBlockShape},
     {"cuFuncSetSharedSize", (void *)cuFuncSetSharedSize},
     {"cuParamSetSize", (void *)cuParamSetSize},
@@ -7706,6 +7704,8 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuLaunch", (void *)cuLaunch},
     {"cuLaunchGrid", (void *)cuLaunchGrid},
     {"cuLaunchGridAsync", (void *)cuLaunchGridAsync},
+    {"cuLaunchCooperativeKernelMultiDevice",
+     (void *)cuLaunchCooperativeKernelMultiDevice},
     {"cuParamSetTexRef", (void *)cuParamSetTexRef},
     {"cuFuncSetSharedMemConfig", (void *)cuFuncSetSharedMemConfig},
     {"cuGraphCreate", (void *)cuGraphCreate},

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -5606,113 +5606,132 @@ extern "C" CUresult cuMemcpyDtoHAsync(void *dstHost, CUdeviceptr srcDevice,
   return cuMemcpyDtoHAsync_v2(dstHost, srcDevice, ByteCount, hStream);
 }
 
-static size_t lupine_memcpy3d_host_span(const CUDA_MEMCPY3D &copy,
-                                        bool source) {
-  size_t x = source ? copy.srcXInBytes : copy.dstXInBytes;
-  size_t y = source ? copy.srcY : copy.dstY;
-  size_t z = source ? copy.srcZ : copy.dstZ;
-  size_t pitch = source ? copy.srcPitch : copy.dstPitch;
-  size_t height = source ? copy.srcHeight : copy.dstHeight;
-  if (pitch == 0) {
-    pitch = copy.WidthInBytes + x;
-  }
-  if (height == 0) {
-    height = copy.Height + y;
-  }
-  if (copy.WidthInBytes == 0 || copy.Height == 0 || copy.Depth == 0) {
-    return 0;
-  }
-  return (z + copy.Depth - 1) * pitch * height + (y + copy.Height - 1) * pitch +
-         x + copy.WidthInBytes;
-}
-
-static size_t lupine_memcpy2d_host_span(const CUDA_MEMCPY2D &copy,
-                                        bool source) {
-  size_t x = source ? copy.srcXInBytes : copy.dstXInBytes;
-  size_t y = source ? copy.srcY : copy.dstY;
-  size_t pitch = source ? copy.srcPitch : copy.dstPitch;
-  if (pitch == 0) {
-    pitch = copy.WidthInBytes + x;
-  }
-  if (copy.WidthInBytes == 0 || copy.Height == 0) {
-    return 0;
-  }
-  return (y + copy.Height - 1) * pitch + x + copy.WidthInBytes;
-}
-
-static int lupine_memcpy2d_rpc_op(bool async, bool unaligned) {
-  if (async) {
-    return RPC_cuMemcpy2DAsync_v2;
-  }
-  if (unaligned) {
-    return RPC_cuMemcpy2DUnaligned_v2;
-  }
-  return RPC_cuMemcpy2D_v2;
-}
-
-static CUresult lupine_cuMemcpy2D_common(const CUDA_MEMCPY2D *pCopy,
-                                         CUstream stream, bool async,
-                                         bool unaligned) {
+extern "C" CUresult cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy) {
   if (pCopy == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-
   CUDA_MEMCPY2D copy = *pCopy;
-  size_t src_host_size = copy.srcMemoryType == CU_MEMORYTYPE_HOST
-                             ? lupine_memcpy2d_host_span(copy, true)
-                             : 0;
-  size_t dst_host_size = copy.dstMemoryType == CU_MEMORYTYPE_HOST
-                             ? lupine_memcpy2d_host_span(copy, false)
-                             : 0;
-  const void *src_host = copy.srcHost;
-  void *dst_host = copy.dstHost;
-  if ((src_host_size != 0 && src_host == nullptr) ||
-      (dst_host_size != 0 && dst_host == nullptr)) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  conn_t *conn = nullptr;
-  if (copy.srcMemoryType == CU_MEMORYTYPE_DEVICE && copy.srcDevice != 0) {
-    conn = lupine_rpc_conn_for_deviceptr(copy.srcDevice);
-  } else if (copy.dstMemoryType == CU_MEMORYTYPE_DEVICE &&
-             copy.dstDevice != 0) {
-    conn = lupine_rpc_conn_for_deviceptr(copy.dstDevice);
-  } else if (stream != nullptr) {
-    conn = lupine_rpc_conn_for_stream(stream);
-  } else {
-    conn = lupine_rpc_conn_for_current_context();
-  }
-  CUresult return_value;
-  size_t returned_dst_size = 0;
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, lupine_memcpy2d_rpc_op(async, unaligned)) <
-          0 ||
-      rpc_write(conn, &copy, sizeof(copy)) < 0 ||
-      rpc_write(conn, &src_host_size, sizeof(src_host_size)) < 0 ||
-      rpc_write(conn, src_host, src_host_size) < 0 ||
-      rpc_write(conn, &dst_host_size, sizeof(dst_host_size)) < 0 ||
-      (async && rpc_write(conn, &stream, sizeof(stream)) < 0) ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &returned_dst_size, sizeof(returned_dst_size)) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (returned_dst_size > dst_host_size) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (returned_dst_size != 0) {
-    if (rpc_read(conn, dst_host, returned_dst_size) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  // UNIFIED addresses are client-space: a managed alias translates to its
+  // server VA and stays unified on the server, a plain host pointer's bytes
+  // must travel, and a device pointer is already server-valid.
+  bool dst_managed = false;
+  if (copy.srcMemoryType == CU_MEMORYTYPE_UNIFIED) {
+    if (!lupine_is_managed_host_alias(copy.srcDevice) &&
+        lupine_copy_pointer_is_host(copy.srcDevice)) {
+      copy.srcHost = (const void *)copy.srcDevice;
+      copy.srcMemoryType = CU_MEMORYTYPE_HOST;
     }
   }
-  if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (copy.dstMemoryType == CU_MEMORYTYPE_UNIFIED) {
+    void *alias = (void *)copy.dstDevice;
+    if (lupine_is_managed_host_alias(copy.dstDevice)) {
+      dst_managed = true;
+    } else if (lupine_copy_pointer_is_host(copy.dstDevice)) {
+      copy.dstHost = alias;
+      copy.dstMemoryType = CU_MEMORYTYPE_HOST;
+    }
   }
-  return return_value;
-}
-
-extern "C" CUresult cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy) {
-  return lupine_cuMemcpy2D_common(pCopy, nullptr, false, false);
+  bool src_host = copy.srcMemoryType == CU_MEMORYTYPE_HOST;
+  bool dst_host = copy.dstMemoryType == CU_MEMORYTYPE_HOST;
+  lupine_copy_direction direction =
+      src_host ? (dst_host ? lupine_copy_direction::host_to_host
+                           : lupine_copy_direction::host_to_device)
+               : (dst_host ? lupine_copy_direction::device_to_host
+                           : lupine_copy_direction::device_to_device);
+  const char *src_base = (const char *)copy.srcHost +
+                         copy.srcY * copy.srcPitch + copy.srcXInBytes;
+  char *dst_base =
+      (char *)copy.dstHost + copy.dstY * copy.dstPitch + copy.dstXInBytes;
+  CUresult return_value;
+  switch (direction) {
+  case lupine_copy_direction::host_to_host:
+    for (size_t row = 0; row < copy.Height; ++row) {
+      memmove(dst_base + row * copy.dstPitch, src_base + row * copy.srcPitch,
+              copy.WidthInBytes);
+    }
+    return CUDA_SUCCESS;
+  case lupine_copy_direction::host_to_device: {
+    conn_t *conn = copy.dstMemoryType == CU_MEMORYTYPE_ARRAY
+                       ? lupine_rpc_conn_for_current_context()
+                       : lupine_rpc_conn_for_deviceptr(copy.dstDevice);
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy2D_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+                          copy.srcPitch, 1, 0) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS && dst_managed) {
+      return_value = lupine_sync_mapped_device_to_host();
+    }
+    return return_value;
+  }
+  case lupine_copy_direction::device_to_host: {
+    conn_t *conn = copy.srcMemoryType == CU_MEMORYTYPE_ARRAY
+                       ? lupine_rpc_conn_for_current_context()
+                       : lupine_rpc_conn_for_deviceptr(copy.srcDevice);
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy2D_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS) {
+      if (rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+                           copy.dstPitch, 1, 0) < 0) {
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+    }
+    if (rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    return return_value;
+  }
+  case lupine_copy_direction::device_to_device: {
+    if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
+        copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
+        !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
+      // Different devices: the rows route through the client.
+      for (size_t row = 0; row < copy.Height; ++row) {
+        return_value = lupine_cuMemcpyDtoD_via_client(
+            copy.dstDevice + (copy.dstY + row) * copy.dstPitch +
+                copy.dstXInBytes,
+            copy.srcDevice + (copy.srcY + row) * copy.srcPitch +
+                copy.srcXInBytes,
+            copy.WidthInBytes, nullptr, false);
+        if (return_value != CUDA_SUCCESS) {
+          return return_value;
+        }
+      }
+      return dst_managed ? lupine_sync_mapped_device_to_host() : CUDA_SUCCESS;
+    }
+    conn_t *conn;
+    if (copy.dstMemoryType != CU_MEMORYTYPE_ARRAY) {
+      conn = lupine_rpc_conn_for_deviceptr(copy.dstDevice);
+    } else if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY) {
+      conn = lupine_rpc_conn_for_deviceptr(copy.srcDevice);
+    } else {
+      conn = lupine_rpc_conn_for_current_context();
+    }
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy2D_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS && dst_managed) {
+      return_value = lupine_sync_mapped_device_to_host();
+    }
+    return return_value;
+  }
+  }
+  return CUDA_ERROR_INVALID_VALUE;
 }
 
 #ifdef cuMemcpy2D
@@ -5723,7 +5742,131 @@ extern "C" CUresult cuMemcpy2D(const CUDA_MEMCPY2D *pCopy) {
 }
 
 extern "C" CUresult cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy) {
-  return lupine_cuMemcpy2D_common(pCopy, nullptr, false, true);
+  if (pCopy == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUDA_MEMCPY2D copy = *pCopy;
+  // UNIFIED addresses are client-space: a managed alias translates to its
+  // server VA and stays unified on the server, a plain host pointer's bytes
+  // must travel, and a device pointer is already server-valid.
+  bool dst_managed = false;
+  if (copy.srcMemoryType == CU_MEMORYTYPE_UNIFIED) {
+    if (!lupine_is_managed_host_alias(copy.srcDevice) &&
+        lupine_copy_pointer_is_host(copy.srcDevice)) {
+      copy.srcHost = (const void *)copy.srcDevice;
+      copy.srcMemoryType = CU_MEMORYTYPE_HOST;
+    }
+  }
+  if (copy.dstMemoryType == CU_MEMORYTYPE_UNIFIED) {
+    void *alias = (void *)copy.dstDevice;
+    if (lupine_is_managed_host_alias(copy.dstDevice)) {
+      dst_managed = true;
+    } else if (lupine_copy_pointer_is_host(copy.dstDevice)) {
+      copy.dstHost = alias;
+      copy.dstMemoryType = CU_MEMORYTYPE_HOST;
+    }
+  }
+  bool src_host = copy.srcMemoryType == CU_MEMORYTYPE_HOST;
+  bool dst_host = copy.dstMemoryType == CU_MEMORYTYPE_HOST;
+  lupine_copy_direction direction =
+      src_host ? (dst_host ? lupine_copy_direction::host_to_host
+                           : lupine_copy_direction::host_to_device)
+               : (dst_host ? lupine_copy_direction::device_to_host
+                           : lupine_copy_direction::device_to_device);
+  const char *src_base = (const char *)copy.srcHost +
+                         copy.srcY * copy.srcPitch + copy.srcXInBytes;
+  char *dst_base =
+      (char *)copy.dstHost + copy.dstY * copy.dstPitch + copy.dstXInBytes;
+  CUresult return_value;
+  switch (direction) {
+  case lupine_copy_direction::host_to_host:
+    for (size_t row = 0; row < copy.Height; ++row) {
+      memmove(dst_base + row * copy.dstPitch, src_base + row * copy.srcPitch,
+              copy.WidthInBytes);
+    }
+    return CUDA_SUCCESS;
+  case lupine_copy_direction::host_to_device: {
+    conn_t *conn = copy.dstMemoryType == CU_MEMORYTYPE_ARRAY
+                       ? lupine_rpc_conn_for_current_context()
+                       : lupine_rpc_conn_for_deviceptr(copy.dstDevice);
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy2DUnaligned_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+                          copy.srcPitch, 1, 0) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS && dst_managed) {
+      return_value = lupine_sync_mapped_device_to_host();
+    }
+    return return_value;
+  }
+  case lupine_copy_direction::device_to_host: {
+    conn_t *conn = copy.srcMemoryType == CU_MEMORYTYPE_ARRAY
+                       ? lupine_rpc_conn_for_current_context()
+                       : lupine_rpc_conn_for_deviceptr(copy.srcDevice);
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy2DUnaligned_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS) {
+      if (rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+                           copy.dstPitch, 1, 0) < 0) {
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+    }
+    if (rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    return return_value;
+  }
+  case lupine_copy_direction::device_to_device: {
+    if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
+        copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
+        !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
+      // Different devices: the rows route through the client.
+      for (size_t row = 0; row < copy.Height; ++row) {
+        return_value = lupine_cuMemcpyDtoD_via_client(
+            copy.dstDevice + (copy.dstY + row) * copy.dstPitch +
+                copy.dstXInBytes,
+            copy.srcDevice + (copy.srcY + row) * copy.srcPitch +
+                copy.srcXInBytes,
+            copy.WidthInBytes, nullptr, false);
+        if (return_value != CUDA_SUCCESS) {
+          return return_value;
+        }
+      }
+      return dst_managed ? lupine_sync_mapped_device_to_host() : CUDA_SUCCESS;
+    }
+    conn_t *conn;
+    if (copy.dstMemoryType != CU_MEMORYTYPE_ARRAY) {
+      conn = lupine_rpc_conn_for_deviceptr(copy.dstDevice);
+    } else if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY) {
+      conn = lupine_rpc_conn_for_deviceptr(copy.srcDevice);
+    } else {
+      conn = lupine_rpc_conn_for_current_context();
+    }
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy2DUnaligned_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS && dst_managed) {
+      return_value = lupine_sync_mapped_device_to_host();
+    }
+    return return_value;
+  }
+  }
+  return CUDA_ERROR_INVALID_VALUE;
 }
 
 #ifdef cuMemcpy2DUnaligned
@@ -5735,7 +5878,134 @@ extern "C" CUresult cuMemcpy2DUnaligned(const CUDA_MEMCPY2D *pCopy) {
 
 extern "C" CUresult cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy,
                                        CUstream hStream) {
-  return lupine_cuMemcpy2D_common(pCopy, hStream, true, false);
+  if (pCopy == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUDA_MEMCPY2D copy = *pCopy;
+  // UNIFIED addresses are client-space: a managed alias translates to its
+  // server VA and stays unified on the server, a plain host pointer's bytes
+  // must travel, and a device pointer is already server-valid.
+  bool dst_managed = false;
+  if (copy.srcMemoryType == CU_MEMORYTYPE_UNIFIED) {
+    if (!lupine_is_managed_host_alias(copy.srcDevice) &&
+        lupine_copy_pointer_is_host(copy.srcDevice)) {
+      copy.srcHost = (const void *)copy.srcDevice;
+      copy.srcMemoryType = CU_MEMORYTYPE_HOST;
+    }
+  }
+  if (copy.dstMemoryType == CU_MEMORYTYPE_UNIFIED) {
+    void *alias = (void *)copy.dstDevice;
+    if (lupine_is_managed_host_alias(copy.dstDevice)) {
+      dst_managed = true;
+    } else if (lupine_copy_pointer_is_host(copy.dstDevice)) {
+      copy.dstHost = alias;
+      copy.dstMemoryType = CU_MEMORYTYPE_HOST;
+    }
+  }
+  bool src_host = copy.srcMemoryType == CU_MEMORYTYPE_HOST;
+  bool dst_host = copy.dstMemoryType == CU_MEMORYTYPE_HOST;
+  lupine_copy_direction direction =
+      src_host ? (dst_host ? lupine_copy_direction::host_to_host
+                           : lupine_copy_direction::host_to_device)
+               : (dst_host ? lupine_copy_direction::device_to_host
+                           : lupine_copy_direction::device_to_device);
+  const char *src_base = (const char *)copy.srcHost +
+                         copy.srcY * copy.srcPitch + copy.srcXInBytes;
+  char *dst_base =
+      (char *)copy.dstHost + copy.dstY * copy.dstPitch + copy.dstXInBytes;
+  CUresult return_value;
+  switch (direction) {
+  case lupine_copy_direction::host_to_host:
+    for (size_t row = 0; row < copy.Height; ++row) {
+      memmove(dst_base + row * copy.dstPitch, src_base + row * copy.srcPitch,
+              copy.WidthInBytes);
+    }
+    return CUDA_SUCCESS;
+  case lupine_copy_direction::host_to_device: {
+    conn_t *conn = copy.dstMemoryType == CU_MEMORYTYPE_ARRAY
+                       ? lupine_rpc_conn_for_stream(hStream)
+                       : lupine_rpc_conn_for_deviceptr(copy.dstDevice);
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy2DAsync_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+                          copy.srcPitch, 1, 0) < 0 ||
+        rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS && dst_managed) {
+      return_value = lupine_sync_mapped_device_to_host();
+    }
+    return return_value;
+  }
+  case lupine_copy_direction::device_to_host: {
+    conn_t *conn = copy.srcMemoryType == CU_MEMORYTYPE_ARRAY
+                       ? lupine_rpc_conn_for_stream(hStream)
+                       : lupine_rpc_conn_for_deviceptr(copy.srcDevice);
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy2DAsync_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS) {
+      if (rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+                           copy.dstPitch, 1, 0) < 0) {
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+    }
+    if (rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    return return_value;
+  }
+  case lupine_copy_direction::device_to_device: {
+    if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
+        copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
+        !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
+      // Different devices: the rows route through the client.
+      for (size_t row = 0; row < copy.Height; ++row) {
+        return_value = lupine_cuMemcpyDtoD_via_client(
+            copy.dstDevice + (copy.dstY + row) * copy.dstPitch +
+                copy.dstXInBytes,
+            copy.srcDevice + (copy.srcY + row) * copy.srcPitch +
+                copy.srcXInBytes,
+            copy.WidthInBytes, hStream, true);
+        if (return_value != CUDA_SUCCESS) {
+          return return_value;
+        }
+      }
+      return dst_managed ? lupine_sync_mapped_device_to_host() : CUDA_SUCCESS;
+    }
+    conn_t *conn;
+    if (copy.dstMemoryType != CU_MEMORYTYPE_ARRAY) {
+      conn = lupine_rpc_conn_for_deviceptr(copy.dstDevice);
+    } else if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY) {
+      conn = lupine_rpc_conn_for_deviceptr(copy.srcDevice);
+    } else {
+      conn = lupine_rpc_conn_for_stream(hStream);
+    }
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy2DAsync_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS && dst_managed) {
+      return_value = lupine_sync_mapped_device_to_host();
+    }
+    return return_value;
+  }
+  }
+  return CUDA_ERROR_INVALID_VALUE;
 }
 
 #ifdef cuMemcpy2DAsync
@@ -5807,55 +6077,136 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
   if (pCopy == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-
   CUDA_MEMCPY3D copy = *pCopy;
-  size_t src_host_size = copy.srcMemoryType == CU_MEMORYTYPE_HOST
-                             ? lupine_memcpy3d_host_span(copy, true)
-                             : 0;
-  size_t dst_host_size = copy.dstMemoryType == CU_MEMORYTYPE_HOST
-                             ? lupine_memcpy3d_host_span(copy, false)
-                             : 0;
-  const void *src_host = copy.srcHost;
-  void *dst_host = copy.dstHost;
-  if ((src_host_size != 0 && src_host == nullptr) ||
-      (dst_host_size != 0 && dst_host == nullptr)) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  conn_t *conn = nullptr;
-  if (copy.srcMemoryType == CU_MEMORYTYPE_DEVICE && copy.srcDevice != 0) {
-    conn = lupine_rpc_conn_for_deviceptr(copy.srcDevice);
-  } else if (copy.dstMemoryType == CU_MEMORYTYPE_DEVICE &&
-             copy.dstDevice != 0) {
-    conn = lupine_rpc_conn_for_deviceptr(copy.dstDevice);
-  } else {
-    conn = lupine_rpc_conn_for_current_context();
-  }
-  CUresult return_value;
-  size_t returned_dst_size = 0;
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemcpy3D_v2) < 0 ||
-      rpc_write(conn, &copy, sizeof(copy)) < 0 ||
-      rpc_write(conn, &src_host_size, sizeof(src_host_size)) < 0 ||
-      rpc_write(conn, src_host, src_host_size) < 0 ||
-      rpc_write(conn, &dst_host_size, sizeof(dst_host_size)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &returned_dst_size, sizeof(returned_dst_size)) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (returned_dst_size > dst_host_size) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (returned_dst_size != 0) {
-    if (rpc_read(conn, dst_host, returned_dst_size) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  // UNIFIED addresses are client-space: a managed alias translates to its
+  // server VA and stays unified on the server, a plain host pointer's bytes
+  // must travel, and a device pointer is already server-valid.
+  bool dst_managed = false;
+  if (copy.srcMemoryType == CU_MEMORYTYPE_UNIFIED) {
+    if (!lupine_is_managed_host_alias(copy.srcDevice) &&
+        lupine_copy_pointer_is_host(copy.srcDevice)) {
+      copy.srcHost = (const void *)copy.srcDevice;
+      copy.srcMemoryType = CU_MEMORYTYPE_HOST;
     }
   }
-  if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (copy.dstMemoryType == CU_MEMORYTYPE_UNIFIED) {
+    void *alias = (void *)copy.dstDevice;
+    if (lupine_is_managed_host_alias(copy.dstDevice)) {
+      dst_managed = true;
+    } else if (lupine_copy_pointer_is_host(copy.dstDevice)) {
+      copy.dstHost = alias;
+      copy.dstMemoryType = CU_MEMORYTYPE_HOST;
+    }
   }
-  return return_value;
+  bool src_host = copy.srcMemoryType == CU_MEMORYTYPE_HOST;
+  bool dst_host = copy.dstMemoryType == CU_MEMORYTYPE_HOST;
+  lupine_copy_direction direction =
+      src_host ? (dst_host ? lupine_copy_direction::host_to_host
+                           : lupine_copy_direction::host_to_device)
+               : (dst_host ? lupine_copy_direction::device_to_host
+                           : lupine_copy_direction::device_to_device);
+  size_t src_slice_pitch = copy.srcHeight * copy.srcPitch;
+  size_t dst_slice_pitch = copy.dstHeight * copy.dstPitch;
+  const char *src_base =
+      (const char *)copy.srcHost + copy.srcZ * src_slice_pitch +
+      copy.srcY * copy.srcPitch + copy.srcXInBytes;
+  char *dst_base = (char *)copy.dstHost + copy.dstZ * dst_slice_pitch +
+                   copy.dstY * copy.dstPitch + copy.dstXInBytes;
+  CUresult return_value;
+  switch (direction) {
+  case lupine_copy_direction::host_to_host:
+    for (size_t z = 0; z < copy.Depth; ++z) {
+      for (size_t row = 0; row < copy.Height; ++row) {
+        memmove(dst_base + z * dst_slice_pitch + row * copy.dstPitch,
+                src_base + z * src_slice_pitch + row * copy.srcPitch,
+                copy.WidthInBytes);
+      }
+    }
+    return CUDA_SUCCESS;
+  case lupine_copy_direction::host_to_device: {
+    conn_t *conn = copy.dstMemoryType == CU_MEMORYTYPE_ARRAY
+                       ? lupine_rpc_conn_for_current_context()
+                       : lupine_rpc_conn_for_deviceptr(copy.dstDevice);
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy3D_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+                          copy.srcPitch, copy.Depth, src_slice_pitch) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS && dst_managed) {
+      return_value = lupine_sync_mapped_device_to_host();
+    }
+    return return_value;
+  }
+  case lupine_copy_direction::device_to_host: {
+    conn_t *conn = copy.srcMemoryType == CU_MEMORYTYPE_ARRAY
+                       ? lupine_rpc_conn_for_current_context()
+                       : lupine_rpc_conn_for_deviceptr(copy.srcDevice);
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy3D_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS) {
+      if (rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+                           copy.dstPitch, copy.Depth, dst_slice_pitch) < 0) {
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+    }
+    if (rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    return return_value;
+  }
+  case lupine_copy_direction::device_to_device: {
+    if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
+        copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
+        !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
+      // Different devices: the rows route through the client.
+      for (size_t z = 0; z < copy.Depth; ++z) {
+        for (size_t row = 0; row < copy.Height; ++row) {
+          return_value = lupine_cuMemcpyDtoD_via_client(
+              copy.dstDevice + (copy.dstZ + z) * dst_slice_pitch +
+                  (copy.dstY + row) * copy.dstPitch + copy.dstXInBytes,
+              copy.srcDevice + (copy.srcZ + z) * src_slice_pitch +
+                  (copy.srcY + row) * copy.srcPitch + copy.srcXInBytes,
+              copy.WidthInBytes, nullptr, false);
+          if (return_value != CUDA_SUCCESS) {
+            return return_value;
+          }
+        }
+      }
+      return dst_managed ? lupine_sync_mapped_device_to_host() : CUDA_SUCCESS;
+    }
+    conn_t *conn;
+    if (copy.dstMemoryType != CU_MEMORYTYPE_ARRAY) {
+      conn = lupine_rpc_conn_for_deviceptr(copy.dstDevice);
+    } else if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY) {
+      conn = lupine_rpc_conn_for_deviceptr(copy.srcDevice);
+    } else {
+      conn = lupine_rpc_conn_for_current_context();
+    }
+    if (lupine_prepare_rpc(conn) < 0 ||
+        rpc_write_start_request(conn, RPC_cuMemcpy3D_v2) < 0 ||
+        rpc_write(conn, &copy, sizeof(copy)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS && dst_managed) {
+      return_value = lupine_sync_mapped_device_to_host();
+    }
+    return return_value;
+  }
+  }
+  return CUDA_ERROR_INVALID_VALUE;
 }
 
 #ifdef cuMemcpy3D

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -2072,114 +2072,234 @@ int handle_cuLinkDestroy(conn_t *conn) {
   return 0;
 }
 
+// The client resolves host-to-host locally and picks the direction, so at most
+// one side is host here. That side's staging buffer reproduces the caller's
+// pitch and offsets, so the descriptor reaches the driver exactly as written
+// and only the copied rows travel.
 int handle_cuMemcpy3D_v2(conn_t *conn) {
   CUDA_MEMCPY3D copy = {};
-  size_t src_host_size = 0;
-  size_t dst_host_size = 0;
-  CUresult result = CUDA_ERROR_INVALID_VALUE;
-
-  if (rpc_read(conn, &copy, sizeof(copy)) < 0 ||
-      rpc_read(conn, &src_host_size, sizeof(src_host_size)) < 0) {
+  if (rpc_read(conn, &copy, sizeof(copy)) < 0) {
     return -1;
   }
-
-  std::vector<unsigned char> src_host(src_host_size);
-  if (src_host_size != 0 &&
-      rpc_read(conn, src_host.data(), src_host_size) < 0) {
-    return -1;
-  }
-  if (rpc_read(conn, &dst_host_size, sizeof(dst_host_size)) < 0) {
-    return -1;
-  }
-  int request_id = rpc_read_end(conn);
-  if (request_id < 0) {
-    return -1;
-  }
-
-  std::vector<unsigned char> dst_host(dst_host_size);
-  if (copy.srcMemoryType == CU_MEMORYTYPE_HOST) {
-    copy.srcHost = src_host.empty() ? nullptr : src_host.data();
-  }
-  if (copy.dstMemoryType == CU_MEMORYTYPE_HOST) {
-    copy.dstHost = dst_host.empty() ? nullptr : dst_host.data();
-  }
-
-  result = cuMemcpy3D_v2(&copy);
-  size_t returned_dst_size = result == CUDA_SUCCESS ? dst_host.size() : 0;
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &returned_dst_size, sizeof(returned_dst_size)) < 0 ||
-      rpc_write(conn, dst_host.data(), returned_dst_size) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    return -1;
-  }
-  return 0;
-}
-
-static int handle_cuMemcpy2D_common(conn_t *conn, bool async, bool unaligned) {
-  CUDA_MEMCPY2D copy = {};
-  size_t src_host_size = 0;
-  size_t dst_host_size = 0;
-  CUstream stream = nullptr;
-  CUresult result = CUDA_ERROR_INVALID_VALUE;
-
-  if (rpc_read(conn, &copy, sizeof(copy)) < 0 ||
-      rpc_read(conn, &src_host_size, sizeof(src_host_size)) < 0) {
-    return -1;
-  }
-
-  std::vector<unsigned char> src_host(src_host_size);
-  if (src_host_size != 0 &&
-      rpc_read(conn, src_host.data(), src_host_size) < 0) {
-    return -1;
-  }
-  if (rpc_read(conn, &dst_host_size, sizeof(dst_host_size)) < 0 ||
-      (async && rpc_read(conn, &stream, sizeof(stream)) < 0)) {
-    return -1;
-  }
-  int request_id = rpc_read_end(conn);
-  if (request_id < 0) {
-    return -1;
-  }
-
-  std::vector<unsigned char> dst_host(dst_host_size);
-  if (copy.srcMemoryType == CU_MEMORYTYPE_HOST) {
-    copy.srcHost = src_host.empty() ? nullptr : src_host.data();
-  }
-  if (copy.dstMemoryType == CU_MEMORYTYPE_HOST) {
-    copy.dstHost = dst_host.empty() ? nullptr : dst_host.data();
-  }
-
-  if (async) {
-    result = cuMemcpy2DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
+  lupine_copy_direction direction =
+      copy.srcMemoryType == CU_MEMORYTYPE_HOST
+          ? lupine_copy_direction::host_to_device
+          : (copy.dstMemoryType == CU_MEMORYTYPE_HOST
+                 ? lupine_copy_direction::device_to_host
+                 : lupine_copy_direction::device_to_device);
+  std::vector<unsigned char> host;
+  size_t slice = 0;
+  size_t offset = 0;
+  switch (direction) {
+  case lupine_copy_direction::host_to_device:
+    slice = copy.srcHeight * copy.srcPitch;
+    offset = copy.srcZ * slice + copy.srcY * copy.srcPitch + copy.srcXInBytes;
+    host.resize((copy.Depth - 1) * slice + (copy.Height - 1) * copy.srcPitch +
+                offset + copy.WidthInBytes);
+    copy.srcHost = host.data();
+    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+                         copy.Height, copy.srcPitch, copy.Depth, slice) < 0) {
+      return -1;
     }
-  } else if (unaligned) {
-    result = cuMemcpy2DUnaligned_v2(&copy);
-  } else {
-    result = cuMemcpy2D_v2(&copy);
+    break;
+  case lupine_copy_direction::device_to_host:
+    slice = copy.dstHeight * copy.dstPitch;
+    offset = copy.dstZ * slice + copy.dstY * copy.dstPitch + copy.dstXInBytes;
+    host.resize((copy.Depth - 1) * slice + (copy.Height - 1) * copy.dstPitch +
+                offset + copy.WidthInBytes);
+    copy.dstHost = host.data();
+    break;
+  default:
+    break;
   }
-
-  size_t returned_dst_size = result == CUDA_SUCCESS ? dst_host.size() : 0;
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &returned_dst_size, sizeof(returned_dst_size)) < 0 ||
-      rpc_write(conn, dst_host.data(), returned_dst_size) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
     return -1;
   }
-  return 0;
+  CUresult result = cuMemcpy3D_v2(&copy);
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0) {
+    return -1;
+  }
+  if (direction == lupine_copy_direction::device_to_host &&
+      result == CUDA_SUCCESS &&
+      rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+                        copy.Height, copy.dstPitch, copy.Depth, slice) < 0) {
+    return -1;
+  }
+  return rpc_write_end(conn) < 0 ? -1 : 0;
 }
 
+// The client resolves host-to-host locally and picks the direction, so at most
+// one side is host here. That side's staging buffer reproduces the caller's
+// pitch and offsets, so the descriptor reaches the driver exactly as written
+// and only the copied rows travel.
 int handle_cuMemcpy2D_v2(conn_t *conn) {
-  return handle_cuMemcpy2D_common(conn, false, false);
+  CUDA_MEMCPY2D copy = {};
+  if (rpc_read(conn, &copy, sizeof(copy)) < 0) {
+    return -1;
+  }
+  lupine_copy_direction direction =
+      copy.srcMemoryType == CU_MEMORYTYPE_HOST
+          ? lupine_copy_direction::host_to_device
+          : (copy.dstMemoryType == CU_MEMORYTYPE_HOST
+                 ? lupine_copy_direction::device_to_host
+                 : lupine_copy_direction::device_to_device);
+  std::vector<unsigned char> host;
+  size_t offset = 0;
+  switch (direction) {
+  case lupine_copy_direction::host_to_device:
+    offset = copy.srcY * copy.srcPitch + copy.srcXInBytes;
+    host.resize((copy.Height - 1) * copy.srcPitch + offset +
+                copy.WidthInBytes);
+    copy.srcHost = host.data();
+    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+                         copy.Height, copy.srcPitch, 1, 0) < 0) {
+      return -1;
+    }
+    break;
+  case lupine_copy_direction::device_to_host:
+    offset = copy.dstY * copy.dstPitch + copy.dstXInBytes;
+    host.resize((copy.Height - 1) * copy.dstPitch + offset +
+                copy.WidthInBytes);
+    copy.dstHost = host.data();
+    break;
+  default:
+    break;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+  CUresult result = cuMemcpy2D_v2(&copy);
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0) {
+    return -1;
+  }
+  if (direction == lupine_copy_direction::device_to_host &&
+      result == CUDA_SUCCESS &&
+      rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+                        copy.Height, copy.dstPitch, 1, 0) < 0) {
+    return -1;
+  }
+  return rpc_write_end(conn) < 0 ? -1 : 0;
 }
 
+// The client resolves host-to-host locally and picks the direction, so at most
+// one side is host here. That side's staging buffer reproduces the caller's
+// pitch and offsets, so the descriptor reaches the driver exactly as written
+// and only the copied rows travel.
 int handle_cuMemcpy2DUnaligned_v2(conn_t *conn) {
-  return handle_cuMemcpy2D_common(conn, false, true);
+  CUDA_MEMCPY2D copy = {};
+  if (rpc_read(conn, &copy, sizeof(copy)) < 0) {
+    return -1;
+  }
+  lupine_copy_direction direction =
+      copy.srcMemoryType == CU_MEMORYTYPE_HOST
+          ? lupine_copy_direction::host_to_device
+          : (copy.dstMemoryType == CU_MEMORYTYPE_HOST
+                 ? lupine_copy_direction::device_to_host
+                 : lupine_copy_direction::device_to_device);
+  std::vector<unsigned char> host;
+  size_t offset = 0;
+  switch (direction) {
+  case lupine_copy_direction::host_to_device:
+    offset = copy.srcY * copy.srcPitch + copy.srcXInBytes;
+    host.resize((copy.Height - 1) * copy.srcPitch + offset +
+                copy.WidthInBytes);
+    copy.srcHost = host.data();
+    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+                         copy.Height, copy.srcPitch, 1, 0) < 0) {
+      return -1;
+    }
+    break;
+  case lupine_copy_direction::device_to_host:
+    offset = copy.dstY * copy.dstPitch + copy.dstXInBytes;
+    host.resize((copy.Height - 1) * copy.dstPitch + offset +
+                copy.WidthInBytes);
+    copy.dstHost = host.data();
+    break;
+  default:
+    break;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+  CUresult result = cuMemcpy2DUnaligned_v2(&copy);
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0) {
+    return -1;
+  }
+  if (direction == lupine_copy_direction::device_to_host &&
+      result == CUDA_SUCCESS &&
+      rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+                        copy.Height, copy.dstPitch, 1, 0) < 0) {
+    return -1;
+  }
+  return rpc_write_end(conn) < 0 ? -1 : 0;
 }
 
+// The client resolves host-to-host locally and picks the direction, so at most
+// one side is host here. That side's staging buffer reproduces the caller's
+// pitch and offsets, so the descriptor reaches the driver exactly as written
+// and only the copied rows travel.
 int handle_cuMemcpy2DAsync_v2(conn_t *conn) {
-  return handle_cuMemcpy2D_common(conn, true, false);
+  CUDA_MEMCPY2D copy = {};
+  CUstream stream = nullptr;
+  if (rpc_read(conn, &copy, sizeof(copy)) < 0) {
+    return -1;
+  }
+  lupine_copy_direction direction =
+      copy.srcMemoryType == CU_MEMORYTYPE_HOST
+          ? lupine_copy_direction::host_to_device
+          : (copy.dstMemoryType == CU_MEMORYTYPE_HOST
+                 ? lupine_copy_direction::device_to_host
+                 : lupine_copy_direction::device_to_device);
+  std::vector<unsigned char> host;
+  size_t offset = 0;
+  switch (direction) {
+  case lupine_copy_direction::host_to_device:
+    offset = copy.srcY * copy.srcPitch + copy.srcXInBytes;
+    host.resize((copy.Height - 1) * copy.srcPitch + offset +
+                copy.WidthInBytes);
+    copy.srcHost = host.data();
+    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+                         copy.Height, copy.srcPitch, 1, 0) < 0) {
+      return -1;
+    }
+    break;
+  case lupine_copy_direction::device_to_host:
+    offset = copy.dstY * copy.dstPitch + copy.dstXInBytes;
+    host.resize((copy.Height - 1) * copy.dstPitch + offset +
+                copy.WidthInBytes);
+    copy.dstHost = host.data();
+    break;
+  default:
+    break;
+  }
+  if (rpc_read(conn, &stream, sizeof(stream)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+  CUresult result = cuMemcpy2DAsync_v2(&copy, stream);
+  if (result == CUDA_SUCCESS) {
+    result = cuStreamSynchronize(stream);
+  }
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0) {
+    return -1;
+  }
+  if (direction == lupine_copy_direction::device_to_host &&
+      result == CUDA_SUCCESS &&
+      rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+                        copy.Height, copy.dstPitch, 1, 0) < 0) {
+    return -1;
+  }
+  return rpc_write_end(conn) < 0 ? -1 : 0;
 }
 
 int handle_cuDeviceGetGraphMemAttribute(conn_t *conn) {

--- a/cuda_server.h
+++ b/cuda_server.h
@@ -5,6 +5,15 @@
 
 #include "rpc.h"
 
+// Which side of a copy is host memory, and therefore which side the handler
+// has to stage locally.
+enum class lupine_copy_direction {
+  host_to_host,
+  host_to_device,
+  device_to_host,
+  device_to_device,
+};
+
 int handle_cuGetErrorName(conn_t *conn);
 int handle_cuGetErrorString(conn_t *conn);
 int handle_cuGetExportTableMetadata(conn_t *conn);

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -1116,10 +1116,7 @@ static bool lupine_is_client_mapped_address(CUdeviceptr ptr) {
   return mincore(reinterpret_cast<void *>(page), page_size, &residency) == 0;
 }
 
-static bool lupine_copy_pointer_is_host(CUdeviceptr ptr) {
-  if (lupine_is_managed_host_alias(ptr)) {
-    return false;
-  }
+extern "C" bool lupine_copy_pointer_is_host(CUdeviceptr ptr) {
   if (lupine_host_ptr_is_tracked(ptr)) {
     return true;
   }
@@ -1128,13 +1125,6 @@ static bool lupine_copy_pointer_is_host(CUdeviceptr ptr) {
   }
   return lupine_is_client_mapped_address(ptr);
 }
-
-enum class lupine_copy_direction {
-  host_to_host,
-  host_to_device,
-  device_to_host,
-  device_to_device,
-};
 
 static lupine_copy_direction lupine_infer_copy_direction(CUdeviceptr dst,
                                                          CUdeviceptr src) {

--- a/memcpy.h
+++ b/memcpy.h
@@ -9,6 +9,13 @@
 
 struct rpc_write_cursor;
 
+enum class lupine_copy_direction {
+  host_to_host,
+  host_to_device,
+  device_to_host,
+  device_to_device,
+};
+extern "C" bool lupine_copy_pointer_is_host(CUdeviceptr ptr);
 extern "C" bool lupine_is_managed_host_alias(CUdeviceptr ptr);
 extern "C" CUresult lupine_sync_mapped_device_to_host();
 

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -86,7 +86,7 @@ CORE_SAMPLES=(
 )
 
 LIBRARY_SAMPLES=(
-  simpleCUBLAS matrixMulCUBLAS simpleCUBLAS_LU batchCUBLAS
+  simpleCUBLAS matrixMulCUBLAS simpleCUBLAS_LU batchCUBLAS simpleCUBLASXT
   simpleCUFFT simpleCUFFT_callback
   oceanFFT
   cuSolverDn_LinearSolver cuSolverSp_LinearSolver cuSolverSp_LowlevelCholesky


### PR DESCRIPTION
Regenerate `codegen/gen_cuda_client.cpp` with the pinned CUDA 13.3.1 environment from #618.

This repairs the deterministic stale generated state currently failing #546.

Verified with the pinned container:
- codegen exits 0
- `git diff --exit-code -- codegen` exits 0