### PR TITLE
Stop synchronizing the stream after async 2D and 3D copies

### DIFF
--- a/cuda_server_memcpy.cpp
+++ b/cuda_server_memcpy.cpp
@@ -1689,9 +1689,6 @@ int handle_cuMemcpy3DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -1715,9 +1712,6 @@ int handle_cuMemcpy3DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
@@ -1738,9 +1732,6 @@ int handle_cuMemcpy3DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -1866,9 +1857,6 @@ int handle_cuMemcpy3DPeerAsync(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DPeerAsync(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -1892,9 +1880,6 @@ int handle_cuMemcpy3DPeerAsync(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DPeerAsync(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
@@ -1915,9 +1900,6 @@ int handle_cuMemcpy3DPeerAsync(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DPeerAsync(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -2106,9 +2088,6 @@ int handle_cuMemcpy2DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy2DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -2129,9 +2108,6 @@ int handle_cuMemcpy2DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy2DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
@@ -2151,9 +2127,6 @@ int handle_cuMemcpy2DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy2DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {


### PR DESCRIPTION
Stacked on #636.

Every async 2D, 3D and 3D-peer handler ended the same way:

```c
CUresult result = cuMemcpy3DAsync_v2(&copy, stream);
if (result == CUDA_SUCCESS) {
  result = cuStreamSynchronize(stream);
}
```

Nine sites. An async copy followed immediately by a full stream synchronize is a synchronous copy written the long way, and `cuStreamSynchronize` waits for the entire stream rather than the copy.

Measured on an RTX 4090, the wait was already done for us in both host directions:

- **device to host**, pageable staging: the driver returns only once the bytes have landed — 4 B through 2 GB, no exceptions.
- **host to device**, pageable staging: `cuMemcpyHtoDAsync_v2` blocked for the full 452 ms of a half-second kernel and consumed the source buffer before returning. Scribbling the source immediately after the call and reading the device back afterwards shows all 4194304 elements original, none scribbled, so the staging vector is safe to destroy on return.

So for both host directions the synchronize repeated work the driver had already done.

The device-to-device branch is the one that changes behaviour. It stages nothing and has nothing to wait for, so the synchronize only forced a genuinely asynchronous copy to block on whatever the stream was running. The client waits for a response either way, and `cuMemcpy3DAsync_v2`'s own return value is what the driver would hand back. Copies routed through the client stay synchronous — that is inherent to moving the bytes — but they no longer drag the caller's stream along with them.

Confirmed by hand rather than by a timing test: a device-to-device `cudaMemcpy2DAsync` enqueued behind a half-second kernel blocks for 451.3 ms against the parent commit and returns in single-digit milliseconds with this change.

Unit tests 9/9, custom driver-API tests 31/31 against inferable-node-008.