### PR TITLE
test: parallelize GPU integration with CTest

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
   id-token: write
 
 jobs:
@@ -89,7 +90,6 @@ jobs:
       # cascades in otherwise passing cuBLAS and PyTorch tests.
       CUDA_SAMPLE_JOBS: 8
       SSH_COMMAND_TIMEOUT: 120
-      PYTORCH_TEST_TIMEOUT: 180
       CUDA_COMPAT_DEB_URL: ${{ matrix.cuda_compat_deb_url }}
       CUDA_COMPAT_DEB_SHA256: ${{ matrix.cuda_compat_deb_sha256 }}
       SERVER_LD_LIBRARY_PATH: ${{ matrix.server_ld_library_path }}
@@ -564,7 +564,7 @@ jobs:
 
           remote_status=0
           "${ssh_base[@]}" \
-            "CLIENT_IMAGE='$CLIENT_IMAGE' CUDA_SAMPLE_JOBS='$CUDA_SAMPLE_JOBS' CUDA_SAMPLE_TIMEOUT='$CUDA_SAMPLE_TIMEOUT' CUDA_LONG_SAMPLE_TIMEOUT='$CUDA_LONG_SAMPLE_TIMEOUT' SSH_COMMAND_TIMEOUT='$SSH_COMMAND_TIMEOUT' COMPLIANCE_TIMEOUT='$COMPLIANCE_TIMEOUT' PYTORCH_TEST_TIMEOUT='$PYTORCH_TEST_TIMEOUT' PYTORCH_INDEX_URL='${{ matrix.pytorch_index_url }}' SERVER_LD_LIBRARY_PATH='$SERVER_LD_LIBRARY_PATH' INTEGRATION_BINARY_CACHE_HIT='$INTEGRATION_BINARY_CACHE_HIT' INTEGRATION_BINARY_CACHE_REMOTE_DIR='$INTEGRATION_BINARY_CACHE_REMOTE_DIR' MATRIX_LABEL='${{ matrix.label }}' GITHUB_RUN_ID='${GITHUB_RUN_ID:-local}' GITHUB_RUN_ATTEMPT='${GITHUB_RUN_ATTEMPT:-1}' bash -s" <<'REMOTE' || remote_status=$?
+            "CLIENT_IMAGE='$CLIENT_IMAGE' CUDA_SAMPLE_JOBS='$CUDA_SAMPLE_JOBS' CUDA_SAMPLE_TIMEOUT='$CUDA_SAMPLE_TIMEOUT' CUDA_LONG_SAMPLE_TIMEOUT='$CUDA_LONG_SAMPLE_TIMEOUT' SSH_COMMAND_TIMEOUT='$SSH_COMMAND_TIMEOUT' COMPLIANCE_TIMEOUT='$COMPLIANCE_TIMEOUT' PYTORCH_INDEX_URL='${{ matrix.pytorch_index_url }}' SERVER_LD_LIBRARY_PATH='$SERVER_LD_LIBRARY_PATH' INTEGRATION_BINARY_CACHE_HIT='$INTEGRATION_BINARY_CACHE_HIT' INTEGRATION_BINARY_CACHE_REMOTE_DIR='$INTEGRATION_BINARY_CACHE_REMOTE_DIR' MATRIX_LABEL='${{ matrix.label }}' GITHUB_RUN_ID='${GITHUB_RUN_ID:-local}' GITHUB_RUN_ATTEMPT='${GITHUB_RUN_ATTEMPT:-1}' bash -s" <<'REMOTE' || remote_status=$?
           set -euo pipefail
           cache_mounts=()
           if [[ "$INTEGRATION_BINARY_CACHE_HIT" == "true" ]]; then
@@ -585,7 +585,6 @@ jobs:
             -e CUDA_LONG_SAMPLE_TIMEOUT="$CUDA_LONG_SAMPLE_TIMEOUT" \
             -e SSH_COMMAND_TIMEOUT="$SSH_COMMAND_TIMEOUT" \
             -e COMPLIANCE_TIMEOUT="$COMPLIANCE_TIMEOUT" \
-            -e PYTORCH_TEST_TIMEOUT="$PYTORCH_TEST_TIMEOUT" \
             -e PYTORCH_INDEX_URL="$PYTORCH_INDEX_URL" \
             -e SERVER_LD_LIBRARY_PATH="$SERVER_LD_LIBRARY_PATH" \
             -e SERVER_HOST=host.docker.internal \
@@ -632,9 +631,10 @@ jobs:
               export SSH_OPTS="-i /tmp/lupine-ssh/id_ed25519 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15 -o ConnectionAttempts=1 -o ServerAliveInterval=15 -o ServerAliveCountMax=4"
               export SAMPLE_TIMEOUT="$CUDA_SAMPLE_TIMEOUT"
               export LONG_SAMPLE_TIMEOUT="$CUDA_LONG_SAMPLE_TIMEOUT"
-              export TEST_TIMEOUT="$PYTORCH_TEST_TIMEOUT"
               export CUDA_SAMPLES_DIR=/opt/cuda-samples-src
               export CUDA_SAMPLES_BUILD_DIR=/opt/cuda-samples-build
+              export CUDA_PYTHON_DIR=/tmp/cuda-python
+              export LIBRARY_SAMPLES_DIR=/opt/cuda-library-samples
 
               python3 -m venv /tmp/venv-pytorch
               /tmp/venv-pytorch/bin/pip install --upgrade pip >/dev/null
@@ -654,33 +654,21 @@ jobs:
               ln -sf libcuda.so.1 "$LUPINE_BUILD_DIR/libcuda.so"
               ln -sf libnvidia-ml.so.1 "$LUPINE_BUILD_DIR/libnvidia-ml.so"
 
-              cuda_status=0
-              RESULTS_DIR="/results/test/cuda-samples/results/$(date +%Y%m%d-%H%M%S)" \
-                BUILD_SAMPLES=0 SAMPLE_SUITE=compliance \
-                /src/test/run_cuda_samples.sh || cuda_status=$?
+              # shellcheck disable=SC2206
+              ssh_args=($SSH_OPTS)
+              timeout --kill-after=5s "$SSH_COMMAND_TIMEOUT" \
+                scp -q "${ssh_args[@]}" "$SERVER_LOCAL_BIN" \
+                  "$SERVER_SSH_TARGET:$SERVER_REMOTE_BIN"
 
-              pytorch_status=0
-              RESULTS_DIR="/results/test/pytorch/results/$(date +%Y%m%d-%H%M%S)" \
-                /src/test/run_pytorch_lupine_tests.sh || pytorch_status=$?
-
-              cuda_python_status=0
-              RESULTS_DIR="/results/test/cuda-python/results/$(date +%Y%m%d-%H%M%S)" \
-                CUDA_PYTHON_DIR=/tmp/cuda-python SERVER_PORT_BASE=20300 \
-                /src/test/run_cuda_python_tests.sh || cuda_python_status=$?
-
-              library_status=0
-              RESULTS_DIR="/results/test/cuda-library-samples/results/$(date +%Y%m%d-%H%M%S)" \
-                LIBRARY_SAMPLES_DIR=/opt/cuda-library-samples BUILD_SAMPLES=0 SERVER_PORT_BASE=21000 \
-                /src/test/run_cuda_library_samples.sh || library_status=$?
-
-              custom_status=0
-              SERVER_PORT_BASE=20900 TEST_JOBS="$CUDA_SAMPLE_JOBS" \
-                /src/test/run_custom_tests.sh || custom_status=$?
-
-              if [[ "$cuda_status" -ne 0 || "$pytorch_status" -ne 0 || "$cuda_python_status" -ne 0 || "$library_status" -ne 0 || "$custom_status" -ne 0 ]]; then
-                echo "CUDA samples exited $cuda_status; PyTorch exited $pytorch_status; cuda-python exited $cuda_python_status; library samples exited $library_status; custom tests exited $custom_status" >&2
-                exit 1
-              fi
+              export INTEGRATION_RESULTS_DIR="/results/test/integration/results/$(date +%Y%m%d-%H%M%S)"
+              mkdir -p "$INTEGRATION_RESULTS_DIR"
+              cmake -S /src/test/integration -B /tmp/lupine-integration-ctest
+              timeout --kill-after=30s "$COMPLIANCE_TIMEOUT" \
+                ctest --test-dir /tmp/lupine-integration-ctest \
+                  --parallel "$CUDA_SAMPLE_JOBS" \
+                  --output-on-failure \
+                  --output-log "$INTEGRATION_RESULTS_DIR/ctest.log" \
+                  --output-junit "$INTEGRATION_RESULTS_DIR/junit.xml"
             '
           REMOTE
 
@@ -747,59 +735,22 @@ jobs:
           fi
           echo "Saved integration binaries to $INTEGRATION_BINARY_CACHE_URI"
 
-      - name: Upload compliance results
+      - name: Publish integration test results
+        if: always()
+        uses: dorny/test-reporter@v3
+        with:
+          name: GPU integration (${{ matrix.label }})
+          path: test/integration/results/*/junit.xml
+          reporter: java-junit
+          fail-on-empty: false
+
+      - name: Upload integration results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: gpu-integration-results-${{ matrix.label }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            test/cuda-samples/results/
-            test/pytorch/results/
-            test/cuda-python/results/
-            test/cuda-library-samples/results/
+          path: test/integration/results/
           if-no-files-found: ignore
-
-      - name: Report sample results
-        id: sample_results
-        if: always()
-        run: |
-          set -uo pipefail
-          rd="$(ls -td test/cuda-samples/results/*/ 2>/dev/null | head -n1 || true)"
-          if [[ -z "${rd:-}" ]]; then
-            echo "No CUDA sample results dir found." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          {
-            echo "### CUDA samples (${{ matrix.label }})"
-            echo '```'
-            [[ -f "$rd/summary.txt" ]] && cat "$rd/summary.txt"
-            [[ -f "$rd/coverage.txt" ]] && { echo; cat "$rd/coverage.txt"; }
-            echo '```'
-            cp="$(ls -td test/cuda-python/results/*/ 2>/dev/null | head -n1 || true)"
-            if [[ -n "${cp:-}" && -f "$cp/summary.txt" ]]; then
-              echo "### cuda-python (${{ matrix.label }})"
-              echo '```'
-              cat "$cp/summary.txt"
-              echo '```'
-            fi
-            lsd="$(ls -td test/cuda-library-samples/results/*/ 2>/dev/null | head -n1 || true)"
-            if [[ -n "${lsd:-}" && -f "$lsd/summary.txt" ]]; then
-              echo "### CUDALibrarySamples (${{ matrix.label }})"
-              echo '```'
-              cat "$lsd/summary.txt"
-              echo '```'
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-          if [[ -f "$rd/summary.txt" ]]; then
-            awk '{print tolower($1)"="$2}' "$rd/summary.txt" >> "$GITHUB_OUTPUT"
-          fi
-          cov=""
-          if [[ -f "$rd/coverage.txt" ]]; then
-            cov="$(grep 'coverage:' "$rd/coverage.txt" | sed -E 's/^CUDA sample coverage: /coverage=/')"
-          fi
-          if [[ -n "${cov:-}" ]]; then
-            echo "$cov" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Refresh Google Cloud credentials for cleanup
         if: always()

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.21)
+project(LupineIntegrationTests NONE)
+enable_testing()
+
+set(port 14900)
+
+function(add_suite suite script)
+    set(list_env ${ARGN})
+    if(suite STREQUAL "cuda-python")
+        set(list_env)
+    endif()
+    execute_process(
+        COMMAND "${CMAKE_COMMAND}" -E env LIST_TESTS=1 SERVER_UPLOAD=0
+                ${list_env} "${script}"
+        OUTPUT_VARIABLE tests OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
+    string(REPLACE "\n" ";" tests "${tests}")
+
+    foreach(name IN LISTS tests)
+        add_test(NAME "${suite}.${name}" COMMAND "${script}" "${name}")
+        set_tests_properties("${suite}.${name}" PROPERTIES
+            ENVIRONMENT "SERVER_PORT_BASE=${port};SERVER_UPLOAD=0;RESULTS_DIR=$ENV{INTEGRATION_RESULTS_DIR}/cases/${suite}/${name};${ARGN}"
+            SKIP_REGULAR_EXPRESSION "SKIP:" TIMEOUT 900)
+        math(EXPR port "${port} + 10")
+    endforeach()
+    set(port "${port}" PARENT_SCOPE)
+endfunction()
+
+set(TEST_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
+add_suite(cuda "${TEST_DIR}/run_cuda_samples.sh" BUILD_SAMPLES=0)
+add_suite(pytorch "${TEST_DIR}/run_pytorch_lupine_tests.sh")
+add_suite(cuda-python "${TEST_DIR}/run_cuda_python_tests.sh" CUDA_PYTHON_INSTALL=0)
+add_suite(cuda-library "${TEST_DIR}/run_cuda_library_samples.sh" BUILD_SAMPLES=0)
+add_suite(custom "${TEST_DIR}/run_custom_tests.sh")
+
+set(decoder "cuda-library.nvJPEG/nvJPEG-Decoder")
+set(encoder "cuda-library.nvJPEG/nvJPEG-Encoder-MultipleInstances")
+set_property(TEST "${encoder}" PROPERTY DEPENDS "${decoder}")

--- a/test/run_cuda_library_samples.sh
+++ b/test/run_cuda_library_samples.sh
@@ -42,6 +42,7 @@ CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 CUDA_LIB_DIR="${CUDA_LIB_DIR:-/usr/local/cuda/lib64}"
 SAMPLE_TIMEOUT="${SAMPLE_TIMEOUT:-180}"
 RESULTS_DIR="${RESULTS_DIR:-$repo_root/test/cuda-library-samples/results/$(date +%Y%m%d-%H%M%S)}"
+nvjpeg_assets="${TMPDIR:-/tmp}/lupine-nvjpeg-assets"
 
 usage() {
   cat <<EOF
@@ -73,15 +74,17 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-mkdir -p "$(dirname "$LIBRARY_SAMPLES_DIR")"
-if [[ ! -d "$LIBRARY_SAMPLES_DIR/.git" ]]; then
-  rm -rf "$LIBRARY_SAMPLES_DIR"
-  git clone --quiet "$LIBRARY_SAMPLES_URL" "$LIBRARY_SAMPLES_DIR"
-fi
-git config --global --add safe.directory "$LIBRARY_SAMPLES_DIR"
-if [[ "$(git -C "$LIBRARY_SAMPLES_DIR" rev-parse --short=7 HEAD)" != "$(git -C "$LIBRARY_SAMPLES_DIR" rev-parse --short=7 "$LIBRARY_SAMPLES_REF" 2>/dev/null || true)" ]]; then
-  git -C "$LIBRARY_SAMPLES_DIR" fetch --quiet origin
-  git -C "$LIBRARY_SAMPLES_DIR" checkout --quiet "$LIBRARY_SAMPLES_REF"
+if [[ "$BUILD_SAMPLES" != "0" ]]; then
+  mkdir -p "$(dirname "$LIBRARY_SAMPLES_DIR")"
+  if [[ ! -d "$LIBRARY_SAMPLES_DIR/.git" ]]; then
+    rm -rf "$LIBRARY_SAMPLES_DIR"
+    git clone --quiet "$LIBRARY_SAMPLES_URL" "$LIBRARY_SAMPLES_DIR"
+  fi
+  git config --global --add safe.directory "$LIBRARY_SAMPLES_DIR"
+  if [[ "$(git -C "$LIBRARY_SAMPLES_DIR" rev-parse --short=7 HEAD)" != "$(git -C "$LIBRARY_SAMPLES_DIR" rev-parse --short=7 "$LIBRARY_SAMPLES_REF" 2>/dev/null || true)" ]]; then
+    git -C "$LIBRARY_SAMPLES_DIR" fetch --quiet origin
+    git -C "$LIBRARY_SAMPLES_DIR" checkout --quiet "$LIBRARY_SAMPLES_REF"
+  fi
 fi
 
 # A sample is a directory with a CMakeLists.txt and no CMake project beneath
@@ -101,6 +104,10 @@ else
       | awk '{ if (prev != "" && index($0, prev "/") == 1) { skip[prev] = 1 } ; prev = $0; lines[n++] = $0 }
              END { for (i = 0; i < n; i++) if (!(lines[i] in skip)) print lines[i] }'
   )
+fi
+if [[ "${LIST_TESTS:-0}" == "1" ]]; then
+  printf '%s\n' "${SAMPLES[@]}"
+  exit 0
 fi
 
 build_sample() {
@@ -173,12 +180,12 @@ done
 unit_argv() {
   local images="$LIBRARY_SAMPLES_DIR/nvJPEG/nvJPEG-Decoder/input_images/"
   case "$1" in
-    nvJPEG/nvJPEG-Decoder/*) printf '%s\0' -i "$images" -b 2 -o "$RESULTS_DIR/nvjpeg-decoded" ;;
+    nvJPEG/nvJPEG-Decoder/*) printf '%s\0' -i "$images" -b 2 -o "$nvjpeg_assets/nvjpeg-decoded" ;;
     nvJPEG/nvJPEG-Decoder-Backend-ROI/*) printf '%s\0' -i "$images" -b 2 ;;
     nvJPEG/nvJPEG-Decoder-MultipleInstances/*) printf '%s\0' -i "$images" -s 2 -j 2 -r 1 ;;
-    nvJPEG/nvJPEG-Encoder-MultipleInstances/*) printf '%s\0' -i "$RESULTS_DIR/nvjpeg-decoded/" -s 2 -j 2 -r 1 ;;
-    nvJPEG/Image-Resize/*) printf '%s\0' -i "$images" -o "$RESULTS_DIR/nvjpeg-resized" ;;
-    nvJPEG/Image-Resize-WaterMark/*) printf '%s\0' -i "$LIBRARY_SAMPLES_DIR/nvJPEG/Image-Resize-WaterMark/input_images/" -o "$RESULTS_DIR/nvjpeg-watermarked" ;;
+    nvJPEG/nvJPEG-Encoder-MultipleInstances/*) printf '%s\0' -i "$nvjpeg_assets/nvjpeg-decoded/" -s 2 -j 2 -r 1 ;;
+    nvJPEG/Image-Resize/*) printf '%s\0' -i "$images" -o "$nvjpeg_assets/nvjpeg-resized" ;;
+    nvJPEG/Image-Resize-WaterMark/*) printf '%s\0' -i "$LIBRARY_SAMPLES_DIR/nvJPEG/Image-Resize-WaterMark/input_images/" -o "$nvjpeg_assets/nvjpeg-watermarked" ;;
     NPP/nppCanny/*) printf '%s\0' example_input.png ;;
   esac
 }
@@ -249,7 +256,10 @@ in_list() {
   return 1
 }
 
-mkdir -p "$RESULTS_DIR" "$RESULTS_DIR/nvjpeg-decoded" "$RESULTS_DIR/nvjpeg-resized" "$RESULTS_DIR/nvjpeg-watermarked"
+mkdir -p "$RESULTS_DIR" \
+  "$nvjpeg_assets/nvjpeg-decoded" \
+  "$nvjpeg_assets/nvjpeg-resized" \
+  "$nvjpeg_assets/nvjpeg-watermarked"
 tsv="$RESULTS_DIR/results.tsv"
 : > "$tsv"
 pass=0

--- a/test/run_cuda_python_tests.sh
+++ b/test/run_cuda_python_tests.sh
@@ -105,15 +105,18 @@ if [[ -z "$CUDA_PYTHON_REF" ]]; then
   CUDA_PYTHON_REF="v$installed"
 fi
 
-mkdir -p "$(dirname "$CUDA_PYTHON_DIR")" "$RESULTS_DIR"
-if [[ ! -d "$CUDA_PYTHON_DIR/.git" ]]; then
-  rm -rf "$CUDA_PYTHON_DIR"
-  git clone --quiet "$CUDA_PYTHON_URL" "$CUDA_PYTHON_DIR"
-fi
-git config --global --add safe.directory "$CUDA_PYTHON_DIR"
-if [[ "$(git -C "$CUDA_PYTHON_DIR" describe --tags --exact-match 2>/dev/null || true)" != "$CUDA_PYTHON_REF" ]]; then
-  git -C "$CUDA_PYTHON_DIR" fetch --quiet --tags origin
-  git -C "$CUDA_PYTHON_DIR" checkout --quiet "$CUDA_PYTHON_REF"
+mkdir -p "$RESULTS_DIR"
+if [[ "$CUDA_PYTHON_INSTALL" != "0" ]]; then
+  mkdir -p "$(dirname "$CUDA_PYTHON_DIR")"
+  if [[ ! -d "$CUDA_PYTHON_DIR/.git" ]]; then
+    rm -rf "$CUDA_PYTHON_DIR"
+    git clone --quiet "$CUDA_PYTHON_URL" "$CUDA_PYTHON_DIR"
+  fi
+  git config --global --add safe.directory "$CUDA_PYTHON_DIR"
+  if [[ "$(git -C "$CUDA_PYTHON_DIR" describe --tags --exact-match 2>/dev/null || true)" != "$CUDA_PYTHON_REF" ]]; then
+    git -C "$CUDA_PYTHON_DIR" fetch --quiet --tags origin
+    git -C "$CUDA_PYTHON_DIR" checkout --quiet "$CUDA_PYTHON_REF"
+  fi
 fi
 
 tests_dir=""
@@ -157,6 +160,11 @@ if [[ -n "$examples_dir" ]]; then
 fi
 if [[ $# -gt 0 ]]; then
   UNITS=("$@")
+fi
+
+if [[ "${LIST_TESTS:-0}" == "1" ]]; then
+  printf '%s\n' "${UNITS[@]}"
+  exit 0
 fi
 
 deselect_args=()

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -160,15 +160,18 @@ if [[ "$BUILD_ONLY" != "1" ]]; then
   fi
 fi
 
-mkdir -p "$(dirname "$CUDA_SAMPLES_DIR")" "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
 
-if [[ ! -d "$CUDA_SAMPLES_DIR/.git" ]]; then
-  if [[ -e "$CUDA_SAMPLES_DIR" ]]; then
-    rm -rf "$CUDA_SAMPLES_DIR"
+if [[ "$BUILD_SAMPLES" != "0" ]]; then
+  mkdir -p "$(dirname "$CUDA_SAMPLES_DIR")"
+  if [[ ! -d "$CUDA_SAMPLES_DIR/.git" ]]; then
+    if [[ -e "$CUDA_SAMPLES_DIR" ]]; then
+      rm -rf "$CUDA_SAMPLES_DIR"
+    fi
+    git clone "$CUDA_SAMPLES_URL" "$CUDA_SAMPLES_DIR"
   fi
-  git clone "$CUDA_SAMPLES_URL" "$CUDA_SAMPLES_DIR"
+  git config --global --add safe.directory "$CUDA_SAMPLES_DIR"
 fi
-git config --global --add safe.directory "$CUDA_SAMPLES_DIR"
 
 detect_cuda_samples_ref() {
   local release=""
@@ -228,7 +231,7 @@ if [[ -z "$CUDA_SAMPLES_REF" ]]; then
   CUDA_SAMPLES_REF="$(detect_cuda_samples_ref)"
 fi
 
-if [[ -n "$CUDA_SAMPLES_REF" ]]; then
+if [[ "$BUILD_SAMPLES" != "0" && -n "$CUDA_SAMPLES_REF" ]]; then
   git -C "$CUDA_SAMPLES_DIR" fetch --tags origin
   git -C "$CUDA_SAMPLES_DIR" checkout "$CUDA_SAMPLES_REF"
   git -C "$CUDA_SAMPLES_DIR" reset --hard "$CUDA_SAMPLES_REF"
@@ -238,7 +241,7 @@ fi
 # -D flag cannot narrow them. Rewrite lists that include the requested arch to
 # just that arch; samples restricted to other archs are left as upstream built
 # them.
-if [[ -n "$CUDA_SAMPLES_ARCH" ]]; then
+if [[ "$BUILD_SAMPLES" != "0" && -n "$CUDA_SAMPLES_ARCH" ]]; then
   find "$CUDA_SAMPLES_DIR" -name CMakeLists.txt -exec sed -i -E \
     "s/set\(CMAKE_CUDA_ARCHITECTURES ([0-9 ]* )?$CUDA_SAMPLES_ARCH( [0-9 ]*)?\)/set(CMAKE_CUDA_ARCHITECTURES $CUDA_SAMPLES_ARCH)/" {} +
 fi
@@ -485,7 +488,6 @@ prepare_sample_runtime_files() {
   esac
 }
 
-explicit_samples=0
 build_full_sample_tree=0
 samples=("$@")
 if [[ ${#samples[@]} -eq 0 ]]; then
@@ -509,8 +511,10 @@ if [[ ${#samples[@]} -eq 0 ]]; then
       exit 1
       ;;
   esac
-else
-  explicit_samples=1
+fi
+if [[ "${LIST_TESTS:-0}" == "1" ]]; then
+  printf '%s\n' "${samples[@]}"
+  exit 0
 fi
 selected_sample_build=0
 if [[ "$build_full_sample_tree" != "1" && ${#samples[@]} -gt 0 ]]; then
@@ -758,18 +762,10 @@ run_sample() {
   sample_exe="$(resolve_sample_exe "$sample" || true)"
   if [[ -z "$sample_exe" ]]; then
     if [[ -z "$(resolve_sample_srcdir "$sample" || true)" ]]; then
-      if [[ "$explicit_samples" == "1" ]]; then
-        status="FAIL:missing"
-      else
-        status="SKIP:missing"
-      fi
+      status="SKIP:missing"
       signature="missing sample source dir: $sample"
     else
-      if [[ "$explicit_samples" == "1" ]]; then
-        status="FAIL:build-failed"
-      else
-        status="SKIP:build-failed"
-      fi
+      status="SKIP:build-failed"
       build_log="$RESULTS_DIR/.build-$sample.log"
       signature="$(compact_signature "$(grep -iE 'will not build|fatal error|:[[:space:]]*error:|No rule to make target|not found' "$build_log" 2>/dev/null || true)")"
       if [[ -z "$signature" ]]; then
@@ -891,7 +887,7 @@ done
 } | tee "$summary"
 
 # Coverage: how much of the pinned cuda-samples catalog this run exercises.
-if [[ "$cmake_samples" == "1" && -d "$CUDA_SAMPLES_DIR/Samples" ]]; then
+if [[ ${#samples[@]} -gt 1 && "$cmake_samples" == "1" && -d "$CUDA_SAMPLES_DIR/Samples" ]]; then
   declare -A _enabled=()
   for _s in "${samples[@]}"; do _enabled["$_s"]=1; done
 

--- a/test/run_custom_tests.sh
+++ b/test/run_custom_tests.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env bash
-# Build and run the repo's custom driver-API tests (test/test_*.cu) through the
-# lupine client shim against a remote server. Mirrors run_cuda_samples.sh's
-# server management and env conventions so the GPU integration job can invoke it
-# the same way. Each test is a standalone driver-API program that exits non-zero
-# on failure; this script fails if any test fails to build or run.
-#
-# Tests build and run TEST_JOBS at a time. Each test gets its own server
-# instance on SERVER_PORT_BASE + index so a test that wedges or crashes its
-# server cannot poison the others.
+# Build and run one custom driver-API test through the lupine client shim.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ "${LIST_TESTS:-0}" == "1" ]]; then
+  printf '%s\n' "$repo_root"/test/test_*.cu | xargs -n1 basename -s .cu
+  exit 0
+fi
 
 SERVER_HOST="${SERVER_HOST:-inferable-node-008}"
 SERVER_USER="${SERVER_USER:-kevin}"
@@ -29,22 +26,13 @@ LUPINE_LIB_DIR="$(cd "$(dirname "$LUPINE_LIB")" && pwd)"
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 CUDA_LIB_DIR="${CUDA_LIB_DIR:-/usr/local/cuda/lib64}"
 NVCC="${NVCC:-$CUDA_HOME/bin/nvcc}"
-TEST_TIMEOUT="${TEST_TIMEOUT:-120}"
 CUDA_SAMPLES_ARCH="${CUDA_SAMPLES_ARCH:-}"
-TEST_JOBS="${TEST_JOBS:-$(nproc)}"
 if [[ -n "${BUILD_DIR:-}" ]]; then
   owns_build_dir=0
 else
   BUILD_DIR="$(mktemp -d)"
   owns_build_dir=1
 fi
-
-case "$TEST_JOBS" in
-  ''|*[!0-9]*|0)
-    echo "TEST_JOBS must be a positive integer: $TEST_JOBS" >&2
-    exit 1
-    ;;
-esac
 
 for f in "$SERVER_LOCAL_BIN" "$LUPINE_LIB"; do
   [[ -e "$f" ]] || { echo "missing build artifact: $f (build lupine first)" >&2; exit 1; }
@@ -54,24 +42,6 @@ ssh_with_timeout() {
   timeout --kill-after=5s "$SSH_COMMAND_TIMEOUT" \
     ssh "${SSH_ARGS[@]}" "$SERVER_SSH_TARGET" "$@"
 }
-
-# Pidfiles and server logs share a $$-scoped prefix so an aborted run can be
-# swept remotely with one ssh command.
-remote_prefix="/tmp/lupine-custom-$$"
-
-cleanup() {
-  ssh_with_timeout "
-    for f in $remote_prefix-*.pid; do
-      [ -f \"\$f\" ] || continue
-      pid=\$(cat \"\$f\" 2>/dev/null || true)
-      [ -n \"\$pid\" ] && kill \"\$pid\" >/dev/null 2>&1
-      rm -f \"\$f\"
-    done
-    rm -f $remote_prefix-*.log '$SERVER_REMOTE_BIN'
-  " >/dev/null 2>&1 || true
-  [[ "$owns_build_dir" == "1" ]] && rm -rf "$BUILD_DIR"
-}
-trap cleanup EXIT
 
 stop_remote_server() {
   local pidfile="$1"
@@ -127,104 +97,26 @@ if [[ "$SERVER_UPLOAD" == "1" ]]; then
     scp -q "${SSH_ARGS[@]}" "$SERVER_LOCAL_BIN" "$SERVER_SSH_TARGET:$SERVER_REMOTE_BIN"
 fi
 
-shopt -s nullglob
-tests=("$repo_root"/test/test_*.cu)
-if [[ ${#tests[@]} -eq 0 ]]; then
-  echo "no test/test_*.cu found" >&2
-  exit 0
-fi
+name="${1:?custom test name required}"
+name="${name%.cu}"
+src="$repo_root/test/$name.cu"
+exe="$BUILD_DIR/$name"
+port="$SERVER_PORT_BASE"
+pidfile="/tmp/lupine-custom-$port.pid"
+server_log="/tmp/lupine-custom-$port.log"
 
-run_one_test() {
-  local i="$1"
-  local src="${tests[$i]}"
-  local name
-  name="$(basename "$src" .cu)"
-  local exe="$BUILD_DIR/$name"
-  local log="$BUILD_DIR/$name.log"
-  local result_file="$BUILD_DIR/.result-$i"
-  local port=$((SERVER_PORT_BASE + i))
-  local pidfile="$remote_prefix-$port.pid"
-  local server_log="$remote_prefix-$port.log"
-  local start_seconds="$SECONDS"
-  local rc=0
-
-  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] custom test $((i + 1))/${#tests[@]}: $name" >&2
-
-  # nvcc targets one architecture by default (sm_75 on 13.3) and leaves every
-  # other device to a PTX JIT, which the test host's driver refuses when it is
-  # older than the toolkit -- the launch then silently does nothing and the
-  # test reports a stale value. Emit a cubin for every architecture nvcc knows
-  # unless CUDA_SAMPLES_ARCH pins one.
-  local arch_arg="-arch=all"
-  if [[ -n "$CUDA_SAMPLES_ARCH" ]]; then
-    arch_arg="-arch=sm_$CUDA_SAMPLES_ARCH"
-  fi
-
-  if ! "$NVCC" --cudart=shared -Wno-deprecated-gpu-targets "$arch_arg" \
-       "$src" -o "$exe" \
-       -lcuda -lcublas -L"$CUDA_HOME/lib64/stubs" >"$log" 2>&1; then
-    echo "FAIL:build" > "$result_file"
-    return 0
-  fi
-
-  if ! start_remote_server "$pidfile" "$server_log" "$port"; then
-    echo "FAIL:server-start" > "$result_file"
-    return 0
-  fi
-
-  set +e
-  timeout --kill-after=5s "$TEST_TIMEOUT" env \
-    LD_LIBRARY_PATH="$LUPINE_LIB_DIR:$CUDA_LIB_DIR:${LD_LIBRARY_PATH:-}" \
-    LUPINE_SERVER="$SERVER_HOST:$port" \
-    "$exe" >>"$log" 2>&1
-  rc=$?
-  set -e
-
+cleanup() {
   stop_remote_server "$pidfile" "$server_log"
-
-  if [[ "$rc" == "0" ]]; then
-    echo "PASS" > "$result_file"
-  else
-    echo "FAIL:$rc" > "$result_file"
-  fi
-  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] custom test $name -> $(cat "$result_file") in $((SECONDS - start_seconds))s" >&2
+  [[ "$SERVER_UPLOAD" == "1" ]] && ssh_with_timeout "rm -f '$SERVER_REMOTE_BIN'" >/dev/null 2>&1 || true
+  [[ "$owns_build_dir" == "1" ]] && rm -rf "$BUILD_DIR"
 }
+trap cleanup EXIT
 
-# Keep TEST_JOBS tests in flight; launch the next one as soon as any finishes.
-active=0
-for i in "${!tests[@]}"; do
-  run_one_test "$i" &
-  active=$((active + 1))
-  if (( active >= TEST_JOBS )); then
-    wait -n || true
-    active=$((active - 1))
-  fi
-done
-while (( active > 0 )); do
-  wait -n || true
-  active=$((active - 1))
-done
+arch_arg="-arch=all"
+[[ -n "$CUDA_SAMPLES_ARCH" ]] && arch_arg="-arch=sm_$CUDA_SAMPLES_ARCH"
+"$NVCC" --cudart=shared -Wno-deprecated-gpu-targets "$arch_arg" \
+  "$src" -o "$exe" -lcuda -lcublas -L"$CUDA_HOME/lib64/stubs"
 
-pass=0 fail=0
-for i in "${!tests[@]}"; do
-  name="$(basename "${tests[$i]}" .cu)"
-  result_file="$BUILD_DIR/.result-$i"
-  if [[ -s "$result_file" ]]; then
-    status="$(cat "$result_file")"
-  else
-    status="FAIL:internal"
-  fi
-
-  echo "=== $name: $status ==="
-  [[ -f "$BUILD_DIR/$name.log" ]] && cat "$BUILD_DIR/$name.log"
-
-  if [[ "$status" == "PASS" ]]; then
-    pass=$((pass + 1))
-  else
-    fail=$((fail + 1))
-  fi
-done
-
-echo ""
-echo "custom tests: $pass passed, $fail failed"
-[[ "$fail" -eq 0 ]]
+start_remote_server "$pidfile" "$server_log" "$port"
+env LD_LIBRARY_PATH="$LUPINE_LIB_DIR:$CUDA_LIB_DIR:${LD_LIBRARY_PATH:-}" \
+  LUPINE_SERVER="$SERVER_HOST:$port" "$exe"

--- a/test/run_pytorch_lupine_tests.sh
+++ b/test/run_pytorch_lupine_tests.sh
@@ -19,7 +19,6 @@ SERVER_LD_LIBRARY_PATH="${SERVER_LD_LIBRARY_PATH:-}"
 PYTORCH_SKIP_LIST="${PYTORCH_SKIP_LIST:-}"
 
 LUPINE_LIB="${LUPINE_LIB:-$repo_root/build/libcuda.so.1}"
-LUPINE_LIB_DIR="$(cd "$(dirname "$LUPINE_LIB")" && pwd)"
 PYTHON_BIN="${PYTHON_BIN:-$repo_root/.venv-pytorch312/bin/python}"
 CUDA_LIB_DIR="${CUDA_LIB_DIR:-/usr/local/cuda/lib64}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-90}"
@@ -41,6 +40,11 @@ TESTS=(
 if [[ $# -gt 0 ]]; then
   TESTS=("$@")
 fi
+if [[ "${LIST_TESTS:-0}" == "1" ]]; then
+  printf '%s\n' "${TESTS[@]}"
+  exit 0
+fi
+LUPINE_LIB_DIR="$(cd "$(dirname "$LUPINE_LIB")" && pwd)"
 
 if [[ ! -x "$PYTHON_BIN" ]]; then
   echo "missing python: $PYTHON_BIN" >&2


### PR DESCRIPTION
## Summary

- add lightweight list/single-case hooks to the existing integration scripts
- register all 421 GPU integration cases directly with CTest and run them through one bounded worker pool
- preserve the nvJPEG decoder/encoder dependency and produce standard CTest output plus JUnit XML
- have GPU CI upload the server once, then invoke CMake and CTest directly

## Validation

- configured 421 unique CTest cases: 165 CUDA samples, 10 PyTorch cases, 23 cuda-python cases, 192 CUDALibrarySamples projects, and 31 custom tests
- exercised representative suites concurrently and verified native CTest skip handling
- verified shell syntax, workflow YAML, JUnit generation, and all 31 custom CUDA test builds

Full GPU execution is handled by the pull-request workflow.