### PR TITLE
test: reenable cuda-python memcpy3d coverage

### DIFF
--- a/test/cuda-python/known_failures.txt
+++ b/test/cuda-python/known_failures.txt
@@ -10,11 +10,6 @@ test_cudart.py::test_cudart_cudaGraphNodeGetDependencies_edgeData_outlives_call
 # #579 cuGraphAddNode
 test_cuda.py::test_graph_poly
 
-# #580 cuMemcpy3DAsync / cuMemcpy3DPeer / cuMemcpy3DPeerAsync
-test_cudart.py::test_cudart_cudaMemcpy3DAsync
-test_cudart.py::test_cudart_cudaMemcpy3DPeer
-test_cudart.py::test_cudart_cudaMemcpy3DPeerAsync
-
 # #581 cuMemRangeGetAttribute
 test_cuda.py::test_cuda_mem_range_attr
 


### PR DESCRIPTION
## Summary
- remove the stale cuda-python deselections for cuMemcpy3DAsync, cuMemcpy3DPeer, and cuMemcpy3DPeerAsync
- re-enable coverage after the implementations landed in #553

Closes #580

## Testing
- cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
- cmake --build build --parallel --target lupine_cuda_client lupine_driver_server
- CUDA 13.3.1 cuda-python test_cudart.py through the shim: 53 passed, 4 unrelated tests deselected