### PR TITLE
feat: support CUDA graph identity APIs

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -4448,6 +4448,38 @@ CUresult cuGraphNodeFindInClone(CUgraphNode *phNode, CUgraphNode hOriginalNode,
  */
 CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type);
 /**
+ * @guard CUDA_VERSION >= 13010
+ * @recordowner GRAPH phGraph
+ * @param hNode SEND_ONLY
+ * @param phGraph RECV_ONLY
+ */
+CUresult cuGraphNodeGetContainingGraph(CUgraphNode hNode, CUgraph *phGraph);
+/**
+ * @guard CUDA_VERSION >= 13010
+ * @param hNode SEND_ONLY
+ * @param nodeId RECV_ONLY
+ */
+CUresult cuGraphNodeGetLocalId(CUgraphNode hNode, unsigned int *nodeId);
+/**
+ * @guard CUDA_VERSION >= 13010
+ * @param hNode SEND_ONLY
+ * @param toolsNodeId RECV_ONLY
+ */
+CUresult cuGraphNodeGetToolsId(CUgraphNode hNode,
+                               unsigned long long *toolsNodeId);
+/**
+ * @guard CUDA_VERSION >= 13010
+ * @param hGraph SEND_ONLY
+ * @param graphId RECV_ONLY
+ */
+CUresult cuGraphGetId(CUgraph hGraph, unsigned int *graphId);
+/**
+ * @guard CUDA_VERSION >= 13010
+ * @param hGraphExec SEND_ONLY
+ * @param graphId RECV_ONLY
+ */
+CUresult cuGraphExecGetId(CUgraphExec hGraphExec, unsigned int *graphId);
+/**
  * @param hGraph SEND_ONLY
  * @param numNodes SEND_RECV
  * @param nodes RECV_ONLY NULLABLE LENGTH:numNodes

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -4973,6 +4973,129 @@ CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type) {
   return return_value;
 }
 
+#if CUDA_VERSION >= 13010
+CUresult cuGraphNodeGetContainingGraph(CUgraphNode hNode, CUgraph *phGraph) {
+  lupine_route route = lupine_route_for_graph_node(hNode);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUgraph *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphNodeGetContainingGraph", &return_value, hNode,
+          phGraph)) {
+    if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+      lupine_note_graph_owner_route(*phGraph, route);
+    }
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphNodeGetContainingGraph) < 0 ||
+      rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, phGraph, sizeof(CUgraph)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+    lupine_note_graph_owner_route(*phGraph, route);
+  }
+  return return_value;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13010
+CUresult cuGraphNodeGetLocalId(CUgraphNode hNode, unsigned int *nodeId) {
+  lupine_route route = lupine_route_for_graph_node(hNode);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, unsigned int *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphNodeGetLocalId", &return_value, hNode, nodeId)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphNodeGetLocalId) < 0 ||
+      rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, nodeId, sizeof(unsigned int)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13010
+CUresult cuGraphNodeGetToolsId(CUgraphNode hNode,
+                               unsigned long long *toolsNodeId) {
+  lupine_route route = lupine_route_for_graph_node(hNode);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, unsigned long long *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphNodeGetToolsId", &return_value, hNode, toolsNodeId)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphNodeGetToolsId) < 0 ||
+      rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, toolsNodeId, sizeof(unsigned long long)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13010
+CUresult cuGraphGetId(CUgraph hGraph, unsigned int *graphId) {
+  lupine_route route = lupine_route_for_graph(hGraph);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraph, unsigned int *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphGetId", &return_value, hGraph, graphId)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphGetId) < 0 ||
+      rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, graphId, sizeof(unsigned int)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13010
+CUresult cuGraphExecGetId(CUgraphExec hGraphExec, unsigned int *graphId) {
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, unsigned int *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecGetId", &return_value, hGraphExec, graphId)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecGetId) < 0 ||
+      rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, graphId, sizeof(unsigned int)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+#endif
+
 CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
   lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
@@ -7802,6 +7925,21 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuGraphClone", (void *)cuGraphClone},
     {"cuGraphNodeFindInClone", (void *)cuGraphNodeFindInClone},
     {"cuGraphNodeGetType", (void *)cuGraphNodeGetType},
+#if CUDA_VERSION >= 13010
+    {"cuGraphNodeGetContainingGraph", (void *)cuGraphNodeGetContainingGraph},
+#endif
+#if CUDA_VERSION >= 13010
+    {"cuGraphNodeGetLocalId", (void *)cuGraphNodeGetLocalId},
+#endif
+#if CUDA_VERSION >= 13010
+    {"cuGraphNodeGetToolsId", (void *)cuGraphNodeGetToolsId},
+#endif
+#if CUDA_VERSION >= 13010
+    {"cuGraphGetId", (void *)cuGraphGetId},
+#endif
+#if CUDA_VERSION >= 13010
+    {"cuGraphExecGetId", (void *)cuGraphExecGetId},
+#endif
     {"cuGraphGetNodes", (void *)cuGraphGetNodes},
     {"cuGraphGetRootNodes", (void *)cuGraphGetRootNodes},
     {"cuGraphDestroyNode", (void *)cuGraphDestroyNode},

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -5762,6 +5762,141 @@ ERROR_0:
   return -1;
 }
 
+#if CUDA_VERSION >= 13010
+int handle_cuGraphNodeGetContainingGraph(conn_t *conn) {
+  CUgraphNode hNode;
+  CUgraph phGraph;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuGraphNodeGetContainingGraph(hNode, &phGraph);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &phGraph, sizeof(CUgraph)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13010
+int handle_cuGraphNodeGetLocalId(conn_t *conn) {
+  CUgraphNode hNode;
+  unsigned int nodeId;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuGraphNodeGetLocalId(hNode, &nodeId);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &nodeId, sizeof(unsigned int)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13010
+int handle_cuGraphNodeGetToolsId(conn_t *conn) {
+  CUgraphNode hNode;
+  unsigned long long toolsNodeId;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuGraphNodeGetToolsId(hNode, &toolsNodeId);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &toolsNodeId, sizeof(unsigned long long)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13010
+int handle_cuGraphGetId(conn_t *conn) {
+  CUgraph hGraph;
+  unsigned int graphId;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuGraphGetId(hGraph, &graphId);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &graphId, sizeof(unsigned int)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
+#if CUDA_VERSION >= 13010
+int handle_cuGraphExecGetId(conn_t *conn) {
+  CUgraphExec hGraphExec;
+  unsigned int graphId;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuGraphExecGetId(hGraphExec, &graphId);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &graphId, sizeof(unsigned int)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+#endif
+
 int handle_cuGraphGetNodes(conn_t *conn) {
   CUgraph hGraph;
   size_t numNodes = 0;

--- a/codegen/gen_rpc_ids.h
+++ b/codegen/gen_rpc_ids.h
@@ -274,6 +274,11 @@
 #define RPC_cuGraphClone 1985984852
 #define RPC_cuGraphNodeFindInClone 1346487083
 #define RPC_cuGraphNodeGetType 1733309030
+#define RPC_cuGraphNodeGetContainingGraph 2073783441
+#define RPC_cuGraphNodeGetLocalId 909459841
+#define RPC_cuGraphNodeGetToolsId 1122255545
+#define RPC_cuGraphGetId 1130798716
+#define RPC_cuGraphExecGetId 1513714907
 #define RPC_cuGraphGetNodes 314616981
 #define RPC_cuGraphGetRootNodes 1731117011
 #define RPC_cuGraphDestroyNode 1083979368

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -477,6 +477,25 @@ LUPINE_DECLARE_HANDLER(RPC_cuMemAdvise_v2, handle_cuMemAdvise_v2,
 LUPINE_DECLARE_HANDLER(RPC_cuFuncGetName, handle_cuFuncGetName,
                        rpc_backend::cuda)
 #endif
+#if CUDA_VERSION >= 13010
+LUPINE_DECLARE_HANDLER(RPC_cuGraphNodeGetContainingGraph,
+                       handle_cuGraphNodeGetContainingGraph, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 13010
+LUPINE_DECLARE_HANDLER(RPC_cuGraphNodeGetLocalId, handle_cuGraphNodeGetLocalId,
+                       rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 13010
+LUPINE_DECLARE_HANDLER(RPC_cuGraphNodeGetToolsId, handle_cuGraphNodeGetToolsId,
+                       rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 13010
+LUPINE_DECLARE_HANDLER(RPC_cuGraphGetId, handle_cuGraphGetId, rpc_backend::cuda)
+#endif
+#if CUDA_VERSION >= 13010
+LUPINE_DECLARE_HANDLER(RPC_cuGraphExecGetId, handle_cuGraphExecGetId,
+                       rpc_backend::cuda)
+#endif
 #if CUDA_VERSION >= 12010
 LUPINE_DECLARE_HANDLER(RPC_cuCoredumpGetAttributeGlobal,
                        handle_cuCoredumpGetAttributeGlobal, rpc_backend::cuda)
@@ -580,102 +599,137 @@ const rpc_handler_registry &lupine_rpc_handlers() {
                                                           handle_cuFuncGetName,
                                                           rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12010
+#if CUDA_VERSION >= 13010
                                       LUPINE_REGISTER_HANDLER(
-                                          RPC_cuCoredumpGetAttributeGlobal,
-                                          handle_cuCoredumpGetAttributeGlobal,
+                                          RPC_cuGraphNodeGetContainingGraph,
+                                          handle_cuGraphNodeGetContainingGraph,
                                           rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12010
+#if CUDA_VERSION >= 13010
                                           LUPINE_REGISTER_HANDLER(
-                                              RPC_cuCoredumpSetAttributeGlobal,
-                                              handle_cuCoredumpSetAttributeGlobal,
+                                              RPC_cuGraphNodeGetLocalId,
+                                              handle_cuGraphNodeGetLocalId,
                                               rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12040
+#if CUDA_VERSION >= 13010
                                               LUPINE_REGISTER_HANDLER(
-                                                  RPC_cuGreenCtxCreate,
-                                                  handle_cuGreenCtxCreate,
+                                                  RPC_cuGraphNodeGetToolsId,
+                                                  handle_cuGraphNodeGetToolsId,
                                                   rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12040
+#if CUDA_VERSION >= 13010
                                                   LUPINE_REGISTER_HANDLER(
-                                                      RPC_cuGreenCtxDestroy,
-                                                      handle_cuGreenCtxDestroy,
+                                                      RPC_cuGraphGetId,
+                                                      handle_cuGraphGetId,
                                                       rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12040
+#if CUDA_VERSION >= 13010
                                                       LUPINE_REGISTER_HANDLER(
-                                                          RPC_cuCtxFromGreenCtx,
-                                                          handle_cuCtxFromGreenCtx,
+                                                          RPC_cuGraphExecGetId,
+                                                          handle_cuGraphExecGetId,
                                                           rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12040
+#if CUDA_VERSION >= 12010
                                                           LUPINE_REGISTER_HANDLER(
-                                                              RPC_cuDeviceGetDevResource,
-                                                              handle_cuDeviceGetDevResource,
+                                                              RPC_cuCoredumpGetAttributeGlobal,
+                                                              handle_cuCoredumpGetAttributeGlobal,
                                                               rpc_backend::cuda)
 #endif
-#if CUDA_VERSION >= 12040
+#if CUDA_VERSION >= 12010
                                                               LUPINE_REGISTER_HANDLER(
-                                                                  RPC_cuCtxGetDevResource,
-                                                                  handle_cuCtxGetDevResource,
+                                                                  RPC_cuCoredumpSetAttributeGlobal,
+                                                                  handle_cuCoredumpSetAttributeGlobal,
                                                                   rpc_backend::
                                                                       cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                                   LUPINE_REGISTER_HANDLER(
-                                                                      RPC_cuGreenCtxGetDevResource,
-                                                                      handle_cuGreenCtxGetDevResource,
+                                                                      RPC_cuGreenCtxCreate,
+                                                                      handle_cuGreenCtxCreate,
                                                                       rpc_backend::
                                                                           cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                                       LUPINE_REGISTER_HANDLER(
-                                                                          RPC_cuDevSmResourceSplitByCount,
-                                                                          handle_cuDevSmResourceSplitByCount,
+                                                                          RPC_cuGreenCtxDestroy,
+                                                                          handle_cuGreenCtxDestroy,
                                                                           rpc_backend::
                                                                               cuda)
 #endif
-#if CUDA_VERSION >= 13010
+#if CUDA_VERSION >= 12040
                                                                           LUPINE_REGISTER_HANDLER(
-                                                                              RPC_cuDevSmResourceSplit,
-                                                                              handle_cuDevSmResourceSplit,
+                                                                              RPC_cuCtxFromGreenCtx,
+                                                                              handle_cuCtxFromGreenCtx,
                                                                               rpc_backend::
                                                                                   cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                                               LUPINE_REGISTER_HANDLER(
-                                                                                  RPC_cuDevResourceGenerateDesc,
-                                                                                  handle_cuDevResourceGenerateDesc,
+                                                                                  RPC_cuDeviceGetDevResource,
+                                                                                  handle_cuDeviceGetDevResource,
                                                                                   rpc_backend::
                                                                                       cuda)
 #endif
 #if CUDA_VERSION >= 12040
                                                                                   LUPINE_REGISTER_HANDLER(
-                                                                                      RPC_cuStreamGetGreenCtx,
-                                                                                      handle_cuStreamGetGreenCtx,
+                                                                                      RPC_cuCtxGetDevResource,
+                                                                                      handle_cuCtxGetDevResource,
                                                                                       rpc_backend::
                                                                                           cuda)
 #endif
-#if CUDA_VERSION >= 12050
+#if CUDA_VERSION >= 12040
                                                                                       LUPINE_REGISTER_HANDLER(
-                                                                                          RPC_cuGreenCtxStreamCreate,
-                                                                                          handle_cuGreenCtxStreamCreate,
+                                                                                          RPC_cuGreenCtxGetDevResource,
+                                                                                          handle_cuGreenCtxGetDevResource,
                                                                                           rpc_backend::
                                                                                               cuda)
 #endif
-#if CUDA_VERSION >= 13010
+#if CUDA_VERSION >= 12040
                                                                                           LUPINE_REGISTER_HANDLER(
-                                                                                              RPC_cuStreamGetDevResource,
-                                                                                              handle_cuStreamGetDevResource,
+                                                                                              RPC_cuDevSmResourceSplitByCount,
+                                                                                              handle_cuDevSmResourceSplitByCount,
                                                                                               rpc_backend::
                                                                                                   cuda)
 #endif
+#if CUDA_VERSION >= 13010
+                                                                                              LUPINE_REGISTER_HANDLER(
+                                                                                                  RPC_cuDevSmResourceSplit,
+                                                                                                  handle_cuDevSmResourceSplit,
+                                                                                                  rpc_backend::
+                                                                                                      cuda)
+#endif
+#if CUDA_VERSION >= 12040
+                                                                                                  LUPINE_REGISTER_HANDLER(
+                                                                                                      RPC_cuDevResourceGenerateDesc,
+                                                                                                      handle_cuDevResourceGenerateDesc,
+                                                                                                      rpc_backend::
+                                                                                                          cuda)
+#endif
+#if CUDA_VERSION >= 12040
+                                                                                                      LUPINE_REGISTER_HANDLER(
+                                                                                                          RPC_cuStreamGetGreenCtx,
+                                                                                                          handle_cuStreamGetGreenCtx,
+                                                                                                          rpc_backend::
+                                                                                                              cuda)
+#endif
+#if CUDA_VERSION >= 12050
+                                                                                                          LUPINE_REGISTER_HANDLER(
+                                                                                                              RPC_cuGreenCtxStreamCreate,
+                                                                                                              handle_cuGreenCtxStreamCreate,
+                                                                                                              rpc_backend::
+                                                                                                                  cuda)
+#endif
+#if CUDA_VERSION >= 13010
+                                                                                                              LUPINE_REGISTER_HANDLER(
+                                                                                                                  RPC_cuStreamGetDevResource,
+                                                                                                                  handle_cuStreamGetDevResource,
+                                                                                                                  rpc_backend::
+                                                                                                                      cuda)
+#endif
 #endif
 #ifdef LUPINE_BUILD_NVML_BACKEND
-                                                                                              LUPINE_NVML_RPC_HANDLERS(
-                                                                                                  LUPINE_REGISTER_HANDLER)
+                                                                                                                  LUPINE_NVML_RPC_HANDLERS(
+                                                                                                                      LUPINE_REGISTER_HANDLER)
 
 #endif
   };

--- a/test/cuda-python/known_failures.txt
+++ b/test/cuda-python/known_failures.txt
@@ -1,18 +1,6 @@
 # pytest node ids (relative to the tests or examples directory) that run_cuda_python_tests.sh
 # deselects. One tracking issue per root cause; drop the lines when it closes.
 
-# #577 CUDA 13.1 graph identity APIs
-test_cuda.py::test_cuGraphGetId
-test_cuda.py::test_cuGraphExecGetId
-test_cuda.py::test_cuGraphNodeGetLocalId
-test_cuda.py::test_cuGraphNodeGetToolsId
-test_cuda.py::test_cuGraphNodeGetContainingGraph
-test_cudart.py::test_cudaGraphGetId
-test_cudart.py::test_cudaGraphExecGetId
-test_cudart.py::test_cudaGraphNodeGetLocalId
-test_cudart.py::test_cudaGraphNodeGetToolsId
-test_cudart.py::test_cudaGraphNodeGetContainingGraph
-
 # #578 cuGraphGetEdges / cuGraphNodeGetDependencies with edgeData
 test_cuda.py::test_cuGraphGetEdges_edgeData_outlives_call
 test_cuda.py::test_cuGraphNodeGetDependencies_edgeData_outlives_call


### PR DESCRIPTION
## Summary

- generate routed RPC wrappers and handlers for the five CUDA 13.1 graph identity APIs
- record ownership for graphs returned by cuGraphNodeGetContainingGraph
- re-enable the corresponding cuda-python driver and runtime tests

## Testing

- ./codegen/run.sh (re-run to verify deterministic output)
- cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
- cmake --build build --parallel
- ctest --test-dir build --output-on-failure -j $(nproc) (9/9 passed; 2 environment-dependent tests skipped)
- cuda-python v13.3.1 test_cuda.py: 48 passed, 7 unrelated known failures deselected
- cuda-python v13.3.1 test_cudart.py: 50 passed, 7 unrelated known failures deselected

Fixes #577