### PR TITLE
Reduce event completion tracking to two tracked facts

### DIFF
--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -4322,7 +4322,7 @@ extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn) {
       return -1;
     }
   }
-  lupine_note_async_dtoh_drained(copy_count);
+  lupine_event_stale_semaphore_add(-static_cast<int64_t>(copy_count));
   return 0;
 }
 
@@ -4371,7 +4371,7 @@ extern "C" CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
           route, "cuEventRecord", &return_value, hEvent, hStream)) {
     return return_value;
   }
-  lupine_note_event_recorded(hEvent);
+  lupine_event_invalidate_completion(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
@@ -4401,7 +4401,7 @@ extern "C" CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
           flags)) {
     return return_value;
   }
-  lupine_note_event_recorded(hEvent);
+  lupine_event_invalidate_completion(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
@@ -4427,9 +4427,9 @@ extern "C" CUresult cuEventRecordWithFlags_ptsz(CUevent hEvent,
 // already produced by RPC_cuEventQuery.
 static void lupine_prefetch_event_queries(CUevent exclude, conn_t *conn) {
   CUevent events[kLupineEventQueryBatch];
-  uint64_t recorded[kLupineEventQueryBatch];
+  uint64_t records[kLupineEventQueryBatch];
   uint32_t count =
-      lupine_collect_event_query_prefetch(exclude, conn, events, recorded);
+      lupine_event_collect_query_batch(exclude, conn, events, records);
   if (count == 0) {
     return;
   }
@@ -4444,7 +4444,7 @@ static void lupine_prefetch_event_queries(CUevent exclude, conn_t *conn) {
       rpc_read_end(conn) < 0) {
     return;
   }
-  lupine_note_event_query_results(events, recorded, results, count);
+  lupine_event_cache_completions(events, records, results, count);
 }
 
 extern "C" CUresult cuEventQuery(CUevent hEvent) {
@@ -4462,8 +4462,8 @@ extern "C" CUresult cuEventQuery(CUevent hEvent) {
   }
   std::shared_lock<std::shared_mutex> event_lifecycle_lock(
       lupine_event_lifecycle_mutex());
-  uint64_t recorded = 0;
-  if (!lupine_event_query_needed(hEvent, &recorded)) {
+  uint64_t record = 0;
+  if (!lupine_event_query_needed(hEvent, &record)) {
     return lupine_sync_mapped_device_to_host();
   }
   CUresult result = CUDA_ERROR_UNKNOWN;
@@ -4475,7 +4475,7 @@ extern "C" CUresult cuEventQuery(CUevent hEvent) {
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  lupine_note_event_query_results(&hEvent, &recorded, &result, 1);
+  lupine_event_cache_completions(&hEvent, &record, &result, 1);
 
   return_value = result;
   if (return_value == CUDA_SUCCESS) {
@@ -5552,7 +5552,7 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (ByteCount != 0) {
-    lupine_note_async_dtoh_copy();
+    lupine_event_stale_semaphore_add(1);
   }
   return CUDA_SUCCESS;
 }

--- a/events.cpp
+++ b/events.cpp
@@ -2,104 +2,6 @@
 
 #include "client_routing.h"
 
-void lupine_event_note_recorded(lupine_event_table *table, CUevent event) {
-  uint64_t seq = table->record_seq.fetch_add(1) + 1;
-  lupine_event_slot *slots = table->slots;
-  std::lock_guard<std::mutex> lock(table->mutex);
-  lupine_event_slot *victim = &slots[0];
-  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
-    if (slots[i].event == event) {
-      slots[i].recorded = seq;
-      return;
-    }
-    if (slots[i].recorded < victim->recorded) {
-      victim = &slots[i];
-    }
-  }
-  *victim = {event, seq, 0};
-}
-
-void lupine_event_note_destroyed(lupine_event_table *table, CUevent event) {
-  std::lock_guard<std::mutex> lock(table->mutex);
-  for (auto &slot : table->slots) {
-    if (slot.event == event) {
-      slot = {};
-    }
-  }
-}
-
-bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
-                               uint64_t *recorded) {
-  bool copies_pending =
-      table->dtoh_pending.load(std::memory_order_relaxed) != 0;
-  lupine_event_slot *slots = table->slots;
-  std::lock_guard<std::mutex> lock(table->mutex);
-  *recorded = 0;
-  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
-    if (slots[i].event != event) {
-      continue;
-    }
-    *recorded = slots[i].recorded;
-    return copies_pending || slots[i].recorded != slots[i].completed;
-  }
-  return true;
-}
-
-uint32_t lupine_event_collect_query_prefetch(
-    lupine_event_table *table, CUevent exclude, conn_t *conn,
-    lupine_event_conn_resolver resolver, CUevent *events, uint64_t *recorded) {
-  lupine_event_slot *slots = table->slots;
-  std::lock_guard<std::mutex> lock(table->mutex);
-  uint32_t count = 0;
-  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
-    if (slots[i].event == nullptr || slots[i].event == exclude ||
-        slots[i].recorded == slots[i].completed ||
-        resolver(slots[i].event) != conn) {
-      continue;
-    }
-    events[count] = slots[i].event;
-    recorded[count] = slots[i].recorded;
-    if (++count == kLupineEventQueryBatch) {
-      break;
-    }
-  }
-  return count;
-}
-
-void lupine_event_note_query_results(lupine_event_table *table,
-                                     const CUevent *events,
-                                     const uint64_t *recorded,
-                                     const CUresult *results, uint32_t count) {
-  lupine_event_slot *slots = table->slots;
-  std::lock_guard<std::mutex> lock(table->mutex);
-  for (uint32_t i = 0; i < count; ++i) {
-    if (results[i] != CUDA_SUCCESS || recorded[i] == 0) {
-      continue;
-    }
-    for (uint32_t j = 0; j < kLupineEventQueryBatch; ++j) {
-      if (slots[j].event == events[i] && slots[j].recorded == recorded[i]) {
-        slots[j].completed = recorded[i];
-        break;
-      }
-    }
-  }
-}
-
-void lupine_event_note_async_dtoh(lupine_event_table *table) {
-  table->dtoh_pending.fetch_add(1, std::memory_order_relaxed);
-}
-
-void lupine_event_note_dtoh_drained(lupine_event_table *table, uint64_t count) {
-  uint64_t pending = table->dtoh_pending.load(std::memory_order_relaxed);
-  while (pending != 0) {
-    uint64_t remaining = count >= pending ? 0 : pending - count;
-    if (table->dtoh_pending.compare_exchange_weak(pending, remaining,
-                                                  std::memory_order_relaxed)) {
-      return;
-    }
-  }
-}
-
 static lupine_event_table &lupine_event_table_instance() {
   static lupine_event_table table;
   return table;
@@ -110,38 +12,135 @@ std::shared_mutex &lupine_event_lifecycle_mutex() {
   return mutex;
 }
 
-void lupine_note_event_recorded(CUevent event) {
-  lupine_event_note_recorded(&lupine_event_table_instance(), event);
+void lupine_event_invalidate_completion(lupine_event_table *table,
+                                        CUevent event) {
+  uint64_t record = table->record_seq.fetch_add(1) + 1;
+  lupine_event_slot *slots = table->slots;
+  std::lock_guard<std::mutex> lock(table->mutex);
+  lupine_event_slot *victim = &slots[0];
+  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    if (slots[i].event == event) {
+      slots[i].record = record;
+      slots[i].complete = false;
+      return;
+    }
+    if (slots[i].record < victim->record) {
+      victim = &slots[i];
+    }
+  }
+  *victim = {event, record, false};
 }
 
-void lupine_note_event_destroyed(CUevent event) {
-  lupine_event_note_destroyed(&lupine_event_table_instance(), event);
+void lupine_event_forget(lupine_event_table *table, CUevent event) {
+  std::lock_guard<std::mutex> lock(table->mutex);
+  for (auto &slot : table->slots) {
+    if (slot.event == event) {
+      slot = {};
+    }
+  }
 }
 
-bool lupine_event_query_needed(CUevent event, uint64_t *recorded) {
+bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
+                               uint64_t *record) {
+  bool copies_owed =
+      table->stale_semaphore.load(std::memory_order_relaxed) != 0;
+  lupine_event_slot *slots = table->slots;
+  std::lock_guard<std::mutex> lock(table->mutex);
+  *record = 0;
+  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    if (slots[i].event != event) {
+      continue;
+    }
+    *record = slots[i].record;
+    return copies_owed || !slots[i].complete;
+  }
+  return true;
+}
+
+uint32_t lupine_event_collect_query_batch(lupine_event_table *table,
+                                          CUevent exclude, conn_t *conn,
+                                          lupine_event_conn_resolver resolver,
+                                          CUevent *events, uint64_t *records) {
+  lupine_event_slot *slots = table->slots;
+  std::lock_guard<std::mutex> lock(table->mutex);
+  uint32_t count = 0;
+  for (uint32_t i = 0; i < kLupineEventQueryBatch; ++i) {
+    if (slots[i].event == nullptr || slots[i].event == exclude ||
+        slots[i].complete || resolver(slots[i].event) != conn) {
+      continue;
+    }
+    events[count] = slots[i].event;
+    records[count] = slots[i].record;
+    if (++count == kLupineEventQueryBatch) {
+      break;
+    }
+  }
+  return count;
+}
+
+void lupine_event_cache_completions(lupine_event_table *table,
+                                    const CUevent *events,
+                                    const uint64_t *records,
+                                    const CUresult *results, uint32_t count) {
+  lupine_event_slot *slots = table->slots;
+  std::lock_guard<std::mutex> lock(table->mutex);
+  for (uint32_t i = 0; i < count; ++i) {
+    if (results[i] != CUDA_SUCCESS || records[i] == 0) {
+      continue;
+    }
+    for (uint32_t j = 0; j < kLupineEventQueryBatch; ++j) {
+      if (slots[j].event == events[i] && slots[j].record == records[i]) {
+        slots[j].complete = true;
+        break;
+      }
+    }
+  }
+}
+
+void lupine_event_stale_semaphore_add(lupine_event_table *table,
+                                      int64_t delta) {
+  if (delta >= 0) {
+    table->stale_semaphore.fetch_add(static_cast<uint64_t>(delta),
+                                     std::memory_order_relaxed);
+    return;
+  }
+  // A graph replay hands back host copies this client never counted, so the
+  // subtraction saturates at zero rather than wrapping.
+  uint64_t delivered = static_cast<uint64_t>(-delta);
+  uint64_t owed = table->stale_semaphore.load(std::memory_order_relaxed);
+  while (owed != 0 && !table->stale_semaphore.compare_exchange_weak(
+                          owed, delivered >= owed ? 0 : owed - delivered,
+                          std::memory_order_relaxed)) {
+  }
+}
+
+void lupine_event_invalidate_completion(CUevent event) {
+  lupine_event_invalidate_completion(&lupine_event_table_instance(), event);
+}
+
+void lupine_event_forget(CUevent event) {
+  lupine_event_forget(&lupine_event_table_instance(), event);
+}
+
+bool lupine_event_query_needed(CUevent event, uint64_t *record) {
   return lupine_event_query_needed(&lupine_event_table_instance(), event,
-                                   recorded);
+                                   record);
 }
 
-uint32_t lupine_collect_event_query_prefetch(CUevent exclude, conn_t *conn,
-                                             CUevent *events,
-                                             uint64_t *recorded) {
-  return lupine_event_collect_query_prefetch(
+uint32_t lupine_event_collect_query_batch(CUevent exclude, conn_t *conn,
+                                          CUevent *events, uint64_t *records) {
+  return lupine_event_collect_query_batch(
       &lupine_event_table_instance(), exclude, conn, lupine_rpc_conn_for_event,
-      events, recorded);
+      events, records);
 }
 
-void lupine_note_event_query_results(const CUevent *events,
-                                     const uint64_t *recorded,
-                                     const CUresult *results, uint32_t count) {
-  lupine_event_note_query_results(&lupine_event_table_instance(), events,
-                                  recorded, results, count);
+void lupine_event_cache_completions(const CUevent *events,
+                                    const uint64_t *records,
+                                    const CUresult *results, uint32_t count) {
+  lupine_event_cache_completions(&lupine_event_table_instance(), events,
+                                 records, results, count);
 }
 
-void lupine_note_async_dtoh_copy() {
-  lupine_event_note_async_dtoh(&lupine_event_table_instance());
-}
-
-void lupine_note_async_dtoh_drained(uint64_t count) {
-  lupine_event_note_dtoh_drained(&lupine_event_table_instance(), count);
+void lupine_event_stale_semaphore_add(int64_t delta) {
+  lupine_event_stale_semaphore_add(&lupine_event_table_instance(), delta);
 }

--- a/events.h
+++ b/events.h
@@ -1,10 +1,17 @@
 #pragma once
 
-// Client-side event completion tracking and explicit query prefetch policy.
-// The lupine_event_* functions operate on a bare table and take the connection
-// resolver as a parameter, so the policy is unit-testable without routing; the
-// lupine_note_*/lupine_collect_* wrappers bind the process-wide table and the
-// real resolver for the client wrappers.
+// Client-side cache of event completion, and the policy for when cuEventQuery
+// may be answered from it instead of costing a round trip.
+//
+// Two things are tracked. Per event: the stamp of its current record, and
+// whether that record is known complete. Completion is monotonic between
+// records, so once the server reports an event complete the client can answer
+// later queries for that same record itself. Process-wide: how many deferred
+// device-to-host copies the server still owes, because those ride back on
+// responses and a locally answered query never collects one.
+//
+// Every operation has a form taking an explicit table so the policy is
+// testable without routing; the short forms bind the process-wide table.
 
 #include <atomic>
 #include <cstdint>
@@ -17,52 +24,70 @@
 
 #include "rpc.h"
 
-// Completion is monotonic between records: once the server reports an event
-// complete for a given record, that stays true until the event is recorded
-// again. Deferred device-to-host copies only reach the client on a query that
-// actually reaches the server, so a locally answered query is legal only while
-// no async copy is waiting to be drained. Other outstanding events may be
-// queried by a separate Lupine RPC to warm this cache.
 constexpr uint32_t kLupineEventQueryBatch = 16;
 
 struct lupine_event_slot {
   CUevent event;
-  uint64_t recorded;
-  uint64_t completed;
+  // Monotonic stamp for this event's current record. It is also the eviction
+  // key, and the token that ties an in-flight query to the record it asked
+  // about: a re-record while that query travels bumps the stamp, so the answer
+  // no longer matches and cannot be cached against the newer record.
+  uint64_t record;
+  bool complete;
 };
 
 struct lupine_event_table {
   std::mutex mutex;
   lupine_event_slot slots[kLupineEventQueryBatch] = {};
   std::atomic<uint64_t> record_seq{0};
-  std::atomic<uint64_t> dtoh_pending{0};
+  // Held by every deferred device-to-host copy the server has not handed back
+  // yet. While it is nonzero every cached completion is unusable, because a
+  // query answered locally is a query that never collects those copies. It
+  // counts rather than flags: a response carries only the copies for the
+  // stream it synchronized, so "some arrived" never means "none are left".
+  std::atomic<uint64_t> stale_semaphore{0};
 };
 
 typedef conn_t *(*lupine_event_conn_resolver)(CUevent event);
 
-void lupine_event_note_recorded(lupine_event_table *table, CUevent event);
-void lupine_event_note_destroyed(lupine_event_table *table, CUevent event);
-bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
-                               uint64_t *recorded);
-uint32_t lupine_event_collect_query_prefetch(
-    lupine_event_table *table, CUevent exclude, conn_t *conn,
-    lupine_event_conn_resolver resolver, CUevent *events, uint64_t *recorded);
-void lupine_event_note_query_results(lupine_event_table *table,
-                                     const CUevent *events,
-                                     const uint64_t *recorded,
-                                     const CUresult *results, uint32_t count);
-void lupine_event_note_async_dtoh(lupine_event_table *table);
-void lupine_event_note_dtoh_drained(lupine_event_table *table, uint64_t count);
+// A fresh record voids the cached completion, and starts tracking the event if
+// it was not tracked before.
+void lupine_event_invalidate_completion(lupine_event_table *table,
+                                        CUevent event);
+void lupine_event_invalidate_completion(CUevent event);
 
-void lupine_note_event_recorded(CUevent event);
-void lupine_note_event_destroyed(CUevent event);
+// Drops the event, so a handle the driver reuses cannot inherit its answer.
+void lupine_event_forget(lupine_event_table *table, CUevent event);
+void lupine_event_forget(CUevent event);
+
+// True when the query has to reach the server. Writes the record stamp to hand
+// back to lupine_event_cache_completions, or zero if the event is not tracked.
+bool lupine_event_query_needed(lupine_event_table *table, CUevent event,
+                               uint64_t *record);
+bool lupine_event_query_needed(CUevent event, uint64_t *record);
+
+// Fills events/records with other outstanding events on the same connection,
+// to warm the cache alongside a query that is already going out.
+uint32_t lupine_event_collect_query_batch(lupine_event_table *table,
+                                          CUevent exclude, conn_t *conn,
+                                          lupine_event_conn_resolver resolver,
+                                          CUevent *events, uint64_t *records);
+uint32_t lupine_event_collect_query_batch(CUevent exclude, conn_t *conn,
+                                          CUevent *events, uint64_t *records);
+
+// Caches the successful answers whose record stamp still matches.
+void lupine_event_cache_completions(lupine_event_table *table,
+                                    const CUevent *events,
+                                    const uint64_t *records,
+                                    const CUresult *results, uint32_t count);
+void lupine_event_cache_completions(const CUevent *events,
+                                    const uint64_t *records,
+                                    const CUresult *results, uint32_t count);
+
+// delta is +1 when a copy is deferred and -N when N of them arrive.
+void lupine_event_stale_semaphore_add(lupine_event_table *table, int64_t delta);
+void lupine_event_stale_semaphore_add(int64_t delta);
+
+// Held shared across a query and exclusively across a destroy, so an event
+// cannot be destroyed out from under a query in flight.
 std::shared_mutex &lupine_event_lifecycle_mutex();
-bool lupine_event_query_needed(CUevent event, uint64_t *recorded);
-uint32_t lupine_collect_event_query_prefetch(CUevent exclude, conn_t *conn,
-                                             CUevent *events,
-                                             uint64_t *recorded);
-void lupine_note_event_query_results(const CUevent *events,
-                                     const uint64_t *recorded,
-                                     const CUresult *results, uint32_t count);
-void lupine_note_async_dtoh_copy();
-void lupine_note_async_dtoh_drained(uint64_t count);

--- a/events_test.cpp
+++ b/events_test.cpp
@@ -37,20 +37,20 @@ void complete(lupine_event_table *table, const CUevent *events,
   for (uint32_t i = 0; i < count; ++i) {
     results[i] = CUDA_SUCCESS;
   }
-  lupine_event_note_query_results(table, events, recorded, results, count);
+  lupine_event_cache_completions(table, events, recorded, results, count);
 }
 
 bool test_completed_event_answers_locally() {
   lupine_event_table table;
   CUevent event = fake_event(0);
   uint64_t recorded = 0;
-  lupine_event_note_recorded(&table, fake_event(0));
+  lupine_event_invalidate_completion(&table, fake_event(0));
   if (!lupine_event_query_needed(&table, event, &recorded) || recorded != 1) {
     std::cerr << "FAIL: first query did not require the recorded event\n";
     return false;
   }
   CUresult result = CUDA_SUCCESS;
-  lupine_event_note_query_results(&table, &event, &recorded, &result, 1);
+  lupine_event_cache_completions(&table, &event, &recorded, &result, 1);
   if (lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: completed event did not answer locally\n";
     return false;
@@ -62,21 +62,21 @@ bool test_rerecord_forces_fresh_query() {
   lupine_event_table table;
   CUevent event = fake_event(0);
   uint64_t recorded = 0;
-  lupine_event_note_recorded(&table, event);
+  lupine_event_invalidate_completion(&table, event);
   if (!lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: first record did not require a query\n";
     return false;
   }
   CUresult result = CUDA_SUCCESS;
-  lupine_event_note_query_results(&table, &event, &recorded, &result, 1);
-  lupine_event_note_recorded(&table, event);
+  lupine_event_cache_completions(&table, &event, &recorded, &result, 1);
+  lupine_event_invalidate_completion(&table, event);
   if (!lupine_event_query_needed(&table, event, &recorded) || recorded != 2) {
     std::cerr << "FAIL: re-recorded event did not raise the record sequence\n";
     return false;
   }
   // A result carrying the stale sequence must not mark the new record done.
   uint64_t stale = 1;
-  lupine_event_note_query_results(&table, &event, &stale, &result, 1);
+  lupine_event_cache_completions(&table, &event, &stale, &result, 1);
   if (!lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: stale completion answered a newer record locally\n";
     return false;
@@ -89,7 +89,7 @@ bool test_eviction_is_oldest_recorded() {
   CUevent events[kLupineEventQueryBatch];
   uint64_t recorded[kLupineEventQueryBatch];
   for (uintptr_t i = 0; i < kLupineEventQueryBatch + 1; ++i) {
-    lupine_event_note_recorded(&table, fake_event(i));
+    lupine_event_invalidate_completion(&table, fake_event(i));
   }
   uint64_t newest_recorded = 0;
   if (!lupine_event_query_needed(&table, fake_event(kLupineEventQueryBatch),
@@ -98,7 +98,7 @@ bool test_eviction_is_oldest_recorded() {
     std::cerr << "FAIL: newest event lost its slot\n";
     return false;
   }
-  uint32_t count = lupine_event_collect_query_prefetch(
+  uint32_t count = lupine_event_collect_query_batch(
       &table, fake_event(kLupineEventQueryBatch), kConnA, resolve_all_to_a,
       events, recorded);
   if (batch_contains(events, count, fake_event(0))) {
@@ -119,10 +119,10 @@ bool test_prefetch_batch_excludes_and_filters() {
   CUevent events[kLupineEventQueryBatch];
   uint64_t recorded[kLupineEventQueryBatch];
   for (uintptr_t i = 0; i < kLupineEventQueryBatch; ++i) {
-    lupine_event_note_recorded(&table, fake_event(i));
+    lupine_event_invalidate_completion(&table, fake_event(i));
   }
   CUevent untracked = fake_event(99);
-  uint32_t count = lupine_event_collect_query_prefetch(
+  uint32_t count = lupine_event_collect_query_batch(
       &table, fake_event(0), kConnA, resolve_all_to_a, events, recorded);
   if (count != kLupineEventQueryBatch - 1 ||
       batch_contains(events, count, fake_event(0))) {
@@ -133,8 +133,8 @@ bool test_prefetch_batch_excludes_and_filters() {
   CUevent done[1] = {fake_event(3)};
   uint64_t done_recorded[1] = {4};
   complete(&table, done, done_recorded, 1);
-  count = lupine_event_collect_query_prefetch(
-      &table, untracked, kConnA, resolve_last_to_b, events, recorded);
+  count = lupine_event_collect_query_batch(&table, untracked, kConnA,
+                                           resolve_last_to_b, events, recorded);
   if (count != kLupineEventQueryBatch - 2) {
     std::cerr << "FAIL: prefetch did not filter completed and foreign events\n";
     return false;
@@ -152,9 +152,9 @@ bool test_query_results_cache_only_successes() {
   CUevent events[2] = {fake_event(0), fake_event(1)};
   uint64_t recorded[2] = {1, 2};
   CUresult results[2] = {CUDA_SUCCESS, CUDA_ERROR_NOT_READY};
-  lupine_event_note_recorded(&table, events[0]);
-  lupine_event_note_recorded(&table, events[1]);
-  lupine_event_note_query_results(&table, events, recorded, results, 2);
+  lupine_event_invalidate_completion(&table, events[0]);
+  lupine_event_invalidate_completion(&table, events[1]);
+  lupine_event_cache_completions(&table, events, recorded, results, 2);
 
   uint64_t query_recorded = 0;
   if (lupine_event_query_needed(&table, events[0], &query_recorded)) {
@@ -174,11 +174,11 @@ bool test_destroyed_event_is_removed_from_prefetch() {
   uint64_t recorded[kLupineEventQueryBatch];
   CUevent primary = fake_event(0);
   CUevent destroyed = fake_event(1);
-  lupine_event_note_recorded(&table, primary);
-  lupine_event_note_recorded(&table, destroyed);
-  lupine_event_note_destroyed(&table, destroyed);
+  lupine_event_invalidate_completion(&table, primary);
+  lupine_event_invalidate_completion(&table, destroyed);
+  lupine_event_forget(&table, destroyed);
 
-  uint32_t count = lupine_event_collect_query_prefetch(
+  uint32_t count = lupine_event_collect_query_batch(
       &table, nullptr, kConnA, resolve_all_to_a, events, recorded);
   if (count != 1 || events[0] != primary ||
       batch_contains(events, count, destroyed)) {
@@ -192,19 +192,19 @@ bool test_pending_dtoh_suppresses_local_answer() {
   lupine_event_table table;
   CUevent event = fake_event(0);
   uint64_t recorded = 0;
-  lupine_event_note_recorded(&table, event);
+  lupine_event_invalidate_completion(&table, event);
   if (!lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: first record did not require a query\n";
     return false;
   }
   CUresult result = CUDA_SUCCESS;
-  lupine_event_note_query_results(&table, &event, &recorded, &result, 1);
-  lupine_event_note_async_dtoh(&table);
+  lupine_event_cache_completions(&table, &event, &recorded, &result, 1);
+  lupine_event_stale_semaphore_add(&table, 1);
   if (!lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: pending async copy was answered locally\n";
     return false;
   }
-  lupine_event_note_dtoh_drained(&table, 1);
+  lupine_event_stale_semaphore_add(&table, -1);
   if (lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: drained copy still forced a round trip\n";
     return false;
@@ -212,25 +212,28 @@ bool test_pending_dtoh_suppresses_local_answer() {
   return true;
 }
 
+// The reason the state is a total and not a flag: a response delivers only the
+// copies for the stream it synchronized, so clearing on any delivery would
+// hand back a stale local answer while another stream's copy is still owed.
 bool test_partially_drained_dtoh_stays_pending() {
   lupine_event_table table;
   CUevent event = fake_event(0);
   uint64_t recorded = 0;
   CUresult result = CUDA_SUCCESS;
-  lupine_event_note_recorded(&table, event);
+  lupine_event_invalidate_completion(&table, event);
   if (!lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: first record did not require a query\n";
     return false;
   }
-  lupine_event_note_query_results(&table, &event, &recorded, &result, 1);
-  lupine_event_note_async_dtoh(&table);
-  lupine_event_note_async_dtoh(&table);
-  lupine_event_note_dtoh_drained(&table, 1);
+  lupine_event_cache_completions(&table, &event, &recorded, &result, 1);
+  lupine_event_stale_semaphore_add(&table, 1);
+  lupine_event_stale_semaphore_add(&table, 1);
+  lupine_event_stale_semaphore_add(&table, -1);
   if (!lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: partially drained copies were treated as complete\n";
     return false;
   }
-  lupine_event_note_dtoh_drained(&table, 1);
+  lupine_event_stale_semaphore_add(&table, -1);
   if (lupine_event_query_needed(&table, event, &recorded)) {
     std::cerr << "FAIL: fully drained copies still forced a round trip\n";
     return false;

--- a/routing.cpp
+++ b/routing.cpp
@@ -596,7 +596,7 @@ extern "C" void lupine_forget_event_owner(CUevent event) {
     std::lock_guard<std::mutex> lock(lupine_routing_mutex());
     lupine_owners<CUevent>().erase(event);
   }
-  lupine_note_event_destroyed(event);
+  lupine_event_forget(event);
 }
 
 template <typename Handle>


### PR DESCRIPTION
Stacked on #631.

`events.h` exported 13 names to maintain two facts. It now exports 6.

The two facts, which the header now states up front:

- per event, the stamp of its current record and whether that record is known complete
- process-wide, how many deferred device-to-host copies the server still owes

Everything else was mechanism. Each operation existed twice under two different names — `lupine_event_note_recorded` beside `lupine_note_event_recorded` — purely so tests could drive a bare table. Those pairs are now overloads of one name, the way `lupine_event_query_needed` already was.

Renamed for what each does rather than that it is being noted:

| was | is |
| --- | --- |
| `lupine_event_note_recorded` | `lupine_event_invalidate_completion` |
| `lupine_event_note_destroyed` | `lupine_event_forget` |
| `lupine_event_note_query_results` | `lupine_event_cache_completions` |
| `lupine_event_collect_query_prefetch` | `lupine_event_collect_query_batch` |
| `lupine_event_note_async_dtoh` + `lupine_event_note_dtoh_drained` | `lupine_event_stale_semaphore_add` |

The slot loses a field: `recorded` and `completed` were two sequence numbers whose equality encoded one bit, so `completed` becomes a `bool complete`. The remaining stamp still earns its place as three things at once — eviction key, and the token that ties an in-flight query to the record it asked about, so a re-record mid-flight cannot be marked complete. `test_rerecord_forces_fresh_query` covers that.

The stale semaphore counts rather than flags, because a response carries only the deferred copies for the stream it synchronized:

1. thread A defers a copy on stream B
2. thread B synchronizes stream A, whose response delivers stream A's copies only
3. a flag cleared on delivery now reads "fresh", so a query for an already-complete event is answered locally and never collects stream B's copy
4. the caller reads its host buffer and sees stale bytes

`test_partially_drained_dtoh_stays_pending` is that case and fails against a flag; it now carries a comment saying so. Subtracting only what was delivered is also what makes the concurrent case safe, where clearing a flag races a copy issued between the server building the response and the client reading it.

Code lines are flat (`events.h` 47 to 46, `events.cpp` 130 to 129); the file grew in comments, which now carry the two invariants and the reason the record stamp exists.

Unit tests 9/9, custom driver-API tests 30/30 against inferable-node-008.