### PR TITLE
Support CUDA memory range attribute queries

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -3440,10 +3440,9 @@ CUresult cuMemAdvise(CUdeviceptr devPtr, size_t count, CUmem_advise advice,
 CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count, CUmem_advise advice,
                         CUmemLocation location);
 /**
- * @disabled - manual client and server marshal the variable-sized result
- * @server CUDA
- * @param data SEND_RECV
+ * @routingkey DEVICEPTR devPtr
  * @param dataSize SEND_ONLY
+ * @param data RECV_ONLY LENGTH:dataSize
  * @param attribute SEND_ONLY
  * @param devPtr SEND_ONLY
  * @param count SEND_ONLY

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -3440,6 +3440,8 @@ CUresult cuMemAdvise(CUdeviceptr devPtr, size_t count, CUmem_advise advice,
 CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count, CUmem_advise advice,
                         CUmemLocation location);
 /**
+ * @disabled - manual client and server marshal the variable-sized result
+ * @server CUDA
  * @param data SEND_RECV
  * @param dataSize SEND_ONLY
  * @param attribute SEND_ONLY
@@ -3450,6 +3452,8 @@ CUresult cuMemRangeGetAttribute(void *data, size_t dataSize,
                                 CUmem_range_attribute attribute,
                                 CUdeviceptr devPtr, size_t count);
 /**
+ * @disabled - manual client and server marshal each variable-sized result
+ * @server CUDA
  * @param data SEND_RECV
  * @param dataSizes SEND_RECV
  * @param attributes SEND_RECV

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -2807,38 +2807,6 @@ CUresult cuMemPoolImportPointer(CUdeviceptr *ptr_out, CUmemoryPool pool,
   return return_value;
 }
 
-CUresult cuMemRangeGetAttributes(void **data, size_t *dataSizes,
-                                 CUmem_range_attribute *attributes,
-                                 size_t numAttributes, CUdeviceptr devPtr,
-                                 size_t count) {
-  lupine_route route = lupine_route_for_deviceptr(devPtr);
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(void **, size_t *, CUmem_range_attribute *,
-                                 size_t, CUdeviceptr, size_t);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemRangeGetAttributes", &return_value, data, dataSizes,
-          attributes, numAttributes, devPtr, count)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
-      rpc_write(conn, data, sizeof(void *)) < 0 ||
-      rpc_write(conn, dataSizes, sizeof(size_t)) < 0 ||
-      rpc_write(conn, attributes, sizeof(CUmem_range_attribute)) < 0 ||
-      rpc_write(conn, &numAttributes, sizeof(size_t)) < 0 ||
-      rpc_write(conn, &devPtr, sizeof(CUdeviceptr)) < 0 ||
-      rpc_write(conn, &count, sizeof(size_t)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, data, sizeof(void *)) < 0 ||
-      rpc_read(conn, dataSizes, sizeof(size_t)) < 0 ||
-      rpc_read(conn, attributes, sizeof(CUmem_range_attribute)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
   lupine_route route = lupine_route_for_current_context();
   CUresult return_value;
@@ -7824,7 +7792,6 @@ std::unordered_map<std::string, void *> functionMap = {
 #if CUDA_VERSION >= 12020
     {"cuMemAdvise_v2", (void *)cuMemAdvise_v2},
 #endif
-    {"cuMemRangeGetAttributes", (void *)cuMemRangeGetAttributes},
     {"cuPointerGetAttributes", (void *)cuPointerGetAttributes},
     {"cuStreamCreate", (void *)cuStreamCreate},
     {"cuStreamCreateWithPriority", (void *)cuStreamCreateWithPriority},

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -2807,6 +2807,33 @@ CUresult cuMemPoolImportPointer(CUdeviceptr *ptr_out, CUmemoryPool pool,
   return return_value;
 }
 
+CUresult cuMemRangeGetAttribute(void *data, size_t dataSize,
+                                CUmem_range_attribute attribute,
+                                CUdeviceptr devPtr, size_t count) {
+  lupine_route route = lupine_route_for_deviceptr(devPtr);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(void *, size_t, CUmem_range_attribute, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemRangeGetAttribute", &return_value, data, dataSize,
+          attribute, devPtr, count)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemRangeGetAttribute) < 0 ||
+      rpc_write(conn, &dataSize, sizeof(size_t)) < 0 ||
+      rpc_write(conn, &attribute, sizeof(CUmem_range_attribute)) < 0 ||
+      rpc_write(conn, &devPtr, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &count, sizeof(size_t)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      (dataSize != 0 && rpc_read(conn, data, dataSize) < 0) ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
 CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
   lupine_route route = lupine_route_for_current_context();
   CUresult return_value;
@@ -7792,6 +7819,7 @@ std::unordered_map<std::string, void *> functionMap = {
 #if CUDA_VERSION >= 12020
     {"cuMemAdvise_v2", (void *)cuMemAdvise_v2},
 #endif
+    {"cuMemRangeGetAttribute", (void *)cuMemRangeGetAttribute},
     {"cuPointerGetAttributes", (void *)cuPointerGetAttributes},
     {"cuStreamCreate", (void *)cuStreamCreate},
     {"cuStreamCreateWithPriority", (void *)cuStreamCreateWithPriority},

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -3392,6 +3392,42 @@ ERROR_0:
 
 #endif
 
+int handle_cuMemRangeGetAttribute(conn_t *conn) {
+  size_t dataSize;
+  void *data = nullptr;
+  CUmem_range_attribute attribute;
+  CUdeviceptr devPtr;
+  size_t count;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &dataSize, sizeof(size_t)) < 0 || false)
+    goto ERROR_0;
+  data = (void *)malloc(dataSize);
+  if ((dataSize != 0 && data == nullptr) ||
+      rpc_read(conn, &attribute, sizeof(CUmem_range_attribute)) < 0 ||
+      rpc_read(conn, &devPtr, sizeof(CUdeviceptr)) < 0 ||
+      rpc_read(conn, &count, sizeof(size_t)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuMemRangeGetAttribute(
+      (dataSize == 0 ? nullptr : data), dataSize, attribute, devPtr, count);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, data, dataSize) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  free((void *)data);
+  return 0;
+ERROR_0:
+  free((void *)data);
+  return -1;
+}
+
 int handle_cuStreamCreate(conn_t *conn) {
   CUstream phStream;
   unsigned int Flags;

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -3392,42 +3392,6 @@ ERROR_0:
 
 #endif
 
-int handle_cuMemRangeGetAttributes(conn_t *conn) {
-  void *data;
-  size_t dataSizes;
-  CUmem_range_attribute attributes;
-  size_t numAttributes;
-  CUdeviceptr devPtr;
-  size_t count;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &data, sizeof(void *)) < 0 ||
-      rpc_read(conn, &dataSizes, sizeof(size_t)) < 0 ||
-      rpc_read(conn, &attributes, sizeof(CUmem_range_attribute)) < 0 ||
-      rpc_read(conn, &numAttributes, sizeof(size_t)) < 0 ||
-      rpc_read(conn, &devPtr, sizeof(CUdeviceptr)) < 0 ||
-      rpc_read(conn, &count, sizeof(size_t)) < 0 || false)
-    goto ERROR_0;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_0;
-  lupine_intercept_result = cuMemRangeGetAttributes(
-      &data, &dataSizes, &attributes, numAttributes, devPtr, count);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &data, sizeof(void *)) < 0 ||
-      rpc_write(conn, &dataSizes, sizeof(size_t)) < 0 ||
-      rpc_write(conn, &attributes, sizeof(CUmem_range_attribute)) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
-
-  return 0;
-ERROR_0:
-  return -1;
-}
-
 int handle_cuStreamCreate(conn_t *conn) {
   CUstream phStream;
   unsigned int Flags;

--- a/codegen/gen_rpc_ids.h
+++ b/codegen/gen_rpc_ids.h
@@ -172,6 +172,7 @@
 #define RPC_cuMemPoolImportPointer 1026713940
 #define RPC_cuMemPrefetchAsync_v2 199313298
 #define RPC_cuMemAdvise_v2 1952016083
+#define RPC_cuMemRangeGetAttribute 1819983801
 #define RPC_cuMemRangeGetAttributes 694140572
 #define RPC_cuPointerSetAttribute 749063765
 #define RPC_cuPointerGetAttributes 1948058610
@@ -397,7 +398,6 @@
 #define RPC_cuMemPoolGetAttribute 830843819
 #define RPC_cuMemPoolSetAttribute 1050377512
 #define RPC_cuMemPrefetchAsync 596440383
-#define RPC_cuMemRangeGetAttribute 1819983801
 #define RPC_cuMemRetainAllocationHandle 1903553150
 #define RPC_cuMemcpyAtoHAsync_v2 1591028942
 #define RPC_cuParamSetv 1622049063

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -52,7 +52,6 @@
   HANDLER(RPC_cuMemPoolExportToShareableHandle, handle_cuMemPoolExportToShareableHandle, rpc_backend::cuda) \
   HANDLER(RPC_cuMemPoolImportFromShareableHandle, handle_cuMemPoolImportFromShareableHandle, rpc_backend::cuda) \
   HANDLER(RPC_cuPointerGetAttribute, handle_cuPointerGetAttribute, rpc_backend::cuda) \
-  HANDLER(RPC_cuMemRangeGetAttribute, handle_cuMemRangeGetAttribute, rpc_backend::cuda) \
   HANDLER(RPC_cuMemRangeGetAttributes, handle_cuMemRangeGetAttributes, rpc_backend::cuda) \
   HANDLER(RPC_cuPointerSetAttribute, handle_cuPointerSetAttribute, rpc_backend::cuda) \
   HANDLER(RPC_cuPointerGetAttributes, handle_cuPointerGetAttributes, rpc_backend::cuda) \
@@ -226,6 +225,7 @@
   HANDLER(RPC_cuMemAllocFromPoolAsync, handle_cuMemAllocFromPoolAsync, rpc_backend::cuda) \
   HANDLER(RPC_cuMemPoolExportPointer, handle_cuMemPoolExportPointer, rpc_backend::cuda) \
   HANDLER(RPC_cuMemPoolImportPointer, handle_cuMemPoolImportPointer, rpc_backend::cuda) \
+  HANDLER(RPC_cuMemRangeGetAttribute, handle_cuMemRangeGetAttribute, rpc_backend::cuda) \
   HANDLER(RPC_cuStreamCreate, handle_cuStreamCreate, rpc_backend::cuda) \
   HANDLER(RPC_cuStreamCreateWithPriority, handle_cuStreamCreateWithPriority, rpc_backend::cuda) \
   HANDLER(RPC_cuStreamGetPriority, handle_cuStreamGetPriority, rpc_backend::cuda) \

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -52,6 +52,8 @@
   HANDLER(RPC_cuMemPoolExportToShareableHandle, handle_cuMemPoolExportToShareableHandle, rpc_backend::cuda) \
   HANDLER(RPC_cuMemPoolImportFromShareableHandle, handle_cuMemPoolImportFromShareableHandle, rpc_backend::cuda) \
   HANDLER(RPC_cuPointerGetAttribute, handle_cuPointerGetAttribute, rpc_backend::cuda) \
+  HANDLER(RPC_cuMemRangeGetAttribute, handle_cuMemRangeGetAttribute, rpc_backend::cuda) \
+  HANDLER(RPC_cuMemRangeGetAttributes, handle_cuMemRangeGetAttributes, rpc_backend::cuda) \
   HANDLER(RPC_cuPointerSetAttribute, handle_cuPointerSetAttribute, rpc_backend::cuda) \
   HANDLER(RPC_cuPointerGetAttributes, handle_cuPointerGetAttributes, rpc_backend::cuda) \
   HANDLER(RPC_cuStreamWaitEvent, handle_cuStreamWaitEvent, rpc_backend::cuda) \
@@ -224,7 +226,6 @@
   HANDLER(RPC_cuMemAllocFromPoolAsync, handle_cuMemAllocFromPoolAsync, rpc_backend::cuda) \
   HANDLER(RPC_cuMemPoolExportPointer, handle_cuMemPoolExportPointer, rpc_backend::cuda) \
   HANDLER(RPC_cuMemPoolImportPointer, handle_cuMemPoolImportPointer, rpc_backend::cuda) \
-  HANDLER(RPC_cuMemRangeGetAttributes, handle_cuMemRangeGetAttributes, rpc_backend::cuda) \
   HANDLER(RPC_cuStreamCreate, handle_cuStreamCreate, rpc_backend::cuda) \
   HANDLER(RPC_cuStreamCreateWithPriority, handle_cuStreamCreateWithPriority, rpc_backend::cuda) \
   HANDLER(RPC_cuStreamGetPriority, handle_cuStreamGetPriority, rpc_backend::cuda) \

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -3961,41 +3961,6 @@ extern "C" CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count,
 }
 #endif
 
-extern "C" CUresult cuMemRangeGetAttribute(
-    void *data, size_t dataSize, CUmem_range_attribute attribute,
-    CUdeviceptr devPtr, size_t count) {
-  if (data == nullptr ||
-      !lupine_mem_range_attribute_size_is_valid(attribute, dataSize)) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  lupine_route route = lupine_route_for_deviceptr(devPtr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(void *, size_t, CUmem_range_attribute,
-                                   CUdeviceptr, size_t);
-    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemRangeGetAttribute");
-    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
-                           : real(data, dataSize, attribute, devPtr, count);
-  }
-
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemRangeGetAttribute) < 0 ||
-      rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
-      rpc_write(conn, &devPtr, sizeof(devPtr)) < 0 ||
-      rpc_write(conn, &count, sizeof(count)) < 0 ||
-      rpc_write(conn, &dataSize, sizeof(dataSize)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &result, sizeof(result)) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (result == CUDA_SUCCESS && rpc_read(conn, data, dataSize) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return rpc_read_end(conn) < 0 ? CUDA_ERROR_DEVICE_UNAVAILABLE : result;
-}
-
 extern "C" CUresult cuMemRangeGetAttributes(
     void **data, size_t *dataSizes, CUmem_range_attribute *attributes,
     size_t numAttributes, CUdeviceptr devPtr, size_t count) {
@@ -9856,7 +9821,6 @@ lupine_manual_function_map() {
       {"cuMemAdvise", (void *)cuMemAdvise},
       {"cuMemPrefetchAsync", (void *)cuMemPrefetchAsync},
       {"cuMemPrefetchAsync_ptsz", (void *)cuMemPrefetchAsync_ptsz},
-      {"cuMemRangeGetAttribute", (void *)cuMemRangeGetAttribute},
       {"cuMemRangeGetAttributes", (void *)cuMemRangeGetAttributes},
       {"cuArrayCreate", (void *)cuArrayCreate_v2},
       {"cuArrayCreate_v2", (void *)cuArrayCreate_v2},

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -3961,6 +3961,93 @@ extern "C" CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count,
 }
 #endif
 
+extern "C" CUresult cuMemRangeGetAttribute(
+    void *data, size_t dataSize, CUmem_range_attribute attribute,
+    CUdeviceptr devPtr, size_t count) {
+  if (data == nullptr ||
+      !lupine_mem_range_attribute_size_is_valid(attribute, dataSize)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  lupine_route route = lupine_route_for_deviceptr(devPtr);
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(void *, size_t, CUmem_range_attribute,
+                                   CUdeviceptr, size_t);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemRangeGetAttribute");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(data, dataSize, attribute, devPtr, count);
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemRangeGetAttribute) < 0 ||
+      rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
+      rpc_write(conn, &devPtr, sizeof(devPtr)) < 0 ||
+      rpc_write(conn, &count, sizeof(count)) < 0 ||
+      rpc_write(conn, &dataSize, sizeof(dataSize)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (result == CUDA_SUCCESS && rpc_read(conn, data, dataSize) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return rpc_read_end(conn) < 0 ? CUDA_ERROR_DEVICE_UNAVAILABLE : result;
+}
+
+extern "C" CUresult cuMemRangeGetAttributes(
+    void **data, size_t *dataSizes, CUmem_range_attribute *attributes,
+    size_t numAttributes, CUdeviceptr devPtr, size_t count) {
+  if (numAttributes != 0 &&
+      (data == nullptr || dataSizes == nullptr || attributes == nullptr ||
+       numAttributes > SIZE_MAX / sizeof(dataSizes[0]) ||
+       numAttributes > SIZE_MAX / sizeof(attributes[0]))) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  for (size_t i = 0; i < numAttributes; ++i) {
+    if (data[i] == nullptr ||
+        !lupine_mem_range_attribute_size_is_valid(attributes[i],
+                                                   dataSizes[i])) {
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+  }
+
+  lupine_route route = lupine_route_for_deviceptr(devPtr);
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(void **, size_t *,
+                                   CUmem_range_attribute *, size_t,
+                                   CUdeviceptr, size_t);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemRangeGetAttributes");
+    return real == nullptr
+               ? CUDA_ERROR_DEVICE_UNAVAILABLE
+               : real(data, dataSizes, attributes, numAttributes, devPtr,
+                      count);
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
+      rpc_write(conn, &numAttributes, sizeof(numAttributes)) < 0 ||
+      rpc_write(conn, dataSizes, numAttributes * sizeof(dataSizes[0])) < 0 ||
+      rpc_write(conn, attributes, numAttributes * sizeof(attributes[0])) < 0 ||
+      rpc_write(conn, &devPtr, sizeof(devPtr)) < 0 ||
+      rpc_write(conn, &count, sizeof(count)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (result == CUDA_SUCCESS) {
+    for (size_t i = 0; i < numAttributes; ++i) {
+      if (rpc_read(conn, data[i], dataSizes[i]) < 0) {
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+    }
+  }
+  return rpc_read_end(conn) < 0 ? CUDA_ERROR_DEVICE_UNAVAILABLE : result;
+}
+
 extern "C" CUresult cuCtxGetStreamPriorityRange(int *leastPriority,
                                                 int *greatestPriority) {
   lupine_route route = lupine_route_for_default();
@@ -9097,7 +9184,6 @@ LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemcpyDtoHAsync)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemcpy2DUnaligned)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemcpy2DAsync)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemcpy3D)
-LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemRangeGetAttribute)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuGetErrorString)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuGetErrorName)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuGraphInstantiate)
@@ -9207,7 +9293,6 @@ static void *lupine_get_unsupported_stub(const char *symbol) {
       LUPINE_STUB_ENTRY(cuMemcpy2DUnaligned),
       LUPINE_STUB_ENTRY(cuMemcpy2DAsync),
       LUPINE_STUB_ENTRY(cuMemcpy3D),
-      LUPINE_STUB_ENTRY(cuMemRangeGetAttribute),
       LUPINE_STUB_ENTRY(cuGetErrorString),
       LUPINE_STUB_ENTRY(cuGetErrorName),
       LUPINE_STUB_ENTRY(cuGraphInstantiate),
@@ -9771,6 +9856,8 @@ lupine_manual_function_map() {
       {"cuMemAdvise", (void *)cuMemAdvise},
       {"cuMemPrefetchAsync", (void *)cuMemPrefetchAsync},
       {"cuMemPrefetchAsync_ptsz", (void *)cuMemPrefetchAsync_ptsz},
+      {"cuMemRangeGetAttribute", (void *)cuMemRangeGetAttribute},
+      {"cuMemRangeGetAttributes", (void *)cuMemRangeGetAttributes},
       {"cuArrayCreate", (void *)cuArrayCreate_v2},
       {"cuArrayCreate_v2", (void *)cuArrayCreate_v2},
       {"cuArray3DCreate", (void *)cuArray3DCreate_v2},

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -3971,9 +3971,7 @@ extern "C" CUresult cuMemRangeGetAttributes(
     return CUDA_ERROR_INVALID_VALUE;
   }
   for (size_t i = 0; i < numAttributes; ++i) {
-    if (data[i] == nullptr ||
-        !lupine_mem_range_attribute_size_is_valid(attributes[i],
-                                                   dataSizes[i])) {
+    if (dataSizes[i] != 0 && data[i] == nullptr) {
       return CUDA_ERROR_INVALID_VALUE;
     }
   }

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -3964,18 +3964,6 @@ extern "C" CUresult cuMemAdvise_v2(CUdeviceptr devPtr, size_t count,
 extern "C" CUresult cuMemRangeGetAttributes(
     void **data, size_t *dataSizes, CUmem_range_attribute *attributes,
     size_t numAttributes, CUdeviceptr devPtr, size_t count) {
-  if (numAttributes != 0 &&
-      (data == nullptr || dataSizes == nullptr || attributes == nullptr ||
-       numAttributes > SIZE_MAX / sizeof(dataSizes[0]) ||
-       numAttributes > SIZE_MAX / sizeof(attributes[0]))) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-  for (size_t i = 0; i < numAttributes; ++i) {
-    if (dataSizes[i] != 0 && data[i] == nullptr) {
-      return CUDA_ERROR_INVALID_VALUE;
-    }
-  }
-
   lupine_route route = lupine_route_for_deviceptr(devPtr);
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(void **, size_t *,

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -1717,9 +1717,7 @@ int handle_cuMemPoolImportFromShareableHandle(conn_t *conn) {
 
 int handle_cuMemRangeGetAttributes(conn_t *conn) {
   size_t num_attributes = 0;
-  if (rpc_read(conn, &num_attributes, sizeof(num_attributes)) < 0 ||
-      num_attributes > SIZE_MAX / sizeof(size_t) ||
-      num_attributes > SIZE_MAX / sizeof(CUmem_range_attribute)) {
+  if (rpc_read(conn, &num_attributes, sizeof(num_attributes)) < 0) {
     return -1;
   }
 
@@ -1727,73 +1725,53 @@ int handle_cuMemRangeGetAttributes(conn_t *conn) {
       std::malloc(num_attributes * sizeof(*data_sizes)));
   CUmem_range_attribute *attributes = static_cast<CUmem_range_attribute *>(
       std::malloc(num_attributes * sizeof(*attributes)));
-  if (num_attributes != 0 && (data_sizes == nullptr || attributes == nullptr)) {
-    std::free(data_sizes);
-    std::free(attributes);
-    return -1;
-  }
-
   CUdeviceptr dev_ptr = 0;
   size_t count = 0;
-  if ((num_attributes != 0 &&
-       rpc_read(conn, data_sizes, num_attributes * sizeof(*data_sizes)) < 0) ||
-      (num_attributes != 0 &&
-       rpc_read(conn, attributes, num_attributes * sizeof(*attributes)) < 0) ||
+  int status = -1;
+  int request_id;
+  void **data;
+  CUresult result;
+  if (rpc_read(conn, data_sizes, num_attributes * sizeof(*data_sizes)) < 0 ||
+      rpc_read(conn, attributes, num_attributes * sizeof(*attributes)) < 0 ||
       rpc_read(conn, &dev_ptr, sizeof(dev_ptr)) < 0 ||
       rpc_read(conn, &count, sizeof(count)) < 0) {
-    std::free(data_sizes);
-    std::free(attributes);
-    return -1;
+    goto CLEANUP_REQUEST;
   }
-  int request_id = rpc_read_end(conn);
+  request_id = rpc_read_end(conn);
   if (request_id < 0) {
-    std::free(data_sizes);
-    std::free(attributes);
-    return -1;
+    goto CLEANUP_REQUEST;
   }
 
-  CUresult result = CUDA_SUCCESS;
-  void **data =
-      static_cast<void **>(std::malloc(num_attributes * sizeof(*data)));
-  size_t allocated = 0;
-  if (num_attributes != 0 && data == nullptr) {
-    result = CUDA_ERROR_OUT_OF_MEMORY;
-  } else {
-    for (; allocated < num_attributes; ++allocated) {
-      data[allocated] = std::malloc(data_sizes[allocated]);
-      if (data_sizes[allocated] != 0 && data[allocated] == nullptr) {
-        result = CUDA_ERROR_OUT_OF_MEMORY;
-        break;
-      }
-    }
+  data = static_cast<void **>(std::malloc(num_attributes * sizeof(*data)));
+  for (size_t i = 0; i < num_attributes; ++i) {
+    data[i] = std::malloc(data_sizes[i]);
   }
 
-  if (result == CUDA_SUCCESS) {
-    result = cuMemRangeGetAttributes(data, data_sizes, attributes,
-                                     num_attributes, dev_ptr, count);
-  }
+  result = cuMemRangeGetAttributes(data, data_sizes, attributes, num_attributes,
+                                   dev_ptr, count);
 
-  int status = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0) {
-    status = -1;
+    goto CLEANUP_DATA;
   }
-  if (status == 0 && result == CUDA_SUCCESS) {
+  if (result == CUDA_SUCCESS) {
     for (size_t i = 0; i < num_attributes; ++i) {
       if (rpc_write(conn, data[i], data_sizes[i]) < 0) {
-        status = -1;
-        break;
+        goto CLEANUP_DATA;
       }
     }
   }
-  if (status == 0 && rpc_write_end(conn) < 0) {
-    status = -1;
+  if (rpc_write_end(conn) < 0) {
+    goto CLEANUP_DATA;
   }
+  status = 0;
 
-  for (size_t i = 0; i < allocated; ++i) {
+CLEANUP_DATA:
+  for (size_t i = 0; i < num_attributes; ++i) {
     std::free(data[i]);
   }
   std::free(data);
+CLEANUP_REQUEST:
   std::free(data_sizes);
   std::free(attributes);
   return status;

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -1715,44 +1715,6 @@ int handle_cuMemPoolImportFromShareableHandle(conn_t *conn) {
   return 0;
 }
 
-int handle_cuMemRangeGetAttribute(conn_t *conn) {
-  CUmem_range_attribute attribute;
-  CUdeviceptr dev_ptr = 0;
-  size_t count = 0;
-  size_t data_size = 0;
-  if (rpc_read(conn, &attribute, sizeof(attribute)) < 0 ||
-      rpc_read(conn, &dev_ptr, sizeof(dev_ptr)) < 0 ||
-      rpc_read(conn, &count, sizeof(count)) < 0 ||
-      rpc_read(conn, &data_size, sizeof(data_size)) < 0) {
-    return -1;
-  }
-  int request_id = rpc_read_end(conn);
-  if (request_id < 0) {
-    return -1;
-  }
-
-  CUresult result = CUDA_ERROR_INVALID_VALUE;
-  std::vector<unsigned char> value;
-  if (lupine_mem_range_attribute_size_is_valid(attribute, data_size)) {
-    try {
-      value.resize(data_size);
-      result = cuMemRangeGetAttribute(value.data(), data_size, attribute,
-                                      dev_ptr, count);
-    } catch (const std::bad_alloc &) {
-      result = CUDA_ERROR_OUT_OF_MEMORY;
-    }
-  }
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 ||
-      (result == CUDA_SUCCESS &&
-       rpc_write(conn, value.data(), value.size()) < 0) ||
-      rpc_write_end(conn) < 0) {
-    return -1;
-  }
-  return 0;
-}
-
 int handle_cuMemRangeGetAttributes(conn_t *conn) {
   size_t num_attributes = 0;
   if (rpc_read(conn, &num_attributes, sizeof(num_attributes)) < 0 ||

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -1723,68 +1723,80 @@ int handle_cuMemRangeGetAttributes(conn_t *conn) {
     return -1;
   }
 
-  std::vector<size_t> data_sizes;
-  std::vector<CUmem_range_attribute> attributes;
-  try {
-    data_sizes.resize(num_attributes);
-    attributes.resize(num_attributes);
-  } catch (const std::bad_alloc &) {
+  size_t *data_sizes = static_cast<size_t *>(
+      std::malloc(num_attributes * sizeof(*data_sizes)));
+  CUmem_range_attribute *attributes = static_cast<CUmem_range_attribute *>(
+      std::malloc(num_attributes * sizeof(*attributes)));
+  if (num_attributes != 0 && (data_sizes == nullptr || attributes == nullptr)) {
+    std::free(data_sizes);
+    std::free(attributes);
     return -1;
   }
+
   CUdeviceptr dev_ptr = 0;
   size_t count = 0;
   if ((num_attributes != 0 &&
-       rpc_read(conn, data_sizes.data(),
-                num_attributes * sizeof(data_sizes[0])) < 0) ||
+       rpc_read(conn, data_sizes, num_attributes * sizeof(*data_sizes)) < 0) ||
       (num_attributes != 0 &&
-       rpc_read(conn, attributes.data(),
-                num_attributes * sizeof(attributes[0])) < 0) ||
+       rpc_read(conn, attributes, num_attributes * sizeof(*attributes)) < 0) ||
       rpc_read(conn, &dev_ptr, sizeof(dev_ptr)) < 0 ||
       rpc_read(conn, &count, sizeof(count)) < 0) {
+    std::free(data_sizes);
+    std::free(attributes);
     return -1;
   }
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
+    std::free(data_sizes);
+    std::free(attributes);
     return -1;
   }
 
   CUresult result = CUDA_SUCCESS;
-  std::vector<std::vector<unsigned char>> values;
-  std::vector<void *> data;
-  try {
-    values.resize(num_attributes);
-    data.resize(num_attributes);
-    for (size_t i = 0; i < num_attributes; ++i) {
-      if (!lupine_mem_range_attribute_size_is_valid(attributes[i],
-                                                     data_sizes[i])) {
-        result = CUDA_ERROR_INVALID_VALUE;
+  void **data =
+      static_cast<void **>(std::malloc(num_attributes * sizeof(*data)));
+  size_t allocated = 0;
+  if (num_attributes != 0 && data == nullptr) {
+    result = CUDA_ERROR_OUT_OF_MEMORY;
+  } else {
+    for (; allocated < num_attributes; ++allocated) {
+      data[allocated] = std::malloc(data_sizes[allocated]);
+      if (data_sizes[allocated] != 0 && data[allocated] == nullptr) {
+        result = CUDA_ERROR_OUT_OF_MEMORY;
         break;
       }
-      values[i].resize(data_sizes[i]);
-      data[i] = values[i].data();
     }
-  } catch (const std::bad_alloc &) {
-    result = CUDA_ERROR_OUT_OF_MEMORY;
   }
 
   if (result == CUDA_SUCCESS) {
-    result = cuMemRangeGetAttributes(data.data(), data_sizes.data(),
-                                     attributes.data(), num_attributes,
-                                     dev_ptr, count);
+    result = cuMemRangeGetAttributes(data, data_sizes, attributes,
+                                     num_attributes, dev_ptr, count);
   }
 
+  int status = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0) {
-    return -1;
+    status = -1;
   }
-  if (result == CUDA_SUCCESS) {
+  if (status == 0 && result == CUDA_SUCCESS) {
     for (size_t i = 0; i < num_attributes; ++i) {
-      if (rpc_write(conn, values[i].data(), values[i].size()) < 0) {
-        return -1;
+      if (rpc_write(conn, data[i], data_sizes[i]) < 0) {
+        status = -1;
+        break;
       }
     }
   }
-  return rpc_write_end(conn) < 0 ? -1 : 0;
+  if (status == 0 && rpc_write_end(conn) < 0) {
+    status = -1;
+  }
+
+  for (size_t i = 0; i < allocated; ++i) {
+    std::free(data[i]);
+  }
+  std::free(data);
+  std::free(data_sizes);
+  std::free(attributes);
+  return status;
 }
 
 int handle_cuPointerGetAttribute(conn_t *conn) {

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -1715,6 +1715,116 @@ int handle_cuMemPoolImportFromShareableHandle(conn_t *conn) {
   return 0;
 }
 
+int handle_cuMemRangeGetAttribute(conn_t *conn) {
+  CUmem_range_attribute attribute;
+  CUdeviceptr dev_ptr = 0;
+  size_t count = 0;
+  size_t data_size = 0;
+  if (rpc_read(conn, &attribute, sizeof(attribute)) < 0 ||
+      rpc_read(conn, &dev_ptr, sizeof(dev_ptr)) < 0 ||
+      rpc_read(conn, &count, sizeof(count)) < 0 ||
+      rpc_read(conn, &data_size, sizeof(data_size)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  CUresult result = CUDA_ERROR_INVALID_VALUE;
+  std::vector<unsigned char> value;
+  if (lupine_mem_range_attribute_size_is_valid(attribute, data_size)) {
+    try {
+      value.resize(data_size);
+      result = cuMemRangeGetAttribute(value.data(), data_size, attribute,
+                                      dev_ptr, count);
+    } catch (const std::bad_alloc &) {
+      result = CUDA_ERROR_OUT_OF_MEMORY;
+    }
+  }
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 ||
+      (result == CUDA_SUCCESS &&
+       rpc_write(conn, value.data(), value.size()) < 0) ||
+      rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+int handle_cuMemRangeGetAttributes(conn_t *conn) {
+  size_t num_attributes = 0;
+  if (rpc_read(conn, &num_attributes, sizeof(num_attributes)) < 0 ||
+      num_attributes > SIZE_MAX / sizeof(size_t) ||
+      num_attributes > SIZE_MAX / sizeof(CUmem_range_attribute)) {
+    return -1;
+  }
+
+  std::vector<size_t> data_sizes;
+  std::vector<CUmem_range_attribute> attributes;
+  try {
+    data_sizes.resize(num_attributes);
+    attributes.resize(num_attributes);
+  } catch (const std::bad_alloc &) {
+    return -1;
+  }
+  CUdeviceptr dev_ptr = 0;
+  size_t count = 0;
+  if ((num_attributes != 0 &&
+       rpc_read(conn, data_sizes.data(),
+                num_attributes * sizeof(data_sizes[0])) < 0) ||
+      (num_attributes != 0 &&
+       rpc_read(conn, attributes.data(),
+                num_attributes * sizeof(attributes[0])) < 0) ||
+      rpc_read(conn, &dev_ptr, sizeof(dev_ptr)) < 0 ||
+      rpc_read(conn, &count, sizeof(count)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  CUresult result = CUDA_SUCCESS;
+  std::vector<std::vector<unsigned char>> values;
+  std::vector<void *> data;
+  try {
+    values.resize(num_attributes);
+    data.resize(num_attributes);
+    for (size_t i = 0; i < num_attributes; ++i) {
+      if (!lupine_mem_range_attribute_size_is_valid(attributes[i],
+                                                     data_sizes[i])) {
+        result = CUDA_ERROR_INVALID_VALUE;
+        break;
+      }
+      values[i].resize(data_sizes[i]);
+      data[i] = values[i].data();
+    }
+  } catch (const std::bad_alloc &) {
+    result = CUDA_ERROR_OUT_OF_MEMORY;
+  }
+
+  if (result == CUDA_SUCCESS) {
+    result = cuMemRangeGetAttributes(data.data(), data_sizes.data(),
+                                     attributes.data(), num_attributes,
+                                     dev_ptr, count);
+  }
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0) {
+    return -1;
+  }
+  if (result == CUDA_SUCCESS) {
+    for (size_t i = 0; i < num_attributes; ++i) {
+      if (rpc_write(conn, values[i].data(), values[i].size()) < 0) {
+        return -1;
+      }
+    }
+  }
+  return rpc_write_end(conn) < 0 ? -1 : 0;
+}
+
 int handle_cuPointerGetAttribute(conn_t *conn) {
   CUpointer_attribute attribute;
   CUdeviceptr ptr = 0;

--- a/cuda_server.h
+++ b/cuda_server.h
@@ -31,6 +31,8 @@ int handle_cuMemExportToShareableHandle(conn_t *conn);
 int handle_cuMemImportFromShareableHandle(conn_t *conn);
 int handle_cuMemPoolExportToShareableHandle(conn_t *conn);
 int handle_cuMemPoolImportFromShareableHandle(conn_t *conn);
+int handle_cuMemRangeGetAttribute(conn_t *conn);
+int handle_cuMemRangeGetAttributes(conn_t *conn);
 int handle_cuPointerGetAttribute(conn_t *conn);
 int handle_cuPointerSetAttribute(conn_t *conn);
 int handle_cuPointerGetAttributes(conn_t *conn);

--- a/cuda_server.h
+++ b/cuda_server.h
@@ -31,7 +31,6 @@ int handle_cuMemExportToShareableHandle(conn_t *conn);
 int handle_cuMemImportFromShareableHandle(conn_t *conn);
 int handle_cuMemPoolExportToShareableHandle(conn_t *conn);
 int handle_cuMemPoolImportFromShareableHandle(conn_t *conn);
-int handle_cuMemRangeGetAttribute(conn_t *conn);
 int handle_cuMemRangeGetAttributes(conn_t *conn);
 int handle_cuPointerGetAttribute(conn_t *conn);
 int handle_cuPointerSetAttribute(conn_t *conn);

--- a/lupine_attr_sizes.h
+++ b/lupine_attr_sizes.h
@@ -27,6 +27,31 @@ inline bool lupine_mem_pool_attribute_size(CUmemPool_attribute attr,
   }
 }
 
+// cuMemRangeGetAttribute(s) accepts caller-sized result buffers. Most
+// attributes are one 32-bit value; ACCESSED_BY is the exception and returns as
+// many 32-bit device ordinals as fit in the supplied buffer.
+inline bool lupine_mem_range_attribute_size_is_valid(
+    CUmem_range_attribute attr, size_t size) {
+  switch (attr) {
+  case CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY:
+  case CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION:
+  case CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION:
+    return size == sizeof(int);
+  case CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY:
+    return size != 0 && size % sizeof(int) == 0;
+#if CUDA_VERSION >= 12020
+  case CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION_TYPE:
+  case CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION_TYPE:
+    return size == sizeof(CUmemLocationType);
+  case CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION_ID:
+  case CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION_ID:
+    return size == sizeof(int);
+#endif
+  default:
+    return false;
+  }
+}
+
 inline bool lupine_pointer_attribute_size(CUpointer_attribute attr,
                                           size_t *size) {
   if (size == nullptr) {

--- a/lupine_attr_sizes.h
+++ b/lupine_attr_sizes.h
@@ -27,31 +27,6 @@ inline bool lupine_mem_pool_attribute_size(CUmemPool_attribute attr,
   }
 }
 
-// cuMemRangeGetAttribute(s) accepts caller-sized result buffers. Most
-// attributes are one 32-bit value; ACCESSED_BY is the exception and returns as
-// many 32-bit device ordinals as fit in the supplied buffer.
-inline bool lupine_mem_range_attribute_size_is_valid(
-    CUmem_range_attribute attr, size_t size) {
-  switch (attr) {
-  case CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY:
-  case CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION:
-  case CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION:
-    return size == sizeof(int);
-  case CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY:
-    return size != 0 && size % sizeof(int) == 0;
-#if CUDA_VERSION >= 12020
-  case CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION_TYPE:
-  case CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION_TYPE:
-    return size == sizeof(CUmemLocationType);
-  case CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION_ID:
-  case CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION_ID:
-    return size == sizeof(int);
-#endif
-  default:
-    return false;
-  }
-}
-
 inline bool lupine_pointer_attribute_size(CUpointer_attribute attr,
                                           size_t *size) {
   if (size == nullptr) {

--- a/test/cuda-python/known_failures.txt
+++ b/test/cuda-python/known_failures.txt
@@ -15,9 +15,6 @@ test_cudart.py::test_cudart_cudaMemcpy3DAsync
 test_cudart.py::test_cudart_cudaMemcpy3DPeer
 test_cudart.py::test_cudart_cudaMemcpy3DPeerAsync
 
-# #581 cuMemRangeGetAttribute
-test_cuda.py::test_cuda_mem_range_attr
-
 # #582 cuPointerSetAttribute(SYNC_MEMOPS)
 test_cuda.py::test_cuda_pointer_attr
 

--- a/test/test_mem_range_attributes.cu
+++ b/test/test_mem_range_attributes.cu
@@ -1,0 +1,121 @@
+// Regression coverage for the singular and plural managed-memory range
+// attribute APIs. The ACCESSED_BY result is deliberately wider than one value
+// so the RPC cannot accidentally pass by copying only a pointer-sized slot.
+
+#include <cuda.h>
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+int check(CUresult status, const char *operation) {
+  if (status == CUDA_SUCCESS) {
+    return 0;
+  }
+  const char *name = nullptr;
+  cuGetErrorName(status, &name);
+  std::fprintf(stderr, "%s failed: %d (%s)\n", operation,
+               static_cast<int>(status), name == nullptr ? "unknown" : name);
+  return 1;
+}
+
+struct RangeAttributes {
+  int read_mostly = -99;
+  int preferred_location = -99;
+  int accessed_by[3] = {-99, -99, -99};
+  int last_prefetch_location = -99;
+};
+
+} // namespace
+
+int main() {
+  int device_count = 0;
+  CUdevice device = 0;
+  CUcontext context = nullptr;
+  if (check(cuInit(0), "cuInit") != 0 ||
+      check(cuDeviceGetCount(&device_count), "cuDeviceGetCount") != 0 ||
+      device_count == 0 || check(cuDeviceGet(&device, 0), "cuDeviceGet") != 0 ||
+      check(cuDevicePrimaryCtxRetain(&context, device),
+            "cuDevicePrimaryCtxRetain") != 0 ||
+      check(cuCtxSetCurrent(context), "cuCtxSetCurrent") != 0) {
+    return 1;
+  }
+
+  constexpr size_t allocation_size = 4096;
+  CUdeviceptr allocation = 0;
+  if (check(cuMemAllocManaged(&allocation, allocation_size,
+                              CU_MEM_ATTACH_GLOBAL),
+            "cuMemAllocManaged") != 0) {
+    cuDevicePrimaryCtxRelease(device);
+    return 2;
+  }
+
+  CUmem_range_attribute attributes[] = {
+      CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY,
+      CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION,
+      CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY,
+      CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION,
+  };
+  constexpr size_t attribute_count = sizeof(attributes) / sizeof(attributes[0]);
+  size_t data_sizes[] = {sizeof(int), sizeof(int), 3 * sizeof(int),
+                         sizeof(int)};
+
+  RangeAttributes individual;
+  void *individual_data[] = {
+      &individual.read_mostly,
+      &individual.preferred_location,
+      individual.accessed_by,
+      &individual.last_prefetch_location,
+  };
+  for (size_t i = 0; i < attribute_count; ++i) {
+    if (check(cuMemRangeGetAttribute(individual_data[i], data_sizes[i],
+                                     attributes[i], allocation,
+                                     allocation_size),
+              "cuMemRangeGetAttribute") != 0) {
+      cuMemFree(allocation);
+      cuDevicePrimaryCtxRelease(device);
+      return 3;
+    }
+  }
+
+  RangeAttributes plural;
+  void *plural_data[] = {
+      &plural.read_mostly,
+      &plural.preferred_location,
+      plural.accessed_by,
+      &plural.last_prefetch_location,
+  };
+  if (check(cuMemRangeGetAttributes(plural_data, data_sizes, attributes,
+                                    attribute_count, allocation,
+                                    allocation_size),
+            "cuMemRangeGetAttributes") != 0) {
+    cuMemFree(allocation);
+    cuDevicePrimaryCtxRelease(device);
+    return 4;
+  }
+
+  for (size_t i = 0; i < attribute_count; ++i) {
+    if (std::memcmp(individual_data[i], plural_data[i], data_sizes[i]) != 0) {
+      std::fprintf(stderr, "attribute %zu differs between singular and plural "
+                           "queries\n",
+                   i);
+      cuMemFree(allocation);
+      cuDevicePrimaryCtxRelease(device);
+      return 5;
+    }
+  }
+
+  if (check(cuMemFree(allocation), "cuMemFree") != 0 ||
+      check(cuDevicePrimaryCtxRelease(device),
+            "cuDevicePrimaryCtxRelease") != 0) {
+    return 6;
+  }
+
+  std::printf("managed-memory range attributes match (%d, %d, [%d, %d, %d], "
+              "%d)\n",
+              individual.read_mostly, individual.preferred_location,
+              individual.accessed_by[0], individual.accessed_by[1],
+              individual.accessed_by[2], individual.last_prefetch_location);
+  return 0;
+}


### PR DESCRIPTION
## Summary

- generate `cuMemRangeGetAttribute` using `RECV_ONLY LENGTH:dataSize` with device-pointer routing
- manually marshal the ragged `cuMemRangeGetAttributes` output with direct allocations sized by the caller
- add singular/plural GPU regression coverage and re-enable the cuda-python test

## Testing

- `cmake --build build -j2`
- `./codegen/run.sh --verify-backend all`
- `ctest --test-dir build --output-on-failure` (7 passed, 2 skipped)
- `test/run_custom_tests.sh` (30 passed, including generated singular and manual plural memory-range paths)
- `test/run_cuda_python_tests.sh test_cuda.py` (50 passed, 5 deselected)

Fixes #581