### PR TITLE
Complete async device-to-host copies into pageable memory before returning

### DIFF
--- a/copy_pipeline.cpp
+++ b/copy_pipeline.cpp
@@ -12,8 +12,13 @@
 
 extern "C" const void *lupine_mapped_host_read_source(const void *host,
                                                       size_t size);
-extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
-                                    size_t ByteCount) {
+// Shared by the synchronous copy and by an async copy into pageable memory,
+// which the driver also completes before returning. The chunks are staged in a
+// bounded pool on the server, so neither shape materializes the whole transfer.
+extern "C" CUresult lupine_copy_dtoh_on_stream(void *dstHost,
+                                               CUdeviceptr srcDevice,
+                                               size_t ByteCount,
+                                               CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(srcDevice);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
   using real_fn_t = CUresult (*)(void *, CUdeviceptr, size_t);
@@ -26,7 +31,8 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
-      rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
+      rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
+      rpc_write(conn, &hStream, sizeof(hStream)) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   int request_id = rpc_write_end(conn);
@@ -59,6 +65,12 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
     }
   } while (offset < ByteCount);
   return return_value;
+}
+
+extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
+                                    size_t ByteCount) {
+  return lupine_copy_dtoh_on_stream(dstHost, srcDevice, ByteCount,
+                                    CU_STREAM_LEGACY);
 }
 
 #ifdef cuMemcpyDtoH
@@ -1467,7 +1479,7 @@ static int lupine_write_dtoh_chunk_response(conn_t *conn, int request_id,
 
 static int lupine_copy_dtoh_serial(conn_t *conn, int request_id,
                                    CUdeviceptr source, size_t bytes,
-                                   size_t offset) {
+                                   size_t offset, CUstream stream) {
   if (offset > bytes) {
     return -1;
   }
@@ -1485,7 +1497,10 @@ static int lupine_copy_dtoh_serial(conn_t *conn, int request_id,
   do {
     size_t chunk = std::min(bytes - offset, staging_size);
     void *destination = chunk == 0 ? nullptr : host.data();
-    CUresult result = cuMemcpyDtoH_v2(destination, source + offset, chunk);
+    // host is pageable, so this returns only once the chunk has landed,
+    // ordered behind whatever was already queued on the caller's stream.
+    CUresult result =
+        cuMemcpyDtoHAsync_v2(destination, source + offset, chunk, stream);
     if (lupine_write_dtoh_chunk_response(conn, request_id, result, host.data(),
                                          chunk) < 0) {
       return -1;
@@ -1521,6 +1536,7 @@ struct lupine_dtoh_pipeline {
 };
 
 static CUresult lupine_cleanup_dtoh_pipeline(lupine_dtoh_pipeline &pipeline,
+                                             CUstream stream,
                                              bool synchronize_stream) {
   CUresult completion_result = CUDA_SUCCESS;
   bool completion_confirmed = true;
@@ -1530,7 +1546,7 @@ static CUresult lupine_cleanup_dtoh_pipeline(lupine_dtoh_pipeline &pipeline,
     }
   }
   if (synchronize_stream) {
-    completion_result = cuStreamSynchronize(CU_STREAM_LEGACY);
+    completion_result = cuStreamSynchronize(stream);
     completion_confirmed = completion_result == CUDA_SUCCESS;
   } else {
     for (const auto &slot : pipeline.slots) {
@@ -1540,7 +1556,7 @@ static CUresult lupine_cleanup_dtoh_pipeline(lupine_dtoh_pipeline &pipeline,
       CUresult result = cuEventSynchronize(slot.completion);
       if (result != CUDA_SUCCESS) {
         completion_result = result;
-        CUresult stream_result = cuStreamSynchronize(CU_STREAM_LEGACY);
+        CUresult stream_result = cuStreamSynchronize(stream);
         completion_confirmed = stream_result == CUDA_SUCCESS;
         break;
       }
@@ -1566,7 +1582,8 @@ static CUresult lupine_cleanup_dtoh_pipeline(lupine_dtoh_pipeline &pipeline,
 // resume.
 static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
                                       CUdeviceptr source, size_t bytes,
-                                      size_t *fallback_offset) {
+                                      size_t *fallback_offset,
+                                      CUstream stream) {
   lupine_dtoh_pipeline pipeline;
   if (cuMemAllocHost(&pipeline.storage, LUPINE_DTOH_PIPELINE_SLOT_COUNT *
                                             LUPINE_DTOH_PIPELINE_SLOT_BYTES) !=
@@ -1581,7 +1598,7 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
     slot.data = storage + index * LUPINE_DTOH_PIPELINE_SLOT_BYTES;
     if (cuEventCreate(&slot.completion, CU_EVENT_DISABLE_TIMING) !=
         CUDA_SUCCESS) {
-      (void)lupine_cleanup_dtoh_pipeline(pipeline, false);
+      (void)lupine_cleanup_dtoh_pipeline(pipeline, stream, false);
       *fallback_offset = 0;
       return 1;
     }
@@ -1597,12 +1614,12 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
     // unproven until an event or stream synchronization establishes completion.
     slot.in_flight = true;
     slot.event_recorded = false;
-    CUresult result = cuMemcpyDtoHAsync_v2(slot.data, source + offset,
-                                           slot.bytes, CU_STREAM_LEGACY);
+    CUresult result =
+        cuMemcpyDtoHAsync_v2(slot.data, source + offset, slot.bytes, stream);
     if (result != CUDA_SUCCESS) {
       return result;
     }
-    if (cuEventRecord(slot.completion, CU_STREAM_LEGACY) != CUDA_SUCCESS) {
+    if (cuEventRecord(slot.completion, stream) != CUDA_SUCCESS) {
       event_record_failed = true;
     } else {
       slot.event_recorded = true;
@@ -1622,7 +1639,7 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
     }
     CUresult result = submit(slot, submitted_offset);
     if (event_record_failed) {
-      CUresult cleanup = lupine_cleanup_dtoh_pipeline(pipeline, true);
+      CUresult cleanup = lupine_cleanup_dtoh_pipeline(pipeline, stream, true);
       if (cleanup != CUDA_SUCCESS) {
         return lupine_write_dtoh_chunk_response(conn, request_id, cleanup,
                                                 nullptr, 0);
@@ -1643,7 +1660,7 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
     if (terminal_error_pending && terminal_error_offset == sent_offset) {
       int write_result = lupine_write_dtoh_chunk_response(
           conn, request_id, terminal_error, nullptr, 0);
-      (void)lupine_cleanup_dtoh_pipeline(pipeline, false);
+      (void)lupine_cleanup_dtoh_pipeline(pipeline, stream, false);
       return write_result;
     }
 
@@ -1651,7 +1668,7 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
                    LUPINE_DTOH_PIPELINE_SLOT_COUNT;
     auto &slot = pipeline.slots[index];
     if (!slot.in_flight || !slot.event_recorded || slot.offset != sent_offset) {
-      CUresult cleanup = lupine_cleanup_dtoh_pipeline(pipeline, true);
+      CUresult cleanup = lupine_cleanup_dtoh_pipeline(pipeline, stream, true);
       if (cleanup != CUDA_SUCCESS) {
         return lupine_write_dtoh_chunk_response(conn, request_id, cleanup,
                                                 nullptr, 0);
@@ -1664,12 +1681,12 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
     if (result != CUDA_SUCCESS) {
       int write_result = lupine_write_dtoh_chunk_response(conn, request_id,
                                                           result, nullptr, 0);
-      (void)lupine_cleanup_dtoh_pipeline(pipeline, true);
+      (void)lupine_cleanup_dtoh_pipeline(pipeline, stream, true);
       return write_result;
     }
     if (lupine_write_dtoh_chunk_response(conn, request_id, CUDA_SUCCESS,
                                          slot.data, slot.bytes) < 0) {
-      (void)lupine_cleanup_dtoh_pipeline(pipeline, false);
+      (void)lupine_cleanup_dtoh_pipeline(pipeline, stream, false);
       return -1;
     }
 
@@ -1679,7 +1696,7 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
     if (submitted_offset < bytes && !terminal_error_pending) {
       result = submit(slot, submitted_offset);
       if (event_record_failed) {
-        CUresult cleanup = lupine_cleanup_dtoh_pipeline(pipeline, true);
+        CUresult cleanup = lupine_cleanup_dtoh_pipeline(pipeline, stream, true);
         if (cleanup != CUDA_SUCCESS) {
           return lupine_write_dtoh_chunk_response(conn, request_id, cleanup,
                                                   nullptr, 0);
@@ -1697,15 +1714,20 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
     }
   }
 
-  (void)lupine_cleanup_dtoh_pipeline(pipeline, false);
+  (void)lupine_cleanup_dtoh_pipeline(pipeline, stream, false);
   return 0;
 }
 
 int handle_cuMemcpyDtoH_v2(conn_t *conn) {
   CUdeviceptr source = 0;
   size_t bytes = 0;
+  // The stream the caller's copy was queued on. A synchronous cuMemcpyDtoH
+  // sends the legacy stream; an async copy into pageable memory sends its own,
+  // so the chunks stay ordered behind that stream's prior work.
+  CUstream stream = CU_STREAM_LEGACY;
   if (rpc_read(conn, &source, sizeof(source)) < 0 ||
-      rpc_read(conn, &bytes, sizeof(bytes)) < 0) {
+      rpc_read(conn, &bytes, sizeof(bytes)) < 0 ||
+      rpc_read(conn, &stream, sizeof(stream)) < 0) {
     return -1;
   }
   int request_id = rpc_read_end(conn);
@@ -1716,13 +1738,13 @@ int handle_cuMemcpyDtoH_v2(conn_t *conn) {
   size_t fallback_offset = 0;
   if (bytes >= LUPINE_DTOH_PIPELINE_MIN_BYTES) {
     int result = lupine_copy_dtoh_pipelined(conn, request_id, source, bytes,
-                                            &fallback_offset);
+                                            &fallback_offset, stream);
     if (result <= 0) {
       return result;
     }
   }
   return lupine_copy_dtoh_serial(conn, request_id, source, bytes,
-                                 fallback_offset);
+                                 fallback_offset, stream);
 }
 
 int lupine_server_copy_htod_async(conn_t *conn, int framed,

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -3219,6 +3219,13 @@ CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
 CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
                               size_t ByteCount, CUstream hStream);
 CUresult cuStreamSynchronize(CUstream hStream);
+extern "C" CUresult lupine_copy_dtoh_on_stream(void *dstHost,
+                                               CUdeviceptr srcDevice,
+                                               size_t ByteCount,
+                                               CUstream hStream);
+// Defined with the capture wrappers below; nonzero only while this client holds
+// a stream capture open, where a pageable copy must stay a graph node.
+extern std::atomic<int> lupine_active_stream_captures;
 extern "C" CUresult cuStreamQuery_ptsz(CUstream hStream);
 extern "C" CUresult cuStreamSynchronize_ptsz(CUstream hStream);
 
@@ -5521,6 +5528,19 @@ extern "C" CUresult cuMemcpyAtoH(void *dstHost, CUarray srcArray,
 
 extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
+  // "API synchronization behavior" lets the driver make this copy synchronous
+  // when the destination is pageable, and every driver does. Callers rely on it
+  // instead of synchronizing: cuSPARSE reads its scalar results (nnz counts,
+  // SpVV dot products) that way, and a deferred copy either never lands or
+  // lands on a stack frame the caller has already left. The bytes come back
+  // through the same bounded, chunked path the synchronous copy uses, issued on
+  // this stream so they stay ordered behind its prior work. Capture is the
+  // exception: there the copy only becomes a graph node and must not block.
+  if (ByteCount != 0 && !lupine_host_ptr_is_page_locked(dstHost) &&
+      lupine_active_stream_captures.load(std::memory_order_relaxed) == 0) {
+    return lupine_copy_dtoh_on_stream(dstHost, srcDevice, ByteCount, hStream);
+  }
+
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
@@ -5574,8 +5594,8 @@ extern "C" CUresult cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy) {
                            : lupine_copy_direction::host_to_device)
                : (dst_host ? lupine_copy_direction::device_to_host
                            : lupine_copy_direction::device_to_device);
-  const char *src_base = (const char *)copy.srcHost +
-                         copy.srcY * copy.srcPitch + copy.srcXInBytes;
+  const char *src_base =
+      (const char *)copy.srcHost + copy.srcY * copy.srcPitch + copy.srcXInBytes;
   char *dst_base =
       (char *)copy.dstHost + copy.dstY * copy.dstPitch + copy.dstXInBytes;
   CUresult return_value;
@@ -5701,8 +5721,8 @@ extern "C" CUresult cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy) {
                            : lupine_copy_direction::host_to_device)
                : (dst_host ? lupine_copy_direction::device_to_host
                            : lupine_copy_direction::device_to_device);
-  const char *src_base = (const char *)copy.srcHost +
-                         copy.srcY * copy.srcPitch + copy.srcXInBytes;
+  const char *src_base =
+      (const char *)copy.srcHost + copy.srcY * copy.srcPitch + copy.srcXInBytes;
   char *dst_base =
       (char *)copy.dstHost + copy.dstY * copy.dstPitch + copy.dstXInBytes;
   CUresult return_value;
@@ -5829,8 +5849,8 @@ extern "C" CUresult cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy,
                            : lupine_copy_direction::host_to_device)
                : (dst_host ? lupine_copy_direction::device_to_host
                            : lupine_copy_direction::device_to_device);
-  const char *src_base = (const char *)copy.srcHost +
-                         copy.srcY * copy.srcPitch + copy.srcXInBytes;
+  const char *src_base =
+      (const char *)copy.srcHost + copy.srcY * copy.srcPitch + copy.srcXInBytes;
   char *dst_base =
       (char *)copy.dstHost + copy.dstY * copy.dstPitch + copy.dstXInBytes;
   CUresult return_value;
@@ -6019,9 +6039,9 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
                            : lupine_copy_direction::device_to_device);
   size_t src_slice_pitch = copy.srcHeight * copy.srcPitch;
   size_t dst_slice_pitch = copy.dstHeight * copy.dstPitch;
-  const char *src_base =
-      (const char *)copy.srcHost + copy.srcZ * src_slice_pitch +
-      copy.srcY * copy.srcPitch + copy.srcXInBytes;
+  const char *src_base = (const char *)copy.srcHost +
+                         copy.srcZ * src_slice_pitch +
+                         copy.srcY * copy.srcPitch + copy.srcXInBytes;
   char *dst_base = (char *)copy.dstHost + copy.dstZ * dst_slice_pitch +
                    copy.dstY * copy.dstPitch + copy.dstXInBytes;
   CUresult return_value;
@@ -8005,7 +8025,7 @@ static CUresult lupine_cuStreamGetCaptureInfo(
 // Stream captures started by this client and not yet terminated. A stream can
 // only be capturing if we started the capture, so cuStreamIsCapturing can
 // answer NONE locally while this is zero.
-static std::atomic<int> lupine_active_stream_captures{0};
+std::atomic<int> lupine_active_stream_captures{0};
 
 class lupine_capture_begin_guard {
 public:

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -1072,6 +1072,26 @@ static bool lupine_host_ptr_is_tracked(CUdeviceptr ptr) {
          lupine_mutable_host_allocations_locked().end();
 }
 
+// Whether the driver would treat this address as page-locked, which is true of
+// exactly the ranges the caller handed to cuMemHostAlloc, cuMemAllocHost,
+// cuMemHostRegister or cuMemAllocManaged. Tracked ranges are rounded out to
+// whole pages, so the exact caller range is what has to be tested: a plain
+// malloc that merely shares a page with a registered one is still pageable, and
+// treating it as page-locked would defer a copy the driver completes inline.
+extern "C" bool lupine_host_ptr_is_page_locked(const void *host) {
+  if (host == nullptr) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(const_cast<void *>(host));
+  if (it == lupine_mutable_host_allocations_locked().end()) {
+    return false;
+  }
+  uintptr_t address = reinterpret_cast<uintptr_t>(host);
+  return address >= it->second.user_base &&
+         address < it->second.user_base + it->second.user_size;
+}
+
 static bool lupine_managed_host_alias_base(CUdeviceptr ptr,
                                            CUdeviceptr *alias_base) {
   void *host = reinterpret_cast<void *>(ptr);
@@ -1209,9 +1229,11 @@ static bool lupine_fetch_stale_range(lupine_host_allocation *allocation,
   }
   // Demand fetch can run from the fault handler and must not re-enter the
   // normal CUDA request-start flush.
+  CUstream fetch_stream = CU_STREAM_LEGACY;
   if (rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
       rpc_write(conn, &src, sizeof(src)) < 0 ||
-      rpc_write(conn, &bytes, sizeof(bytes)) < 0) {
+      rpc_write(conn, &bytes, sizeof(bytes)) < 0 ||
+      rpc_write(conn, &fetch_stream, sizeof(fetch_stream)) < 0) {
     return false;
   }
   int request_id = rpc_write_end(conn);

--- a/memcpy.h
+++ b/memcpy.h
@@ -11,6 +11,7 @@ enum class lupine_copy_direction {
   device_to_device,
 };
 extern "C" bool lupine_copy_pointer_is_host(CUdeviceptr ptr);
+extern "C" bool lupine_host_ptr_is_page_locked(const void *host);
 extern "C" bool lupine_is_managed_host_alias(CUdeviceptr ptr);
 extern "C" CUresult lupine_sync_mapped_device_to_host();
 extern "C" void lupine_materialize_host_allocations();

--- a/test/cuda-library-samples/known_failures.txt
+++ b/test/cuda-library-samples/known_failures.txt
@@ -1,25 +1,6 @@
 # Units (<sample dir>/<executable>) that run_cuda_library_samples.sh marks
 # SKIP:known. One tracking issue per root cause; drop the lines when it closes.
 
-# #590 cuSPARSE SpSV/SpSM solve SIGFPE
-cuSPARSE/cg/cg_example
-cuSPARSE/spsm_coo/spsm_coo_example
-cuSPARSE/spsm_csr/spsm_csr_example
-cuSPARSE/spsv_coo/spsv_coo_example
-cuSPARSE/spsv_csr/spsv_csr_example
-
-# #591 cuSPARSE SpGEMM cudaErrorInvalidValue
-cuSPARSE/spgemm/spgemm_example
-cuSPARSE/spgemm_mem/spgemm_mem_example
-cuSPARSE/spgemm_reuse/spgemm_reuse_example
-
-# #592 cuSPARSE dense2sparse_csr stack smashing
-cuSPARSE/dense2sparse_csr/dense2sparse_csr_example
-
-# #593 cuSPARSE wrong results
-cuSPARSE/spsv_sell/spsv_sell_example
-cuSPARSE/spvv/spvv_example
-
 # #595 cuFFT multi-GPU c2c wrong results
 cuFFT/1d_mgpu_c2c/bin/1d_mgpu_c2c_example
 cuFFT/3d_mgpu_c2c/bin/3d_mgpu_c2c_example

--- a/test/test_pageable_async_dtoh.cu
+++ b/test/test_pageable_async_dtoh.cu
@@ -1,0 +1,126 @@
+// Verify that an async DtoH copy into pageable host memory has landed by the
+// time the call returns. The driver is free to make such a copy synchronous
+// and always does, staging it through pinned memory; only a page-locked
+// destination is truly deferred. Libraries such as cuSPARSE read their scalar
+// results this way and never synchronize, and the destination is often a stack
+// variable that is gone by the next synchronize.
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+constexpr size_t kElements = 4096;
+constexpr size_t kBytes = kElements * sizeof(int);
+constexpr int kUntouched = -1;
+
+bool check(cudaError_t result, const char *operation) {
+  if (result == cudaSuccess) {
+    return true;
+  }
+  std::fprintf(stderr, "FAIL: %s: %s\n", operation, cudaGetErrorString(result));
+  return false;
+}
+
+__global__ void fill(int *out, int value, size_t elements) {
+  size_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index < elements) {
+    out[index] = value;
+  }
+}
+
+// Reads back into a stack buffer the way cuSPARSE reads its result scalars: a
+// deferred copy would either never arrive or land on a dead frame.
+bool read_back_on_stack(const int *device, cudaStream_t stream, int value,
+                        const char *label) {
+  int host[kElements];
+  std::fill(host, host + kElements, kUntouched);
+  if (!check(
+          cudaMemcpyAsync(host, device, kBytes, cudaMemcpyDeviceToHost, stream),
+          label)) {
+    return false;
+  }
+  if (!std::all_of(host, host + kElements,
+                   [value](int seen) { return seen == value; })) {
+    std::fprintf(stderr, "FAIL: %s did not deliver %d before returning\n",
+                 label, value);
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+int main() {
+  int *device = nullptr;
+  cudaStream_t stream = nullptr;
+  if (!check(cudaMalloc(reinterpret_cast<void **>(&device), kBytes),
+             "cudaMalloc") ||
+      !check(cudaStreamCreate(&stream), "cudaStreamCreate")) {
+    return 1;
+  }
+
+  const unsigned int blocks = (kElements + 255) / 256;
+  fill<<<blocks, 256, 0, stream>>>(device, 7, kElements);
+  if (!check(cudaGetLastError(), "launch fill on stream") ||
+      !read_back_on_stack(device, stream, 7, "stream DtoH")) {
+    return 1;
+  }
+
+  // The same guarantee holds on the legacy default stream, which is what a
+  // library that never creates a stream of its own uses.
+  fill<<<blocks, 256>>>(device, 11, kElements);
+  if (!check(cudaGetLastError(), "launch fill on default stream") ||
+      !read_back_on_stack(device, nullptr, 11, "default-stream DtoH")) {
+    return 1;
+  }
+
+  // A heap destination is pageable too, and its bytes must be visible without
+  // a synchronize just the same.
+  std::vector<int> heap(kElements, kUntouched);
+  fill<<<blocks, 256, 0, stream>>>(device, 13, kElements);
+  if (!check(cudaGetLastError(), "launch fill for heap readback") ||
+      !check(cudaMemcpyAsync(heap.data(), device, kBytes,
+                             cudaMemcpyDeviceToHost, stream),
+             "heap DtoH")) {
+    return 1;
+  }
+  if (!std::all_of(heap.begin(), heap.end(),
+                   [](int seen) { return seen == 13; })) {
+    std::fprintf(stderr, "FAIL: heap DtoH did not deliver 13 before "
+                         "returning\n");
+    return 1;
+  }
+
+  // A page-locked range is tracked rounded out to whole pages, so a plain
+  // allocation that merely shares a page with one is still pageable and must
+  // not inherit its deferred copy.
+  std::vector<int> registered(kElements, kUntouched);
+  if (!check(
+          cudaHostRegister(registered.data(), kBytes, cudaHostRegisterDefault),
+          "cudaHostRegister")) {
+    return 1;
+  }
+  std::vector<int> neighbour(kElements, kUntouched);
+  fill<<<blocks, 256, 0, stream>>>(device, 17, kElements);
+  if (!check(cudaGetLastError(), "launch fill for neighbour readback") ||
+      !check(cudaMemcpyAsync(neighbour.data(), device, kBytes,
+                             cudaMemcpyDeviceToHost, stream),
+             "page-neighbour DtoH")) {
+    return 1;
+  }
+  if (!std::all_of(neighbour.begin(), neighbour.end(),
+                   [](int seen) { return seen == 17; })) {
+    std::fprintf(stderr, "FAIL: an allocation sharing a page with a registered "
+                         "one was treated as page-locked\n");
+    return 1;
+  }
+  cudaHostUnregister(registered.data());
+
+  cudaStreamDestroy(stream);
+  cudaFree(device);
+  std::printf("PASS: pageable async DtoH completes before returning\n");
+  return 0;
+}


### PR DESCRIPTION
Fixes #590, fixes #591, fixes #592, fixes #593 — all four were the same bug.

`cuMemcpyDtoHAsync_v2` was fire-and-forget for every destination. The driver is permitted to make that copy synchronous when the destination is pageable, and in practice always is:

> For transfers between device memory and pageable host memory, the function **might** be synchronous with respect to host. […] If pageable memory must first be staged to pinned memory, the driver may synchronize with the stream and stage the copy into pinned memory.
> — [API synchronization behavior](https://docs.nvidia.com/cuda/cuda-driver-api/api-sync-behavior.html), which also calls the `Async` suffix "a misnomer"

Measured on an RTX 4090 behind a ~0.5s kernel, calling `cuMemcpyDtoHAsync_v2` directly: a pageable destination blocks for the whole kernel at every size from 4 B to 2 GB, a pinned one returns in 0.01 ms. A gdb breakpoint on a native run shows cuSPARSE reaching that async entry point from inside `libcusparse.so.12` and never touching `cuMemcpyDtoH_v2` or any synchronize; nsys agrees — `cudaLaunchKernel` → `cudaMemcpyAsync` → `cudaFree`, no sync anywhere.

So cuSPARSE reads its scalar results (SpGEMM nnz counts, SpSV/SpSM analysis counts, the SpVV dot product) from a copy it never waits on. Through the shim those bytes were deferred to the next synchronize, which either never came or landed on a stack frame the caller had already left: zeros that divide (#590 SIGFPE), an nnz of 0 that becomes a NULL `cudaMalloc` and a rejected copy (#591), wrong results (#593), and a smashed stack canary (#592).

When the destination is not one of the host ranges the client tracks, the copy now goes down the same path as the synchronous one, carrying the stream it was queued on so the chunks stay ordered behind that stream's prior work. That path already stages on the server in a bounded pool — two 4 MiB pinned slots, or a single 4 MiB pageable chunk below the pipeline threshold — and compresses. A 256 MB pageable copy leaves the server at 8.7 MB peak RSS. Nothing in the path synchronizes explicitly: staging pageable means the server's own copy blocks exactly as the caller's would locally, so the wait belongs to the driver rather than to us. Page-locked destinations keep the deferred path untouched, and a capturing stream keeps it too, since there the copy only becomes a graph node.

That last part is where the throughput-sensitive traffic lives: PyTorch's `.to("cpu", non_blocking=True)` allocates its destination from the pinned host caching allocator, so it never takes this branch. (Its tutorial's "async D2H gives wrong results" example is a pinned copy, which is genuinely asynchronous — `copy_` into an explicitly pageable tensor with `non_blocking=True` and no synchronize returns correct data.)

Latency, small copy behind a trivial kernel, 2 reps against a LAN server:

| shape | main | this PR |
| --- | --- | --- |
| pageable, no sync (the cuSPARSE shape) | ~176 µs, wrong data | ~517 µs |
| pageable + `cudaStreamSynchronize` | ~1555 µs | ~672 µs |
| pinned, no sync | ~13 µs | ~15 µs |

The pageable+sync shape gets faster than main because the deferred path page-locks a staging buffer with `cuMemAllocHost` on every copy.

`test/test_pageable_async_dtoh.cu` covers stack, heap, created-stream and legacy-default-stream destinations; it fails on main.

Verified against inferable-node-008 (RTX 4090, driver 590.48, client CUDA 13.3): cuSPARSE library samples 35/35 with all four issues' entries dropped from `known_failures.txt`; custom driver-API tests 30/30; unit tests 9/9; a 256 MB pageable copy read with no synchronize comes back byte-correct.