### PR TITLE
Require LZ4 framing for every payload

### DIFF
--- a/compress.cpp
+++ b/compress.cpp
@@ -1,7 +1,6 @@
-// LZ4 compression for large host<->device memory transfer payloads.
+// LZ4 compression for host<->device memory transfer payloads.
 //
-// LZ4 framing is part of the wire protocol. A payload is framed when its total
-// (uncompressed) size is at least kLupineCompressMinBytes.
+// LZ4 framing is part of the wire protocol for every non-empty payload.
 // A framed payload is a sequence of blocks, each covering up to
 // LUPINE_COMPRESS_BLOCK_BYTES of uncompressed data:
 //
@@ -25,14 +24,11 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <cstdio>
-#include <cstring>
 #include <lz4.h>
 #include <stdlib.h>
 
 namespace {
 
-constexpr size_t kLupineCompressMinBytes = 64 * 1024;
 constexpr size_t kLupineCompressBlockBytes = LUPINE_COMPRESS_BLOCK_BYTES;
 
 static_assert(kLupineCompressBlockBytes <= LZ4_MAX_INPUT_SIZE,
@@ -40,40 +36,27 @@ static_assert(kLupineCompressBlockBytes <= LZ4_MAX_INPUT_SIZE,
 
 } // namespace
 
-int lupine_payload_framed(size_t total_size) {
-  return total_size >= kLupineCompressMinBytes;
-}
-
-// rpc_write_payload writes a bulk data payload, compressing it when the
-// payload is large enough. The payload is compressed lazily by the transport
-// as it streams to the socket; like rpc_write, the caller's buffer must stay
-// valid until rpc_write_end().
+// rpc_write_payload writes a framed data payload. The payload is compressed
+// lazily by the transport as it streams to the socket; like rpc_write, the
+// caller's buffer must stay valid until rpc_write_end().
 int rpc_write_payload(conn_t *conn, const void *data, size_t size) {
   if (size == 0) {
     return 0;
   }
-  if (!lupine_payload_framed(size)) {
-    return rpc_write(conn, data, size);
-  }
   return rpc_write_framed(conn, data, size);
 }
 
-// rpc_read_payload_part reads `size` uncompressed payload bytes. `framed`
-// must be computed once per payload via lupine_payload_framed() with the
-// payload's total size, so chunked readers stay consistent with the writer.
-// Each part read must either be a multiple of the block size or extend to the
-// end of the payload.
-int rpc_read_payload_part(conn_t *conn, int framed, void *data, size_t size) {
+// rpc_read_payload_part reads `size` uncompressed payload bytes. Each part
+// read must either be a multiple of the block size or extend to the end of the
+// payload.
+int rpc_read_payload_part(conn_t *conn, void *data, size_t size) {
   if (size == 0) {
     return 0;
   }
-  if (!framed) {
-    return rpc_read(conn, data, size);
-  }
-
   auto *dst = static_cast<char *>(data);
   size_t remaining = size;
   char *scratch = nullptr;
+  size_t scratch_size = 0;
   while (remaining > 0) {
     size_t raw = std::min(kLupineCompressBlockBytes, remaining);
     uint32_t token = 0;
@@ -92,12 +75,14 @@ int rpc_read_payload_part(conn_t *conn, int framed, void *data, size_t size) {
         free(scratch);
         return -1;
       }
-      if (scratch == nullptr) {
-        scratch = static_cast<char *>(malloc(static_cast<size_t>(
-            LZ4_compressBound(static_cast<int>(kLupineCompressBlockBytes)))));
-        if (scratch == nullptr) {
+      if (scratch_size < token) {
+        char *resized = static_cast<char *>(realloc(scratch, token));
+        if (resized == nullptr) {
+          free(scratch);
           return -1;
         }
+        scratch = resized;
+        scratch_size = token;
       }
       if (rpc_read(conn, scratch, token) < 0 ||
           LZ4_decompress_safe(scratch, dst, static_cast<int>(token),
@@ -113,13 +98,9 @@ int rpc_read_payload_part(conn_t *conn, int framed, void *data, size_t size) {
   return static_cast<int>(size);
 }
 
-// rpc_drain_payload discards `size` uncompressed payload bytes, honoring the
-// payload framing. Like rpc_read_payload_part, drains must start at a block
-// boundary of the payload.
-int rpc_drain_payload(conn_t *conn, int framed, size_t size) {
-  if (!framed) {
-    return rpc_drain(conn, size);
-  }
+// rpc_drain_payload discards `size` uncompressed payload bytes. Like
+// rpc_read_payload_part, drains must start at a block boundary of the payload.
+int rpc_drain_payload(conn_t *conn, size_t size) {
   size_t remaining = size;
   while (remaining > 0) {
     size_t raw = std::min(kLupineCompressBlockBytes, remaining);

--- a/compress.cpp
+++ b/compress.cpp
@@ -1,12 +1,7 @@
-// Optional LZ4 compression for large host<->device memory transfer payloads.
+// LZ4 compression for large host<->device memory transfer payloads.
 //
-// The client always advertises support with an "x-lupine-compress: lz4"
-// HTTP/2 request header and the server mirrors it, so both directions of a
-// connection frame large payloads; toward a peer that did not advertise
-// (e.g. an older client) the wire format stays byte-identical to before.
-//
-// A payload is framed only when both ends negotiated compression and the
-// total (uncompressed) payload size is at least LUPINE_COMPRESS_MIN_BYTES.
+// LZ4 framing is part of the wire protocol. A payload is framed when its total
+// (uncompressed) size is at least kLupineCompressMinBytes.
 // A framed payload is a sequence of blocks, each covering up to
 // LUPINE_COMPRESS_BLOCK_BYTES of uncompressed data:
 //
@@ -45,19 +40,19 @@ static_assert(kLupineCompressBlockBytes <= LZ4_MAX_INPUT_SIZE,
 
 } // namespace
 
-int lupine_payload_framed(conn_t *conn, size_t total_size) {
-  return total_size >= kLupineCompressMinBytes && rpc_http2_compress_lz4(conn);
+int lupine_payload_framed(size_t total_size) {
+  return total_size >= kLupineCompressMinBytes;
 }
 
 // rpc_write_payload writes a bulk data payload, compressing it when the
-// connection negotiated compression and the payload is large enough. The
-// payload is compressed lazily by the transport as it streams to the socket;
-// like rpc_write, the caller's buffer must stay valid until rpc_write_end().
+// payload is large enough. The payload is compressed lazily by the transport
+// as it streams to the socket; like rpc_write, the caller's buffer must stay
+// valid until rpc_write_end().
 int rpc_write_payload(conn_t *conn, const void *data, size_t size) {
   if (size == 0) {
     return 0;
   }
-  if (!lupine_payload_framed(conn, size)) {
+  if (!lupine_payload_framed(size)) {
     return rpc_write(conn, data, size);
   }
   return rpc_write_framed(conn, data, size);

--- a/cuda_server.h
+++ b/cuda_server.h
@@ -111,9 +111,9 @@ int handle_cuTensorMapEncodeTiled(conn_t *conn);
 bool lupine_server_initialize_connection(conn_t *conn);
 void lupine_server_cleanup_connection(conn_t *conn);
 
-int lupine_server_copy_htod_async(conn_t *conn, int framed,
-                                  CUdeviceptr destination, size_t bytes,
-                                  CUstream stream, CUresult &result);
+int lupine_server_copy_htod_async(conn_t *conn, CUdeviceptr destination,
+                                  size_t bytes, CUstream stream,
+                                  CUresult &result);
 
 int handle_cuDevicePrimaryCtxRetain(conn_t *conn);
 int handle_cuDevicePrimaryCtxRelease_v2(conn_t *conn);

--- a/cuda_server_memcpy.cpp
+++ b/cuda_server_memcpy.cpp
@@ -1164,7 +1164,7 @@ int handle_cuMemcpyHtoD_v2(conn_t *conn) {
     return -1;
   }
 
-  int framed = lupine_payload_framed(conn, bytes);
+  int framed = lupine_payload_framed(bytes);
   auto *state = lupine_staging_state_for(conn);
   CUcontext context = nullptr;
   CUdevice device = 0;
@@ -2150,7 +2150,7 @@ int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     return -1;
   }
 
-  int framed = lupine_payload_framed(conn, byteCount);
+  int framed = lupine_payload_framed(byteCount);
   CUstreamCaptureStatus capture_status = CU_STREAM_CAPTURE_STATUS_NONE;
   CUresult capture_query_result = CUDA_SUCCESS;
   if (stream != nullptr) {

--- a/cuda_server_memcpy.cpp
+++ b/cuda_server_memcpy.cpp
@@ -346,11 +346,10 @@ static void lupine_release_staging_window(lupine_staging_state &state,
 
 // Reads a payload into staging with the connection's window held, charging the
 // received bytes to the staging buffer rather than crediting them immediately.
-static int lupine_read_staged_payload(conn_t *conn, int framed, void *host,
-                                      size_t bytes,
+static int lupine_read_staged_payload(conn_t *conn, void *host, size_t bytes,
                                       rpc_http2_window_credit &held) {
   rpc_http2_window_hold_begin(conn);
-  int result = rpc_read_payload_part(conn, framed, host, bytes);
+  int result = rpc_read_payload_part(conn, host, bytes);
   rpc_http2_window_credit credit = rpc_http2_window_hold_end(conn);
   if (held.bytes != 0 && held.stream_id != credit.stream_id) {
     rpc_http2_window_release(conn, credit);
@@ -581,9 +580,9 @@ static void lupine_async_htod_discard_spill(lupine_staging_state &state,
 }
 
 static CUresult lupine_async_htod_enqueue_spill(
-    lupine_staging_state &state, conn_t *conn, int framed,
-    CUdeviceptr destination, size_t bytes, CUstream stream, CUcontext context,
-    bool *payload_consumed, bool *connection_failed) {
+    lupine_staging_state &state, conn_t *conn, CUdeviceptr destination,
+    size_t bytes, CUstream stream, CUcontext context, bool *payload_consumed,
+    bool *connection_failed) {
   if (payload_consumed != nullptr) {
     *payload_consumed = false;
   }
@@ -612,7 +611,7 @@ static CUresult lupine_async_htod_enqueue_spill(
   while (offset < bytes) {
     size_t chunk = std::min(LUPINE_HTOD_CHUNK_BYTES, bytes - offset);
     auto *chunk_host = static_cast<unsigned char *>(spill.ptr) + offset;
-    if (lupine_read_staged_payload(conn, framed, chunk_host, chunk,
+    if (lupine_read_staged_payload(conn, chunk_host, chunk,
                                    spill.held_window_credit) < 0) {
       if (spill.work_queued) {
         (void)lupine_async_htod_publish_spill(state, spill, stream);
@@ -635,7 +634,7 @@ static CUresult lupine_async_htod_enqueue_spill(
     offset += chunk;
     if (result != CUDA_SUCCESS) {
       (void)lupine_async_htod_publish_spill(state, spill, stream);
-      if (rpc_drain_payload(conn, framed, bytes - offset) < 0) {
+      if (rpc_drain_payload(conn, bytes - offset) < 0) {
         if (connection_failed != nullptr) {
           *connection_failed = true;
         }
@@ -991,28 +990,27 @@ int lupine_write_lifecycle_response(conn_t *conn, int request_id,
   return 0;
 }
 
-int lupine_copy_htod_serial(conn_t *conn, int framed, CUdeviceptr destination,
-                            size_t bytes, lupine_staging_state &state,
-                            CUresult *result) {
+int lupine_copy_htod_serial(conn_t *conn, CUdeviceptr destination, size_t bytes,
+                            lupine_staging_state &state, CUresult *result) {
   size_t chunk_bytes = std::min(LUPINE_HTOD_CHUNK_BYTES, bytes);
   lupine_staging staging =
       lupine_acquire_staging(chunk_bytes, state.sync_staging);
   if (chunk_bytes != 0 && staging.ptr == nullptr) {
     *result = CUDA_ERROR_OUT_OF_MEMORY;
-    return rpc_drain_payload(conn, framed, bytes) < 0 ? -1 : 0;
+    return rpc_drain_payload(conn, bytes) < 0 ? -1 : 0;
   }
 
   size_t offset = 0;
   while (*result == CUDA_SUCCESS && offset < bytes) {
     size_t chunk = std::min(chunk_bytes, bytes - offset);
-    if (rpc_read_payload_part(conn, framed, staging.ptr, chunk) < 0) {
+    if (rpc_read_payload_part(conn, staging.ptr, chunk) < 0) {
       lupine_release_staging(staging);
       return -1;
     }
     *result = cuMemcpyHtoD_v2(destination + offset, staging.ptr, chunk);
     offset += chunk;
     if (*result != CUDA_SUCCESS &&
-        rpc_drain_payload(conn, framed, bytes - offset) < 0) {
+        rpc_drain_payload(conn, bytes - offset) < 0) {
       lupine_release_staging(staging);
       return -1;
     }
@@ -1050,14 +1048,12 @@ static CUresult lupine_wait_sync_htod_events(
 // Returns 1 after consuming the payload, 0 when the serial path should handle
 // it, and -1 on a transport failure. The legacy stream preserves synchronous
 // memcpy ordering while two pinned slots overlap network receipt with DMA.
-static int lupine_copy_htod_pipelined(conn_t *conn, int framed,
-                                      CUdeviceptr destination, size_t bytes,
-                                      CUcontext context,
+static int lupine_copy_htod_pipelined(conn_t *conn, CUdeviceptr destination,
+                                      size_t bytes, CUcontext context,
                                       lupine_staging_state &state,
                                       CUresult *result) {
 #ifdef _WIN32
   (void)conn;
-  (void)framed;
   (void)destination;
   (void)bytes;
   (void)context;
@@ -1088,7 +1084,7 @@ static int lupine_copy_htod_pipelined(conn_t *conn, int framed,
       if (wait_result != CUDA_SUCCESS) {
         *result = wait_result;
         state.sync_htod.disabled = true;
-        if (rpc_drain_payload(conn, framed, bytes - offset) < 0) {
+        if (rpc_drain_payload(conn, bytes - offset) < 0) {
           lupine_destroy_sync_htod_events(events);
           return -1;
         }
@@ -1100,7 +1096,7 @@ static int lupine_copy_htod_pipelined(conn_t *conn, int framed,
 
     size_t chunk = std::min(LUPINE_SYNC_HTOD_SLOT_BYTES, bytes - offset);
     void *host = state.sync_htod.slots[slot];
-    if (rpc_read_payload_part(conn, framed, host, chunk) < 0) {
+    if (rpc_read_payload_part(conn, host, chunk) < 0) {
       state.sync_htod.disabled = true;
       (void)cuStreamSynchronize(CU_STREAM_LEGACY);
       lupine_destroy_sync_htod_events(events);
@@ -1113,7 +1109,7 @@ static int lupine_copy_htod_pipelined(conn_t *conn, int framed,
     if (copy_result != CUDA_SUCCESS) {
       *result = copy_result;
       state.sync_htod.disabled = true;
-      if (rpc_drain_payload(conn, framed, bytes - offset) < 0) {
+      if (rpc_drain_payload(conn, bytes - offset) < 0) {
         lupine_destroy_sync_htod_events(events);
         return -1;
       }
@@ -1128,11 +1124,11 @@ static int lupine_copy_htod_pipelined(conn_t *conn, int framed,
       if (synchronize_result != CUDA_SUCCESS) {
         *result = synchronize_result;
         state.sync_htod.disabled = true;
-        if (rpc_drain_payload(conn, framed, bytes - offset) < 0) {
+        if (rpc_drain_payload(conn, bytes - offset) < 0) {
           lupine_destroy_sync_htod_events(events);
           return -1;
         }
-      } else if (lupine_copy_htod_serial(conn, framed, destination + offset,
+      } else if (lupine_copy_htod_serial(conn, destination + offset,
                                          bytes - offset, state, result) < 0) {
         lupine_destroy_sync_htod_events(events);
         return -1;
@@ -1164,7 +1160,6 @@ int handle_cuMemcpyHtoD_v2(conn_t *conn) {
     return -1;
   }
 
-  int framed = lupine_payload_framed(bytes);
   auto *state = lupine_staging_state_for(conn);
   CUcontext context = nullptr;
   CUdevice device = 0;
@@ -1184,17 +1179,16 @@ int handle_cuMemcpyHtoD_v2(conn_t *conn) {
 
   int pipeline_result = 0;
   if (result == CUDA_SUCCESS) {
-    pipeline_result = lupine_copy_htod_pipelined(
-        conn, framed, destination, bytes, context, *state, &result);
+    pipeline_result = lupine_copy_htod_pipelined(conn, destination, bytes,
+                                                 context, *state, &result);
   }
-  if (pipeline_result < 0 ||
-      (pipeline_result == 0 && result == CUDA_SUCCESS &&
-       lupine_copy_htod_serial(conn, framed, destination, bytes, *state,
-                               &result) < 0)) {
+  if (pipeline_result < 0 || (pipeline_result == 0 && result == CUDA_SUCCESS &&
+                              lupine_copy_htod_serial(conn, destination, bytes,
+                                                      *state, &result) < 0)) {
     return -1;
   }
   if (pipeline_result == 0 && result != CUDA_SUCCESS &&
-      rpc_drain_payload(conn, framed, bytes) < 0) {
+      rpc_drain_payload(conn, bytes) < 0) {
     return -1;
   }
 
@@ -1491,9 +1485,9 @@ int handle_cuMemcpyDtoH_v2(conn_t *conn) {
                                  fallback_offset, stream);
 }
 
-int lupine_server_copy_htod_async(conn_t *conn, int framed,
-                                  CUdeviceptr dstDevice, size_t byteCount,
-                                  CUstream stream, CUresult &result) {
+int lupine_server_copy_htod_async(conn_t *conn, CUdeviceptr dstDevice,
+                                  size_t byteCount, CUstream stream,
+                                  CUresult &result) {
   auto *state = lupine_staging_state_for(conn);
   CUcontext context = nullptr;
   CUdevice device = 0;
@@ -1526,7 +1520,7 @@ int lupine_server_copy_htod_async(conn_t *conn, int framed,
       break;
     }
     size_t chunk = std::min(slot->size, byteCount - offset);
-    if (lupine_read_staged_payload(conn, framed, slot->ptr, chunk,
+    if (lupine_read_staged_payload(conn, slot->ptr, chunk,
                                    slot->held_window_credit) < 0) {
       return -1;
     }
@@ -1537,7 +1531,7 @@ int lupine_server_copy_htod_async(conn_t *conn, int framed,
     if (copy_result != CUDA_SUCCESS) {
       (void)lupine_async_htod_publish_slot(*state, slot, stream);
       result = copy_result;
-      if (rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
+      if (rpc_drain_payload(conn, byteCount - offset) < 0) {
         return -1;
       }
       break;
@@ -1547,7 +1541,7 @@ int lupine_server_copy_htod_async(conn_t *conn, int framed,
       // The copy was accepted but its completion could not be published.
       // Keep the slot quarantined until context teardown and report the CUDA
       // error without ever synchronizing the caller's stream.
-      if (rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
+      if (rpc_drain_payload(conn, byteCount - offset) < 0) {
         return -1;
       }
       break;
@@ -1559,16 +1553,16 @@ int lupine_server_copy_htod_async(conn_t *conn, int framed,
     bool connection_failed = false;
     size_t remaining = byteCount - offset;
     result = lupine_async_htod_enqueue_spill(
-        *state, conn, framed, dstDevice + offset, remaining, stream, context,
+        *state, conn, dstDevice + offset, remaining, stream, context,
         &payload_consumed, &connection_failed);
     if (connection_failed) {
       return -1;
     }
-    if (!payload_consumed && rpc_drain_payload(conn, framed, remaining) < 0) {
+    if (!payload_consumed && rpc_drain_payload(conn, remaining) < 0) {
       return -1;
     }
   } else if (result != CUDA_SUCCESS && offset == 0 &&
-             rpc_drain_payload(conn, framed, byteCount) < 0) {
+             rpc_drain_payload(conn, byteCount) < 0) {
     return -1;
   }
   return 0;
@@ -2150,7 +2144,6 @@ int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     return -1;
   }
 
-  int framed = lupine_payload_framed(byteCount);
   CUstreamCaptureStatus capture_status = CU_STREAM_CAPTURE_STATUS_NONE;
   CUresult capture_query_result = CUDA_SUCCESS;
   if (stream != nullptr) {
@@ -2158,7 +2151,7 @@ int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
   }
   if (capture_query_result != CUDA_SUCCESS) {
     result = capture_query_result;
-    if (rpc_drain_payload(conn, framed, byteCount) < 0) {
+    if (rpc_drain_payload(conn, byteCount) < 0) {
       return -1;
     }
   } else if (capture_status != CU_STREAM_CAPTURE_STATUS_NONE) {
@@ -2166,12 +2159,12 @@ int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     capture_host = lupine_alloc_capture_scratch(resources, byteCount);
     if (capture_host == nullptr && byteCount != 0) {
       result = CUDA_ERROR_OUT_OF_MEMORY;
-      if (rpc_drain_payload(conn, framed, byteCount) < 0) {
+      if (rpc_drain_payload(conn, byteCount) < 0) {
         return -1;
       }
     } else {
       if (byteCount != 0 &&
-          rpc_read_payload_part(conn, framed, capture_host, byteCount) < 0) {
+          rpc_read_payload_part(conn, capture_host, byteCount) < 0) {
         return -1;
       }
     }
@@ -2183,7 +2176,7 @@ int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       result = cuMemAllocHost(&host, byteCount);
     }
     if (result != CUDA_SUCCESS) {
-      if (rpc_drain_payload(conn, framed, byteCount) < 0) {
+      if (rpc_drain_payload(conn, byteCount) < 0) {
         return -1;
       }
     }
@@ -2191,7 +2184,7 @@ int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     while (result == CUDA_SUCCESS && offset < byteCount) {
       size_t chunk = std::min(LUPINE_HTOD_CHUNK_BYTES, byteCount - offset);
       auto *chunk_host = static_cast<unsigned char *>(host) + offset;
-      if (rpc_read_payload_part(conn, framed, chunk_host, chunk) < 0) {
+      if (rpc_read_payload_part(conn, chunk_host, chunk) < 0) {
         cuStreamSynchronize(stream);
         cuMemFreeHost(host);
         return -1;
@@ -2204,7 +2197,7 @@ int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
         cuMemFreeHost(host);
         result = copy_result;
         offset += chunk;
-        if (rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
+        if (rpc_drain_payload(conn, byteCount - offset) < 0) {
           return -1;
         }
         host = nullptr;
@@ -2220,8 +2213,8 @@ int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       }
     }
 #else
-    if (lupine_server_copy_htod_async(conn, framed, dstDevice, byteCount,
-                                      stream, result) < 0) {
+    if (lupine_server_copy_htod_async(conn, dstDevice, byteCount, stream,
+                                      result) < 0) {
       return -1;
     }
 #endif

--- a/cuda_server_memcpy.h
+++ b/cuda_server_memcpy.h
@@ -58,8 +58,7 @@ void lupine_server_prepare_context_destroy(conn_t *conn, CUcontext context);
 void lupine_server_prepare_primary_context(conn_t *conn, CUdevice device);
 int lupine_write_lifecycle_response(conn_t *conn, int request_id,
                                     CUresult result);
-int lupine_copy_htod_serial(conn_t *conn, int framed, CUdeviceptr destination,
-                            size_t bytes, lupine_staging_state &state,
-                            CUresult *result);
+int lupine_copy_htod_serial(conn_t *conn, CUdeviceptr destination, size_t bytes,
+                            lupine_staging_state &state, CUresult *result);
 
 #endif

--- a/h2.cpp
+++ b/h2.cpp
@@ -64,7 +64,6 @@ struct h2_transport {
   bool server = false;
   bool request_received = false;
   bool request_handled = false;
-  bool compress_lz4 = false;
   int32_t dispatch_stream_id = -1;
   nghttp2_session *session = nullptr;
   std::unordered_map<int32_t, h2_stream> streams;
@@ -436,8 +435,6 @@ nghttp2_nv h2_nv(const char *name, const char *value) {
           NGHTTP2_NV_FLAG_NO_COPY_NAME | NGHTTP2_NV_FLAG_NO_COPY_VALUE};
 }
 
-constexpr char kLupineCompressHeader[] = "x-lupine-compress";
-constexpr char kLupineCompressLz4[] = "lz4";
 constexpr char kLupineCudaVersionHeader[] = "x-lupine-cuda-version";
 constexpr char kLupineSessionHeader[] = "x-lupine-session";
 constexpr char kLupineVaBaseHeader[] = "x-lupine-va-base";
@@ -628,13 +625,8 @@ int h2_on_header_callback(nghttp2_session *, const nghttp2_frame *frame,
   h2_stream &stream = h2_get_stream(transport, frame->hd.stream_id);
   if (transport->server) {
     if (frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
-      if (namelen == strlen(kLupineCompressHeader) &&
-          memcmp(name, kLupineCompressHeader, namelen) == 0 &&
-          valuelen == strlen(kLupineCompressLz4) &&
-          memcmp(value, kLupineCompressLz4, valuelen) == 0) {
-        transport->compress_lz4 = true;
-      } else if (namelen == strlen(kLupineSessionHeader) &&
-                 memcmp(name, kLupineSessionHeader, namelen) == 0) {
+      if (namelen == strlen(kLupineSessionHeader) &&
+          memcmp(name, kLupineSessionHeader, namelen) == 0) {
         transport->session_id.assign(reinterpret_cast<const char *>(value),
                                      valuelen);
       } else if (namelen == strlen(kLupineVaBaseHeader) &&
@@ -872,11 +864,9 @@ int h2_init_direct(conn_t *conn, bool server, bool probe,
         h2_nv(":authority", "lupine"),
     };
     if (!probe) {
-      headers.push_back(h2_nv(kLupineCompressHeader, kLupineCompressLz4));
       if (session_id != nullptr && session_id[0] != '\0') {
         headers.push_back(h2_nv(kLupineSessionHeader, session_id));
       }
-      transport->compress_lz4 = true;
       if (conn->va_size != 0) {
         transport->local_va_base = h2_hex(conn->va_base);
         transport->local_va_size = h2_hex(conn->va_size);
@@ -1150,11 +1140,6 @@ int32_t rpc_http2_accept_stream(conn_t *conn) {
   }
   pthread_mutex_unlock(&transport->session_mutex);
   return stream_id;
-}
-
-int rpc_http2_compress_lz4(conn_t *conn) {
-  auto *transport = static_cast<h2_transport *>(conn->http2);
-  return transport != nullptr && transport->compress_lz4 ? 1 : 0;
 }
 
 const char *rpc_http2_session_id(conn_t *conn) {

--- a/h2.cpp
+++ b/h2.cpp
@@ -265,8 +265,7 @@ ssize_t h2_send_callback(nghttp2_session *, const uint8_t *data, size_t length,
 void h2_materialize_block(h2_transport *transport, rpc_write_cursor &cursor) {
   size_t raw =
       std::min<size_t>(LUPINE_COMPRESS_BLOCK_BYTES, cursor.source_size);
-  size_t bound =
-      static_cast<size_t>(LZ4_compressBound(LUPINE_COMPRESS_BLOCK_BYTES));
+  size_t bound = static_cast<size_t>(LZ4_compressBound(static_cast<int>(raw)));
   if (transport->compress_scratch.size() < sizeof(uint32_t) + bound) {
     transport->compress_scratch.resize(sizeof(uint32_t) + bound);
   }

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1159,6 +1159,14 @@ void test_rpc_write_buffer_cleans_up_on_transport_failure_and_destroy() {
           "rpc_conn_destroy retained the copy buffer");
 }
 
+void test_lz4_payload_size_threshold() {
+  constexpr size_t kCompressMinBytes = 64 * 1024;
+  require(!lupine_payload_framed(kCompressMinBytes - 1),
+          "payload below LZ4 threshold was framed");
+  require(lupine_payload_framed(kCompressMinBytes),
+          "payload at LZ4 threshold was not framed");
+}
+
 void test_rpc_lz4_payload_round_trip() {
   h2_pair pair = make_pair();
 
@@ -1371,6 +1379,7 @@ int main() {
   test_rpc_write_queue_grows();
   test_rpc_write_buffer_uses_fixed_allocation();
   test_rpc_write_buffer_cleans_up_on_transport_failure_and_destroy();
+  test_lz4_payload_size_threshold();
   test_rpc_lz4_payload_round_trip();
   test_rpc_repeated_responses_on_lane();
   test_response_wait_sends_transport_heartbeat();

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1159,14 +1159,6 @@ void test_rpc_write_buffer_cleans_up_on_transport_failure_and_destroy() {
           "rpc_conn_destroy retained the copy buffer");
 }
 
-void test_lz4_payload_size_threshold() {
-  constexpr size_t kCompressMinBytes = 64 * 1024;
-  require(!lupine_payload_framed(kCompressMinBytes - 1),
-          "payload below LZ4 threshold was framed");
-  require(lupine_payload_framed(kCompressMinBytes),
-          "payload at LZ4 threshold was not framed");
-}
-
 void test_rpc_lz4_payload_round_trip() {
   h2_pair pair = make_pair();
 
@@ -1379,7 +1371,6 @@ int main() {
   test_rpc_write_queue_grows();
   test_rpc_write_buffer_uses_fixed_allocation();
   test_rpc_write_buffer_cleans_up_on_transport_failure_and_destroy();
-  test_lz4_payload_size_threshold();
   test_rpc_lz4_payload_round_trip();
   test_rpc_repeated_responses_on_lane();
   test_response_wait_sends_transport_heartbeat();

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1004,10 +1004,10 @@ void test_framed_payload_round_trip() {
   std::thread reader([&] {
     received_prefix = read_string(&pair.server, prefix.size());
     size_t first = LUPINE_COMPRESS_BLOCK_BYTES;
-    require(rpc_read_payload_part(&pair.server, 1, received.data(), first) ==
+    require(rpc_read_payload_part(&pair.server, received.data(), first) ==
                 static_cast<int>(first),
             "framed read part 1 failed");
-    require(rpc_read_payload_part(&pair.server, 1, received.data() + first,
+    require(rpc_read_payload_part(&pair.server, received.data() + first,
                                   received.size() - first) ==
                 static_cast<int>(received.size() - first),
             "framed read part 2 failed");
@@ -1159,13 +1159,13 @@ void test_rpc_write_buffer_cleans_up_on_transport_failure_and_destroy() {
           "rpc_conn_destroy retained the copy buffer");
 }
 
-void test_rpc_lz4_payload_round_trip() {
+void test_rpc_lz4_small_payload_round_trip() {
   h2_pair pair = make_pair();
 
   std::string prefix = "before";
   std::string suffix = "after";
   constexpr int kOp = 79;
-  std::vector<char> payload(LUPINE_COMPRESS_BLOCK_BYTES + 128 * 1024);
+  std::vector<char> payload(1024);
   for (size_t i = 0; i < payload.size(); ++i) {
     payload[i] = static_cast<char>(i % 13);
   }
@@ -1173,7 +1173,6 @@ void test_rpc_lz4_payload_round_trip() {
   std::string received_prefix(prefix.size(), '\0');
   std::string received_suffix(suffix.size(), '\0');
   std::vector<char> received(payload.size());
-  const rpc_http2_read_stats before = read_stats(&pair.server);
   std::thread reader([&] {
     int32_t stream_id = rpc_http2_accept_stream(&pair.server);
     require(rpc_bind_http2_stream(&pair.server, stream_id) == 0,
@@ -1201,6 +1200,11 @@ void test_rpc_lz4_payload_round_trip() {
           "lz4 payload prefix write failed");
   require(rpc_write_payload(&pair.client, payload.data(), payload.size()) == 0,
           "lz4 payload payload write failed");
+  const rpc_write_cursor &payload_cursor = pair.client.write_queue.back();
+  require(payload_cursor.source ==
+                  reinterpret_cast<const unsigned char *>(payload.data()) &&
+              payload_cursor.source_size == payload.size(),
+          "small payload was not LZ4-framed");
   require(rpc_write(&pair.client, suffix.data(), suffix.size()) == 0,
           "lz4 payload suffix write failed");
   require(rpc_write_end(&pair.client) > 0, "lz4 payload write_end failed");
@@ -1209,9 +1213,6 @@ void test_rpc_lz4_payload_round_trip() {
   require(received_prefix == prefix, "lz4 payload prefix mismatch");
   require(received == payload, "lz4 payload payload mismatch");
   require(received_suffix == suffix, "lz4 payload suffix mismatch");
-  const rpc_http2_read_stats after = read_stats(&pair.server);
-  require(after.direct_bytes > before.direct_bytes,
-          "lz4 payload did not use direct receive");
 }
 
 void test_rpc_repeated_responses_on_lane() {
@@ -1371,7 +1372,7 @@ int main() {
   test_rpc_write_queue_grows();
   test_rpc_write_buffer_uses_fixed_allocation();
   test_rpc_write_buffer_cleans_up_on_transport_failure_and_destroy();
-  test_rpc_lz4_payload_round_trip();
+  test_rpc_lz4_small_payload_round_trip();
   test_rpc_repeated_responses_on_lane();
   test_response_wait_sends_transport_heartbeat();
   test_client_to_server();

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -588,8 +588,7 @@ static int rpc_read_http2(conn_t *conn, void *data, size_t size) {
 }
 
 static int rpc_read_framed_payload(conn_t *conn, void *data, size_t size) {
-  return rpc_read_payload_part(conn, lupine_payload_framed(conn, size), data,
-                               size);
+  return rpc_read_payload_part(conn, lupine_payload_framed(size), data, size);
 }
 
 int rpc_read(conn_t *conn, void *data, size_t size) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -588,7 +588,7 @@ static int rpc_read_http2(conn_t *conn, void *data, size_t size) {
 }
 
 static int rpc_read_framed_payload(conn_t *conn, void *data, size_t size) {
-  return rpc_read_payload_part(conn, lupine_payload_framed(size), data, size);
+  return rpc_read_payload_part(conn, data, size);
 }
 
 int rpc_read(conn_t *conn, void *data, size_t size) {

--- a/rpc.h
+++ b/rpc.h
@@ -5,9 +5,9 @@
 #include <stdint.h>
 #include <vector>
 
-// Uncompressed block size for the optional LZ4 payload framing. The framed
-// bytes are produced lazily, one block at a time, by the HTTP/2 transport
-// (h2.cpp) and decoded by the rpc_read_payload helpers (compress.cpp).
+// Uncompressed block size for LZ4 payload framing. The framed bytes are
+// produced lazily, one block at a time, by the HTTP/2 transport (h2.cpp) and
+// decoded by the rpc_read_payload helpers (compress.cpp).
 #define LUPINE_COMPRESS_BLOCK_BYTES (4 * 1024 * 1024)
 
 // References caller-owned bytes while an RPC is being serialized. Plain
@@ -263,7 +263,6 @@ extern int rpc_http2_server_init(conn_t *conn);
 extern int
 rpc_http2_server_init_with_metadata(conn_t *conn,
                                     const rpc_http2_server_metadata *metadata);
-extern int rpc_http2_compress_lz4(conn_t *conn);
 // Returns the x-lupine-session request header after the server has consumed
 // the HTTP/2 request headers, or nullptr when no session was supplied.
 extern const char *rpc_http2_session_id(conn_t *conn);
@@ -291,8 +290,8 @@ extern rpc_http2_window_credit rpc_http2_window_hold_end(conn_t *conn);
 extern void rpc_http2_window_release(conn_t *conn,
                                      rpc_http2_window_credit credit);
 
-// Optional LZ4 framing for large memory transfer payloads (see compress.cpp).
-extern int lupine_payload_framed(conn_t *conn, size_t total_size);
+// LZ4 framing for large memory transfer payloads (see compress.cpp).
+extern int lupine_payload_framed(size_t total_size);
 extern int rpc_write_payload(conn_t *conn, const void *data, size_t size);
 extern int rpc_read_payload(conn_t *conn, void *data, size_t size);
 extern int rpc_read_payload_part(conn_t *conn, int framed, void *data,

--- a/rpc.h
+++ b/rpc.h
@@ -290,12 +290,10 @@ extern rpc_http2_window_credit rpc_http2_window_hold_end(conn_t *conn);
 extern void rpc_http2_window_release(conn_t *conn,
                                      rpc_http2_window_credit credit);
 
-// LZ4 framing for large memory transfer payloads (see compress.cpp).
-extern int lupine_payload_framed(size_t total_size);
+// LZ4 framing for memory transfer payloads (see compress.cpp).
 extern int rpc_write_payload(conn_t *conn, const void *data, size_t size);
 extern int rpc_read_payload(conn_t *conn, void *data, size_t size);
-extern int rpc_read_payload_part(conn_t *conn, int framed, void *data,
-                                 size_t size);
-extern int rpc_drain_payload(conn_t *conn, int framed, size_t size);
+extern int rpc_read_payload_part(conn_t *conn, void *data, size_t size);
+extern int rpc_drain_payload(conn_t *conn, size_t size);
 
 #endif


### PR DESCRIPTION
## Summary

- frame every non-empty memory-transfer payload with LZ4, with no capability negotiation or size cutoff
- let each LZ4 result determine whether the block is sent compressed or stored raw
- remove the now-redundant framing flags from the RPC and CUDA staging paths
- size compression scratch space to the current raw block and transmitted compressed token
- cover a 1 KiB payload through the high-level RPC wrappers while retaining mixed compressed/raw multi-block coverage

## Testing

- `cmake --build build --parallel`
- `ctest --test-dir build --output-on-failure` (5/5 passed)
- CUDA 13.3 `lupine_driver_server` build

Fixes #643