### PR TITLE
Add global CUDA coredump attribute RPCs

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -5154,6 +5154,22 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
                              cuuint64_t flags,
                              CUdriverProcAddressQueryResult *symbolStatus);
 /**
+ * @guard CUDA_VERSION >= 12010
+ * @param attrib SEND_ONLY
+ * @param size SEND_RECV
+ * @param value RECV_ONLY LENGTH:size
+ */
+CUresult cuCoredumpGetAttributeGlobal(CUcoredumpSettings attrib, void *value,
+                                      size_t *size);
+/**
+ * @guard CUDA_VERSION >= 12010
+ * @param attrib SEND_ONLY
+ * @param size SEND_RECV
+ * @param value SEND_ONLY LENGTH:size
+ */
+CUresult cuCoredumpSetAttributeGlobal(CUcoredumpSettings attrib, void *value,
+                                      size_t *size);
+/**
  * @disabled
  * @param ppExportTable SEND_RECV
  * @param pExportTableId SEND_RECV

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -6755,6 +6755,61 @@ CUresult cuGraphicsUnmapResources(unsigned int count,
   return return_value;
 }
 
+#if CUDA_VERSION >= 12010
+CUresult cuCoredumpGetAttributeGlobal(CUcoredumpSettings attrib, void *value,
+                                      size_t *size) {
+  lupine_route route = lupine_route_for_default();
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUcoredumpSettings, void *, size_t *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuCoredumpGetAttributeGlobal", &return_value, attrib, value,
+          size)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCoredumpGetAttributeGlobal) < 0 ||
+      rpc_write(conn, &attrib, sizeof(CUcoredumpSettings)) < 0 ||
+      rpc_write(conn, size, sizeof(size_t)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, size, sizeof(size_t)) < 0 ||
+      (*size != 0 && rpc_read(conn, value, *size) < 0) ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
+#if CUDA_VERSION >= 12010
+CUresult cuCoredumpSetAttributeGlobal(CUcoredumpSettings attrib, void *value,
+                                      size_t *size) {
+  lupine_route route = lupine_route_for_default();
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUcoredumpSettings, void *, size_t *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuCoredumpSetAttributeGlobal", &return_value, attrib, value,
+          size)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (*size != 0 && value == nullptr)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuCoredumpSetAttributeGlobal) < 0 ||
+      rpc_write(conn, &attrib, sizeof(CUcoredumpSettings)) < 0 ||
+      rpc_write(conn, size, sizeof(size_t)) < 0 ||
+      rpc_write(conn, value, *size) < 0 || rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, size, sizeof(size_t)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
 #if CUDA_VERSION >= 12040
 CUresult cuGreenCtxCreate(CUgreenCtx *phCtx, CUdevResourceDesc desc,
                           CUdevice dev, unsigned int flags) {
@@ -7842,6 +7897,12 @@ std::unordered_map<std::string, void *> functionMap = {
      (void *)cuGraphicsResourceSetMapFlags_v2},
     {"cuGraphicsMapResources", (void *)cuGraphicsMapResources},
     {"cuGraphicsUnmapResources", (void *)cuGraphicsUnmapResources},
+#if CUDA_VERSION >= 12010
+    {"cuCoredumpGetAttributeGlobal", (void *)cuCoredumpGetAttributeGlobal},
+#endif
+#if CUDA_VERSION >= 12010
+    {"cuCoredumpSetAttributeGlobal", (void *)cuCoredumpSetAttributeGlobal},
+#endif
 #if CUDA_VERSION >= 12040
     {"cuGreenCtxCreate", (void *)cuGreenCtxCreate},
 #endif

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -7884,6 +7884,81 @@ ERROR_0:
   return -1;
 }
 
+#if CUDA_VERSION >= 12010
+int handle_cuCoredumpGetAttributeGlobal(conn_t *conn) {
+  CUcoredumpSettings attrib;
+  size_t size;
+  void *value = nullptr;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &attrib, sizeof(CUcoredumpSettings)) < 0 ||
+      rpc_read(conn, &size, sizeof(size_t)) < 0 || false)
+    goto ERROR_0;
+  value = (void *)malloc(size);
+  if ((size != 0 && value == nullptr) || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuCoredumpGetAttributeGlobal(
+      attrib, (size == 0 ? nullptr : value), &size);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &size, sizeof(size_t)) < 0 ||
+      rpc_write(conn, value, size) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  free((void *)value);
+  return 0;
+ERROR_0:
+  free((void *)value);
+  return -1;
+}
+
+#endif
+
+#if CUDA_VERSION >= 12010
+int handle_cuCoredumpSetAttributeGlobal(conn_t *conn) {
+  CUcoredumpSettings attrib;
+  size_t size;
+  void *value = nullptr;
+  size_t value_size;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &attrib, sizeof(CUcoredumpSettings)) < 0 ||
+      rpc_read(conn, &size, sizeof(size_t)) < 0 || false)
+    goto ERROR_0;
+  value_size = size;
+  value = (void *)malloc(value_size);
+  if (value_size != 0 && value == nullptr)
+    goto ERROR_0;
+  if ((value_size != 0 && rpc_read(conn, value, value_size) < 0) || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuCoredumpSetAttributeGlobal(
+      attrib, (size == 0 ? nullptr : value), &size);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &size, sizeof(size_t)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  free((void *)value);
+  return 0;
+ERROR_0:
+  free((void *)value);
+  return -1;
+}
+
+#endif
+
 #if CUDA_VERSION >= 12040
 int handle_cuGreenCtxCreate(conn_t *conn) {
   CUgreenCtx phCtx;

--- a/codegen/gen_rpc_ids.h
+++ b/codegen/gen_rpc_ids.h
@@ -361,6 +361,8 @@
 #define RPC_cuGraphicsMapResources 156810469
 #define RPC_cuGraphicsUnmapResources 121118754
 #define RPC_cuGetProcAddress_v2 1976428842
+#define RPC_cuCoredumpGetAttributeGlobal 2132238767
+#define RPC_cuCoredumpSetAttributeGlobal 1511844529
 #define RPC_cuGetExportTable 2020229241
 #define RPC_cuGreenCtxCreate 1079242194
 #define RPC_cuGreenCtxDestroy 1043831578

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -165,6 +165,20 @@ class ArrayOperation:
             return self.byte_count_expr()
         return f"{self.element_count_expr()} * sizeof({self.ptr.ptr_to.format()})"
 
+    def server_element_count_expr(self) -> str:
+        if isinstance(self.length, int):
+            return str(self.length)
+        # Pointer length parameters are unmarshalled into scalar server locals.
+        return self.length.name
+
+    def server_transfer_size_expr(self) -> str:
+        if self.is_void_bytes:
+            return self.server_element_count_expr()
+        return (
+            f"{self.server_element_count_expr()} * "
+            f"sizeof({self.ptr.ptr_to.format()})"
+        )
+
     def mutable_ptr_format(self) -> str:
         c = self.ptr.ptr_to.const
         self.ptr.ptr_to.const = False
@@ -365,13 +379,13 @@ class ArrayOperation:
                     "    {param_name} = ({server_type})malloc({size});\n".format(
                         param_name=self.parameter.name,
                         server_type=self.ptr.format(),
-                        size=self.transfer_size_expr(),
+                        size=self.server_transfer_size_expr(),
                     )
                 )
                 f.write(
                     "    if (({size} != 0 && {param_name} == nullptr) ||\n".format(
                         param_name=self.parameter.name,
-                        size=self.transfer_size_expr(),
+                        size=self.server_transfer_size_expr(),
                     )
                 )
                 return self.parameter.name
@@ -382,7 +396,7 @@ class ArrayOperation:
             f.write(
                 "    {param_name}_size = {size};\n".format(
                     param_name=self.parameter.name,
-                    size=self.transfer_size_expr(),
+                    size=self.server_transfer_size_expr(),
                 )
             )
             f.write(
@@ -437,7 +451,10 @@ class ArrayOperation:
             return f"{self.parameter.name}.data()"
         if isinstance(self.length, int):
             return f"{self.parameter.name}"
-        return f"({self.transfer_size_expr()} == 0 ? nullptr : {self.parameter.name})"
+        return (
+            f"({self.server_transfer_size_expr()} == 0 ? "
+            f"nullptr : {self.parameter.name})"
+        )
 
     def server_rpc_write(self, f):
         if not self.recv:
@@ -454,7 +471,7 @@ class ArrayOperation:
                 "        {write_fn}(conn, {param_name}, {size}) < 0 ||\n".format(
                     write_fn="rpc_write_payload" if self.compressible else "rpc_write",
                     param_name=self.parameter.name,
-                    size=self.transfer_size_expr(),
+                    size=self.server_transfer_size_expr(),
                 )
             )
 

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -474,6 +474,14 @@ LUPINE_DECLARE_HANDLER(RPC_cuMemAdvise_v2, handle_cuMemAdvise_v2,
 LUPINE_DECLARE_HANDLER(RPC_cuFuncGetName, handle_cuFuncGetName,
                        rpc_backend::cuda)
 #endif
+#if CUDA_VERSION >= 12010
+LUPINE_DECLARE_HANDLER(RPC_cuCoredumpGetAttributeGlobal,
+                       handle_cuCoredumpGetAttributeGlobal, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 12010
+LUPINE_DECLARE_HANDLER(RPC_cuCoredumpSetAttributeGlobal,
+                       handle_cuCoredumpSetAttributeGlobal, rpc_backend::cuda)
+#endif
 #if CUDA_VERSION >= 12040
 LUPINE_DECLARE_HANDLER(RPC_cuGreenCtxCreate, handle_cuGreenCtxCreate,
                        rpc_backend::cuda)
@@ -569,88 +577,102 @@ const rpc_handler_registry &lupine_rpc_handlers() {
                                                           handle_cuFuncGetName,
                                                           rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12040
+#if CUDA_VERSION >= 12010
                                       LUPINE_REGISTER_HANDLER(
-                                          RPC_cuGreenCtxCreate,
-                                          handle_cuGreenCtxCreate,
+                                          RPC_cuCoredumpGetAttributeGlobal,
+                                          handle_cuCoredumpGetAttributeGlobal,
                                           rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12040
+#if CUDA_VERSION >= 12010
                                           LUPINE_REGISTER_HANDLER(
-                                              RPC_cuGreenCtxDestroy,
-                                              handle_cuGreenCtxDestroy,
+                                              RPC_cuCoredumpSetAttributeGlobal,
+                                              handle_cuCoredumpSetAttributeGlobal,
                                               rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                               LUPINE_REGISTER_HANDLER(
-                                                  RPC_cuCtxFromGreenCtx,
-                                                  handle_cuCtxFromGreenCtx,
+                                                  RPC_cuGreenCtxCreate,
+                                                  handle_cuGreenCtxCreate,
                                                   rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                   LUPINE_REGISTER_HANDLER(
-                                                      RPC_cuDeviceGetDevResource,
-                                                      handle_cuDeviceGetDevResource,
+                                                      RPC_cuGreenCtxDestroy,
+                                                      handle_cuGreenCtxDestroy,
                                                       rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                       LUPINE_REGISTER_HANDLER(
-                                                          RPC_cuCtxGetDevResource,
-                                                          handle_cuCtxGetDevResource,
+                                                          RPC_cuCtxFromGreenCtx,
+                                                          handle_cuCtxFromGreenCtx,
                                                           rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                           LUPINE_REGISTER_HANDLER(
-                                                              RPC_cuGreenCtxGetDevResource,
-                                                              handle_cuGreenCtxGetDevResource,
+                                                              RPC_cuDeviceGetDevResource,
+                                                              handle_cuDeviceGetDevResource,
                                                               rpc_backend::cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                               LUPINE_REGISTER_HANDLER(
-                                                                  RPC_cuDevSmResourceSplitByCount,
-                                                                  handle_cuDevSmResourceSplitByCount,
+                                                                  RPC_cuCtxGetDevResource,
+                                                                  handle_cuCtxGetDevResource,
                                                                   rpc_backend::
                                                                       cuda)
 #endif
-#if CUDA_VERSION >= 13010
+#if CUDA_VERSION >= 12040
                                                                   LUPINE_REGISTER_HANDLER(
-                                                                      RPC_cuDevSmResourceSplit,
-                                                                      handle_cuDevSmResourceSplit,
+                                                                      RPC_cuGreenCtxGetDevResource,
+                                                                      handle_cuGreenCtxGetDevResource,
                                                                       rpc_backend::
                                                                           cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                                       LUPINE_REGISTER_HANDLER(
-                                                                          RPC_cuDevResourceGenerateDesc,
-                                                                          handle_cuDevResourceGenerateDesc,
+                                                                          RPC_cuDevSmResourceSplitByCount,
+                                                                          handle_cuDevSmResourceSplitByCount,
                                                                           rpc_backend::
                                                                               cuda)
 #endif
-#if CUDA_VERSION >= 12040
+#if CUDA_VERSION >= 13010
                                                                           LUPINE_REGISTER_HANDLER(
-                                                                              RPC_cuStreamGetGreenCtx,
-                                                                              handle_cuStreamGetGreenCtx,
+                                                                              RPC_cuDevSmResourceSplit,
+                                                                              handle_cuDevSmResourceSplit,
                                                                               rpc_backend::
                                                                                   cuda)
 #endif
-#if CUDA_VERSION >= 12050
+#if CUDA_VERSION >= 12040
                                                                               LUPINE_REGISTER_HANDLER(
-                                                                                  RPC_cuGreenCtxStreamCreate,
-                                                                                  handle_cuGreenCtxStreamCreate,
+                                                                                  RPC_cuDevResourceGenerateDesc,
+                                                                                  handle_cuDevResourceGenerateDesc,
                                                                                   rpc_backend::
                                                                                       cuda)
 #endif
-#if CUDA_VERSION >= 13010
+#if CUDA_VERSION >= 12040
                                                                                   LUPINE_REGISTER_HANDLER(
-                                                                                      RPC_cuStreamGetDevResource,
-                                                                                      handle_cuStreamGetDevResource,
+                                                                                      RPC_cuStreamGetGreenCtx,
+                                                                                      handle_cuStreamGetGreenCtx,
                                                                                       rpc_backend::
                                                                                           cuda)
 #endif
+#if CUDA_VERSION >= 12050
+                                                                                      LUPINE_REGISTER_HANDLER(
+                                                                                          RPC_cuGreenCtxStreamCreate,
+                                                                                          handle_cuGreenCtxStreamCreate,
+                                                                                          rpc_backend::
+                                                                                              cuda)
+#endif
+#if CUDA_VERSION >= 13010
+                                                                                          LUPINE_REGISTER_HANDLER(
+                                                                                              RPC_cuStreamGetDevResource,
+                                                                                              handle_cuStreamGetDevResource,
+                                                                                              rpc_backend::
+                                                                                                  cuda)
+#endif
 #endif
 #ifdef LUPINE_BUILD_NVML_BACKEND
-                                                                                      LUPINE_NVML_RPC_HANDLERS(
-                                                                                          LUPINE_REGISTER_HANDLER)
+                                                                                              LUPINE_NVML_RPC_HANDLERS(
+                                                                                                  LUPINE_REGISTER_HANDLER)
 
 #endif
   };

--- a/test/cuda-python/known_failures.txt
+++ b/test/cuda-python/known_failures.txt
@@ -33,9 +33,6 @@ test_cuda.py::test_cuda_mem_range_attr
 # #582 cuPointerSetAttribute(SYNC_MEMOPS)
 test_cuda.py::test_cuda_pointer_attr
 
-# #583 cuCoredumpSetAttributeGlobal
-test_cuda.py::test_cuda_coredump_attr
-
 # #599 CUDA 11 cuGraphInstantiate_v2 with a log buffer (11.8 lane)
 test_cuda.py::test_cuda_graphMem_attr
 test_cudart.py::test_cudart_cudaGraphAddMemcpyNode1D


### PR DESCRIPTION
Summary:
- generate guarded RPC wrappers for cuCoredumpGetAttributeGlobal and cuCoredumpSetAttributeGlobal
- teach array marshalling to use scalar length locals on the server when the client length parameter is a pointer
- re-enable the cuda-python coredump attribute regression

Testing:
- ./codegen/run.sh (reproducible output verified)
- cmake --build build --parallel
- ctest --test-dir build --output-on-failure
- NVIDIA cuda-python v13.3.1 test_cuda.py through the shim on inferable-node-008 (44 passed, 11 deselected)

Fixes #583