### PR TITLE
Send pitched copies as packed compressed payloads

### DIFF
--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -3157,7 +3157,7 @@ extern "C" CUresult cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy) {
     if (lupine_prepare_rpc(conn) < 0 ||
         rpc_write_start_request(conn, RPC_cuMemcpy2D_v2) < 0 ||
         rpc_write(conn, &copy, sizeof(copy)) < 0 ||
-        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+        rpc_write_pitched_payload(conn, src_base, copy.WidthInBytes, copy.Height,
                           copy.srcPitch, 1, 0) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -3179,7 +3179,7 @@ extern "C" CUresult cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy) {
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
         (return_value == CUDA_SUCCESS &&
-         rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+         rpc_read_pitched_payload(conn, dst_base, copy.WidthInBytes, copy.Height,
                           copy.dstPitch, 1, 0) < 0) ||
         rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -3284,7 +3284,7 @@ extern "C" CUresult cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy) {
     if (lupine_prepare_rpc(conn) < 0 ||
         rpc_write_start_request(conn, RPC_cuMemcpy2DUnaligned_v2) < 0 ||
         rpc_write(conn, &copy, sizeof(copy)) < 0 ||
-        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+        rpc_write_pitched_payload(conn, src_base, copy.WidthInBytes, copy.Height,
                           copy.srcPitch, 1, 0) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -3306,7 +3306,7 @@ extern "C" CUresult cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy) {
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
         (return_value == CUDA_SUCCESS &&
-         rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+         rpc_read_pitched_payload(conn, dst_base, copy.WidthInBytes, copy.Height,
                           copy.dstPitch, 1, 0) < 0) ||
         rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -3412,7 +3412,7 @@ extern "C" CUresult cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy,
     if (lupine_prepare_rpc(conn) < 0 ||
         rpc_write_start_request(conn, RPC_cuMemcpy2DAsync_v2) < 0 ||
         rpc_write(conn, &copy, sizeof(copy)) < 0 ||
-        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+        rpc_write_pitched_payload(conn, src_base, copy.WidthInBytes, copy.Height,
                           copy.srcPitch, 1, 0) < 0 ||
         rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3436,7 +3436,7 @@ extern "C" CUresult cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy,
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
         (return_value == CUDA_SUCCESS &&
-         rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+         rpc_read_pitched_payload(conn, dst_base, copy.WidthInBytes, copy.Height,
                           copy.dstPitch, 1, 0) < 0) ||
         rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -3557,7 +3557,7 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
     if (lupine_prepare_rpc(conn) < 0 ||
         rpc_write_start_request(conn, RPC_cuMemcpy3D_v2) < 0 ||
         rpc_write(conn, &copy, sizeof(copy)) < 0 ||
-        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+        rpc_write_pitched_payload(conn, src_base, copy.WidthInBytes, copy.Height,
                           copy.srcPitch, copy.Depth, src_slice_pitch) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -3579,7 +3579,7 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
         (return_value == CUDA_SUCCESS &&
-         rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+         rpc_read_pitched_payload(conn, dst_base, copy.WidthInBytes, copy.Height,
                           copy.dstPitch, copy.Depth, dst_slice_pitch) < 0) ||
         rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -3686,7 +3686,7 @@ extern "C" CUresult cuMemcpy3DAsync_v2(const CUDA_MEMCPY3D *pCopy,
     if (lupine_prepare_rpc(conn) < 0 ||
         rpc_write_start_request(conn, RPC_cuMemcpy3DAsync_v2) < 0 ||
         rpc_write(conn, &copy, sizeof(copy)) < 0 ||
-        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+        rpc_write_pitched_payload(conn, src_base, copy.WidthInBytes, copy.Height,
                           copy.srcPitch, copy.Depth, src_slice_pitch) < 0 ||
         rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3710,7 +3710,7 @@ extern "C" CUresult cuMemcpy3DAsync_v2(const CUDA_MEMCPY3D *pCopy,
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
         (return_value == CUDA_SUCCESS &&
-         rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+         rpc_read_pitched_payload(conn, dst_base, copy.WidthInBytes, copy.Height,
                           copy.dstPitch, copy.Depth, dst_slice_pitch) < 0) ||
         rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -3824,7 +3824,7 @@ extern "C" CUresult cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy) {
     if (lupine_prepare_rpc(conn) < 0 ||
         rpc_write_start_request(conn, RPC_cuMemcpy3DPeer) < 0 ||
         rpc_write(conn, &copy, sizeof(copy)) < 0 ||
-        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+        rpc_write_pitched_payload(conn, src_base, copy.WidthInBytes, copy.Height,
                           copy.srcPitch, copy.Depth, src_slice_pitch) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -3843,7 +3843,7 @@ extern "C" CUresult cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy) {
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
         (return_value == CUDA_SUCCESS &&
-         rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+         rpc_read_pitched_payload(conn, dst_base, copy.WidthInBytes, copy.Height,
                           copy.dstPitch, copy.Depth, dst_slice_pitch) < 0) ||
         rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -3930,7 +3930,7 @@ extern "C" CUresult cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy,
     if (lupine_prepare_rpc(conn) < 0 ||
         rpc_write_start_request(conn, RPC_cuMemcpy3DPeerAsync) < 0 ||
         rpc_write(conn, &copy, sizeof(copy)) < 0 ||
-        rpc_write_pitched(conn, src_base, copy.WidthInBytes, copy.Height,
+        rpc_write_pitched_payload(conn, src_base, copy.WidthInBytes, copy.Height,
                           copy.srcPitch, copy.Depth, src_slice_pitch) < 0 ||
         rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3951,7 +3951,7 @@ extern "C" CUresult cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy,
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
         (return_value == CUDA_SUCCESS &&
-         rpc_read_pitched(conn, dst_base, copy.WidthInBytes, copy.Height,
+         rpc_read_pitched_payload(conn, dst_base, copy.WidthInBytes, copy.Height,
                           copy.dstPitch, copy.Depth, dst_slice_pitch) < 0) ||
         rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;

--- a/cuda_server_memcpy.cpp
+++ b/cuda_server_memcpy.cpp
@@ -1689,9 +1689,6 @@ int handle_cuMemcpy3DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -1715,9 +1712,6 @@ int handle_cuMemcpy3DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
@@ -1738,9 +1732,6 @@ int handle_cuMemcpy3DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -1866,9 +1857,6 @@ int handle_cuMemcpy3DPeerAsync(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DPeerAsync(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -1892,9 +1880,6 @@ int handle_cuMemcpy3DPeerAsync(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DPeerAsync(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
@@ -1915,9 +1900,6 @@ int handle_cuMemcpy3DPeerAsync(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy3DPeerAsync(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -2106,9 +2088,6 @@ int handle_cuMemcpy2DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy2DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {
@@ -2129,9 +2108,6 @@ int handle_cuMemcpy2DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy2DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
@@ -2151,9 +2127,6 @@ int handle_cuMemcpy2DAsync_v2(conn_t *conn) {
       return -1;
     }
     CUresult result = cuMemcpy2DAsync_v2(&copy, stream);
-    if (result == CUDA_SUCCESS) {
-      result = cuStreamSynchronize(stream);
-    }
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         rpc_write_end(conn) < 0) {

--- a/cuda_server_memcpy.cpp
+++ b/cuda_server_memcpy.cpp
@@ -1598,7 +1598,7 @@ int handle_cuMemcpy3D_v2(conn_t *conn) {
                                     (copy.Height - 1) * copy.srcPitch + offset +
                                     copy.WidthInBytes);
     copy.srcHost = host.data();
-    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+    if (rpc_read_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                          copy.Height, copy.srcPitch, copy.Depth, slice) < 0) {
       return -1;
     }
@@ -1630,7 +1630,7 @@ int handle_cuMemcpy3D_v2(conn_t *conn) {
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
-         rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+         rpc_write_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                            copy.Height, copy.dstPitch, copy.Depth,
                            slice) < 0) ||
         rpc_write_end(conn) < 0) {
@@ -1679,7 +1679,7 @@ int handle_cuMemcpy3DAsync_v2(conn_t *conn) {
                                     (copy.Height - 1) * copy.srcPitch + offset +
                                     copy.WidthInBytes);
     copy.srcHost = host.data();
-    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+    if (rpc_read_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                          copy.Height, copy.srcPitch, copy.Depth, slice) < 0 ||
         rpc_read(conn, &stream, sizeof(stream)) < 0) {
       return -1;
@@ -1715,7 +1715,7 @@ int handle_cuMemcpy3DAsync_v2(conn_t *conn) {
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
-         rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+         rpc_write_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                            copy.Height, copy.dstPitch, copy.Depth,
                            slice) < 0) ||
         rpc_write_end(conn) < 0) {
@@ -1766,7 +1766,7 @@ int handle_cuMemcpy3DPeer(conn_t *conn) {
                                     (copy.Height - 1) * copy.srcPitch + offset +
                                     copy.WidthInBytes);
     copy.srcHost = host.data();
-    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+    if (rpc_read_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                          copy.Height, copy.srcPitch, copy.Depth, slice) < 0) {
       return -1;
     }
@@ -1798,7 +1798,7 @@ int handle_cuMemcpy3DPeer(conn_t *conn) {
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
-         rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+         rpc_write_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                            copy.Height, copy.dstPitch, copy.Depth,
                            slice) < 0) ||
         rpc_write_end(conn) < 0) {
@@ -1847,7 +1847,7 @@ int handle_cuMemcpy3DPeerAsync(conn_t *conn) {
                                     (copy.Height - 1) * copy.srcPitch + offset +
                                     copy.WidthInBytes);
     copy.srcHost = host.data();
-    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+    if (rpc_read_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                          copy.Height, copy.srcPitch, copy.Depth, slice) < 0 ||
         rpc_read(conn, &stream, sizeof(stream)) < 0) {
       return -1;
@@ -1883,7 +1883,7 @@ int handle_cuMemcpy3DPeerAsync(conn_t *conn) {
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
-         rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+         rpc_write_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                            copy.Height, copy.dstPitch, copy.Depth,
                            slice) < 0) ||
         rpc_write_end(conn) < 0) {
@@ -1931,7 +1931,7 @@ int handle_cuMemcpy2D_v2(conn_t *conn) {
     std::vector<unsigned char> host((copy.Height - 1) * copy.srcPitch + offset +
                                     copy.WidthInBytes);
     copy.srcHost = host.data();
-    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+    if (rpc_read_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                          copy.Height, copy.srcPitch, 1, 0) < 0) {
       return -1;
     }
@@ -1960,7 +1960,7 @@ int handle_cuMemcpy2D_v2(conn_t *conn) {
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
-         rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+         rpc_write_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                            copy.Height, copy.dstPitch, 1, 0) < 0) ||
         rpc_write_end(conn) < 0) {
       return -1;
@@ -2004,7 +2004,7 @@ int handle_cuMemcpy2DUnaligned_v2(conn_t *conn) {
     std::vector<unsigned char> host((copy.Height - 1) * copy.srcPitch + offset +
                                     copy.WidthInBytes);
     copy.srcHost = host.data();
-    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+    if (rpc_read_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                          copy.Height, copy.srcPitch, 1, 0) < 0) {
       return -1;
     }
@@ -2033,7 +2033,7 @@ int handle_cuMemcpy2DUnaligned_v2(conn_t *conn) {
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
-         rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+         rpc_write_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                            copy.Height, copy.dstPitch, 1, 0) < 0) ||
         rpc_write_end(conn) < 0) {
       return -1;
@@ -2078,7 +2078,7 @@ int handle_cuMemcpy2DAsync_v2(conn_t *conn) {
     std::vector<unsigned char> host((copy.Height - 1) * copy.srcPitch + offset +
                                     copy.WidthInBytes);
     copy.srcHost = host.data();
-    if (rpc_read_pitched(conn, host.data() + offset, copy.WidthInBytes,
+    if (rpc_read_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                          copy.Height, copy.srcPitch, 1, 0) < 0 ||
         rpc_read(conn, &stream, sizeof(stream)) < 0) {
       return -1;
@@ -2111,7 +2111,7 @@ int handle_cuMemcpy2DAsync_v2(conn_t *conn) {
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
         (result == CUDA_SUCCESS &&
-         rpc_write_pitched(conn, host.data() + offset, copy.WidthInBytes,
+         rpc_write_pitched_payload(conn, host.data() + offset, copy.WidthInBytes,
                            copy.Height, copy.dstPitch, 1, 0) < 0) ||
         rpc_write_end(conn) < 0) {
       return -1;

--- a/h2.cpp
+++ b/h2.cpp
@@ -77,6 +77,9 @@ struct h2_transport {
   // flight (see h2_materialize_block). Writes are serialized per connection,
   // so a single buffer suffices and memory stays bounded by one block.
   std::vector<unsigned char> compress_scratch;
+  // Holds one gathered block of a pitched payload; only the cursor currently
+  // being materialized ever uses it, exactly like compress_scratch.
+  std::vector<unsigned char> gather_scratch;
   pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_cond_t session_progress = PTHREAD_COND_INITIALIZER;
   pthread_cond_t heartbeat_progress = PTHREAD_COND_INITIALIZER;
@@ -272,8 +275,31 @@ void h2_materialize_block(h2_transport *transport, rpc_write_cursor &cursor) {
     transport->compress_scratch.resize(sizeof(uint32_t) + bound);
   }
   unsigned char *out = transport->compress_scratch.data();
+
+  // A pitched source is gathered into a second scratch first: LZ4 needs its
+  // input contiguous, and the rows have padding between them that should reach
+  // neither the compressor nor the wire. The stored path below would copy the
+  // block anyway, so this costs a pass only when the block actually compresses.
+  const unsigned char *block = cursor.source;
+  if (cursor.is_pitched()) {
+    if (transport->gather_scratch.size() < LUPINE_COMPRESS_BLOCK_BYTES) {
+      transport->gather_scratch.resize(LUPINE_COMPRESS_BLOCK_BYTES);
+    }
+    unsigned char *packed = transport->gather_scratch.data();
+    size_t filled = 0;
+    while (filled < raw) {
+      size_t run = 0;
+      const unsigned char *from =
+          cursor.packed_at(cursor.packed_offset + filled, &run);
+      size_t take = std::min(run, raw - filled);
+      memcpy(packed + filled, from, take);
+      filled += take;
+    }
+    block = packed;
+  }
+
   int compressed =
-      LZ4_compress_default(reinterpret_cast<const char *>(cursor.source),
+      LZ4_compress_default(reinterpret_cast<const char *>(block),
                            reinterpret_cast<char *>(out + sizeof(uint32_t)),
                            static_cast<int>(raw), static_cast<int>(bound));
   uint32_t token = 0;
@@ -282,12 +308,15 @@ void h2_materialize_block(h2_transport *transport, rpc_write_cursor &cursor) {
     token = static_cast<uint32_t>(compressed);
     block_len = static_cast<size_t>(compressed);
   } else {
-    memcpy(out + sizeof(uint32_t), cursor.source, raw);
+    memcpy(out + sizeof(uint32_t), block, raw);
   }
   memcpy(out, &token, sizeof(token));
   cursor.data = out;
   cursor.size = sizeof(uint32_t) + block_len;
-  cursor.source += raw;
+  if (!cursor.is_pitched()) {
+    cursor.source += raw;
+  }
+  cursor.packed_offset += raw;
   cursor.source_size -= raw;
 }
 

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -592,6 +592,60 @@ int rpc_read_payload(conn_t *conn, void *data, size_t size) {
   return rpc_read_into_context(conn, data, size, rpc_read_framed_payload);
 }
 
+// Reads a pitched region that was sent as one framed payload. The payload
+// arrives packed and compressed, so it is decoded a block at a time into a
+// bounded buffer and scattered across the rows.
+int rpc_read_pitched_payload(conn_t *conn, void *data, size_t width,
+                             size_t rows, size_t row_stride, size_t slices,
+                             size_t slice_stride) {
+  if (width == 0 || rows == 0 || slices == 0) {
+    return 0;
+  }
+  size_t total = width * rows * slices;
+  if (row_stride == width && (slices == 1 || slice_stride == width * rows)) {
+    return rpc_read_payload(conn, data, total);
+  }
+  // Framing is a property of the whole payload, so it is decided once here and
+  // every part read below either spans a whole block or runs to the end.
+  int framed = lupine_payload_framed(conn, total);
+  if (!framed) {
+    return rpc_read_pitched(conn, data, width, rows, row_stride, slices,
+                            slice_stride);
+  }
+
+  size_t staging_size = std::min(total, (size_t)LUPINE_COMPRESS_BLOCK_BYTES);
+  std::vector<unsigned char> packed;
+  try {
+    packed.resize(staging_size);
+  } catch (...) {
+    return -1;
+  }
+
+  size_t offset = 0;
+  while (offset < total) {
+    size_t chunk = std::min(staging_size, total - offset);
+    if (rpc_read_payload_part(conn, framed, packed.data(), chunk) < 0) {
+      return -1;
+    }
+    size_t filled = 0;
+    while (filled < chunk) {
+      size_t position = offset + filled;
+      size_t per_slice = width * rows;
+      size_t slice = position / per_slice;
+      size_t within = position % per_slice;
+      size_t row = within / width;
+      size_t column = within % width;
+      size_t run = std::min(width - column, chunk - filled);
+      memcpy(static_cast<char *>(data) + slice * slice_stride +
+                 row * row_stride + column,
+             packed.data() + filled, run);
+      filled += run;
+    }
+    offset += chunk;
+  }
+  return 0;
+}
+
 int rpc_read_pitched(conn_t *conn, void *data, size_t width, size_t rows,
                      size_t row_stride, size_t slices, size_t slice_stride) {
   for (size_t z = 0; z < slices; ++z) {
@@ -864,7 +918,10 @@ int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
   for (size_t i = 0; i < count; ++i) {
     if ((cursors[i].data == nullptr && cursors[i].size != 0) ||
         (cursors[i].source == nullptr && cursors[i].source_size != 0) ||
-        (cursors[i].size != 0 && cursors[i].source_size != 0)) {
+        (cursors[i].size != 0 && cursors[i].source_size != 0) ||
+        (cursors[i].is_pitched() &&
+         (cursors[i].row_stride < cursors[i].row_width ||
+          cursors[i].rows_per_slice == 0))) {
       return -1;
     }
     conn->write_queue.push_back(cursors[i]);
@@ -878,6 +935,30 @@ int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
 // rpc_write(). See compress.cpp for the framing format.
 int rpc_write_framed(conn_t *conn, const void *data, const size_t size) {
   return rpc_write_queue_push(conn, rpc_write_cursor::framed(data, size));
+}
+
+// Queues a pitched region as one framed payload. A region whose rows are
+// already back to back is handed over as an ordinary contiguous payload, so the
+// gather in the transport only runs when there is padding to skip.
+int rpc_write_pitched_payload(conn_t *conn, const void *data, size_t width,
+                              size_t rows, size_t row_stride, size_t slices,
+                              size_t slice_stride) {
+  if (width == 0 || rows == 0 || slices == 0) {
+    return 0;
+  }
+  size_t total = width * rows * slices;
+  if (row_stride == width && (slices == 1 || slice_stride == width * rows)) {
+    return rpc_write_payload(conn, data, total);
+  }
+  // The reader decides framing from the payload's total size, so a region the
+  // connection would not frame has to go out unframed, row by row.
+  if (!lupine_payload_framed(conn, total)) {
+    return rpc_write_pitched(conn, data, width, rows, row_stride, slices,
+                             slice_stride);
+  }
+  return rpc_write_queue_push(
+      conn, rpc_write_cursor::pitched(data, width, rows, row_stride, slices,
+                                      slice_stride));
 }
 
 // rpc_write_end finalizes the current request builder on the given connection

--- a/rpc.h
+++ b/rpc.h
@@ -19,16 +19,58 @@ struct rpc_write_cursor {
   size_t size = 0;
   const unsigned char *source = nullptr;
   size_t source_size = 0;
+  // Pitched geometry. row_width == 0 means source is contiguous and blocks are
+  // compressed straight out of it; otherwise the transport gathers rows out of
+  // source as it fills the block it was going to materialize anyway, so the
+  // padding between rows never reaches the wire and never reaches LZ4.
+  size_t row_width = 0;
+  size_t rows_per_slice = 0;
+  size_t row_stride = 0;
+  size_t slice_stride = 0;
+  size_t packed_offset = 0;
 
   static rpc_write_cursor plain(const void *data, size_t size) {
-    return {static_cast<const unsigned char *>(data), size, nullptr, 0};
+    rpc_write_cursor cursor;
+    cursor.data = static_cast<const unsigned char *>(data);
+    cursor.size = size;
+    return cursor;
   }
 
   static rpc_write_cursor framed(const void *data, size_t size) {
-    return {nullptr, 0, static_cast<const unsigned char *>(data), size};
+    rpc_write_cursor cursor;
+    cursor.source = static_cast<const unsigned char *>(data);
+    cursor.source_size = size;
+    return cursor;
+  }
+
+  static rpc_write_cursor pitched(const void *base, size_t width, size_t rows,
+                                  size_t row_stride, size_t slices,
+                                  size_t slice_stride) {
+    rpc_write_cursor cursor;
+    cursor.source = static_cast<const unsigned char *>(base);
+    cursor.source_size = width * rows * slices;
+    cursor.row_width = width;
+    cursor.rows_per_slice = rows;
+    cursor.row_stride = row_stride;
+    cursor.slice_stride = slice_stride;
+    return cursor;
   }
 
   size_t remaining() const { return size + source_size; }
+
+  bool is_pitched() const { return row_width != 0; }
+
+  // Source address of the payload byte at `offset` in the packed stream, and
+  // how many bytes of that row follow it.
+  const unsigned char *packed_at(size_t offset, size_t *run) const {
+    size_t per_slice = row_width * rows_per_slice;
+    size_t slice = offset / per_slice;
+    size_t within = offset % per_slice;
+    size_t row = within / row_width;
+    size_t column = within % row_width;
+    *run = row_width - column;
+    return source + slice * slice_stride + row * row_stride + column;
+  }
 };
 
 struct rpc_http2_read_stats {
@@ -176,6 +218,15 @@ extern int rpc_write(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_pitched(conn_t *conn, const void *data, size_t width,
                              size_t rows, size_t row_stride, size_t slices,
                              size_t slice_stride);
+// Pitched transfers sent as one compressed payload; the padding between rows
+// reaches neither LZ4 nor the wire.
+extern int rpc_write_pitched_payload(conn_t *conn, const void *data,
+                                     size_t width, size_t rows,
+                                     size_t row_stride, size_t slices,
+                                     size_t slice_stride);
+extern int rpc_read_pitched_payload(conn_t *conn, void *data, size_t width,
+                                    size_t rows, size_t row_stride,
+                                    size_t slices, size_t slice_stride);
 extern int rpc_read_pitched(conn_t *conn, void *data, size_t width, size_t rows,
                             size_t row_stride, size_t slices,
                             size_t slice_stride);

--- a/test/test_pitched_copy_roundtrip.cu
+++ b/test/test_pitched_copy_roundtrip.cu
@@ -1,0 +1,85 @@
+// 2D and 3D copies whose rows carry padding travel as a packed, compressed
+// payload. Exercises both sides of the size at which the connection starts
+// framing a payload, and both copy directions, checking every byte back.
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+bool check(cudaError_t result, const char *operation) {
+  if (result == cudaSuccess) {
+    return true;
+  }
+  std::fprintf(stderr, "FAIL: %s: %s\n", operation, cudaGetErrorString(result));
+  return false;
+}
+
+// Padding between rows must never reach the far side, so the destination rows
+// are pre-poisoned and the padding is checked to be untouched.
+bool roundtrip_2d(size_t width, size_t height, const char *label) {
+  const size_t host_pitch = width + 64;
+  std::vector<unsigned char> source(host_pitch * height);
+  std::vector<unsigned char> readback(host_pitch * height, 0xEE);
+  for (size_t row = 0; row < height; ++row) {
+    for (size_t column = 0; column < host_pitch; ++column) {
+      source[row * host_pitch + column] =
+          column < width
+              ? static_cast<unsigned char>((row * 31 + column) & 0xff)
+              : 0xAA;
+    }
+  }
+
+  void *device = nullptr;
+  size_t device_pitch = 0;
+  if (!check(cudaMallocPitch(&device, &device_pitch, width, height),
+             "cudaMallocPitch")) {
+    return false;
+  }
+  bool ok =
+      check(cudaMemcpy2D(device, device_pitch, source.data(), host_pitch, width,
+                         height, cudaMemcpyHostToDevice),
+            "cudaMemcpy2D HtoD") &&
+      check(cudaMemcpy2D(readback.data(), host_pitch, device, device_pitch,
+                         width, height, cudaMemcpyDeviceToHost),
+            "cudaMemcpy2D DtoH");
+  if (ok) {
+    for (size_t row = 0; row < height && ok; ++row) {
+      for (size_t column = 0; column < host_pitch && ok; ++column) {
+        unsigned char got = readback[row * host_pitch + column];
+        unsigned char want =
+            column < width
+                ? static_cast<unsigned char>((row * 31 + column) & 0xff)
+                : 0xEE; // padding must be left alone
+        if (got != want) {
+          std::fprintf(stderr,
+                       "FAIL: %s row %zu column %zu: got %02x want %02x\n",
+                       label, row, column, got, want);
+          ok = false;
+        }
+      }
+    }
+  }
+  cudaFree(device);
+  if (ok) {
+    std::printf("ok: %s (%zu x %zu, host pitch %zu)\n", label, width, height,
+                host_pitch);
+  }
+  return ok;
+}
+
+} // namespace
+
+int main() {
+  // 16 KiB of payload stays under the size at which payloads are framed; 1 MiB
+  // is comfortably over it, so both the packed-and-compressed path and the
+  // row-by-row fallback are covered.
+  if (!roundtrip_2d(256, 64, "unframed 2D with padding") ||
+      !roundtrip_2d(4096, 256, "framed 2D with padding") ||
+      !roundtrip_2d(1, 1024, "single-byte rows")) {
+    return 1;
+  }
+  std::printf("PASS: pitched copies round-trip through the payload path\n");
+  return 0;
+}


### PR DESCRIPTION
Stacked on #638.

`rpc_write_pitched` and `rpc_read_pitched` were a loop of raw per-row `rpc_write`/`rpc_read`. Every 2D and 3D transfer therefore crossed the wire uncompressed while linear transfers of the same bytes got LZ4, and the padding between rows was the only thing they skipped.

A pitched transfer is now a payload plus its geometry: packed, compressed, and streamed in bounded blocks like any other payload.

Packing the whole region first would have cost a full extra pass over the data. It does not need one. `h2_materialize_block` already materializes each 4 MiB block into the transport's scratch — when a block does not compress it literally `memcpy`s the source there. So the gather happens into the block the transport was going to build anyway: free on the stored path, one memcpy per block on the compressed path, and bounded to the existing 4 MiB scratch either way. `rpc_write_cursor` grows a pitched form carrying `row_width`, `rows_per_slice`, `row_stride` and `slice_stride`, and the framer walks rows out of it as it fills each block. A region whose rows are already back to back skips the gather entirely and takes the existing zero-copy contiguous path.

The read side decodes a block at a time into a bounded buffer and scatters it across the rows.

Framing is a property of the whole payload, not of a chunk: `lupine_payload_framed` frames only at 64 KiB and above, and only when the connection negotiated LZ4. Both new helpers therefore decide once from the total size and fall back to the row-by-row path when the answer is no, so a small pitched region cannot be written framed and read raw.

4 MiB padded 2D transfer of compressible data, ten iterations against a LAN server:

| | host to device | device to host |
| --- | --- | --- |
| before | 15.89 ms | 16.31 ms |
| after | 3.77 ms | 4.93 ms |

Bytes verified identical in both directions.

`test/test_pitched_copy_roundtrip.cu` round-trips padded 2D regions either side of the 64 KiB framing threshold and with single-byte rows, checking every byte and that the destination padding is left untouched.

Unit tests 9/9, custom driver-API tests 32/32, and cuda-samples 77 pass / 4 fail — the same four failures as a `main` baseline run.