### PR TITLE
test: cover cuPointerSetAttribute on managed allocations

### DIFF
--- a/test/cuda-python/known_failures.txt
+++ b/test/cuda-python/known_failures.txt
@@ -10,9 +10,6 @@ test_cudart.py::test_cudart_cudaGraphNodeGetDependencies_edgeData_outlives_call
 # #579 cuGraphAddNode
 test_cuda.py::test_graph_poly
 
-# #582 cuPointerSetAttribute(SYNC_MEMOPS)
-test_cuda.py::test_cuda_pointer_attr
-
 # #599 CUDA 11 cuGraphInstantiate_v2 with a log buffer (11.8 lane)
 test_cuda.py::test_cuda_graphMem_attr
 test_cudart.py::test_cudart_cudaGraphAddMemcpyNode1D

--- a/test/test_pointer_set_attribute.cu
+++ b/test/test_pointer_set_attribute.cu
@@ -6,12 +6,6 @@
 // kills the server process and takes the connection with it. This test sets
 // CU_POINTER_ATTRIBUTE_SYNC_MEMOPS (the only settable pointer attribute) and
 // then issues further driver calls to prove the connection survived.
-//
-// The attribute is also allocator-sensitive: the driver only accepts it on
-// allocations whose backing supports it, and rejects a virtual-memory backing
-// with CUDA_ERROR_NOT_SUPPORTED. Both cuMemAlloc and cuMemAllocManaged
-// pointers are covered so a change to how the server backs either allocator
-// cannot silently make the attribute unsettable.
 
 #include <cuda.h>
 
@@ -151,27 +145,6 @@ int main() {
     return 1;
   }
   CHECK(cuMemGetInfo(&free_bytes, &total_bytes));
-
-  // cuMemAllocManaged is backed by a different server-side allocator than
-  // cuMemAlloc, so it has to round-trip the attribute on its own.
-  CUdeviceptr managed = 0;
-  CHECK(cuMemAllocManaged(&managed, 4096, CU_MEM_ATTACH_GLOBAL));
-  static const int wanted_values[] = {1, 0};
-  for (int wanted : wanted_values) {
-    sync_memops = wanted;
-    CHECK(cuPointerSetAttribute(&sync_memops, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                managed));
-    observed = -1;
-    CHECK(cuPointerGetAttribute(&observed, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                managed));
-    if (observed != wanted) {
-      std::fprintf(stderr,
-                   "managed SYNC_MEMOPS read back as %d after setting %d\n",
-                   observed, wanted);
-      return 1;
-    }
-  }
-  CHECK(cuMemFree(managed));
 
   CHECK(cuMemFree(ptr));
   CHECK(cuDevicePrimaryCtxRelease(device));

--- a/test/test_pointer_set_attribute.cu
+++ b/test/test_pointer_set_attribute.cu
@@ -6,6 +6,12 @@
 // kills the server process and takes the connection with it. This test sets
 // CU_POINTER_ATTRIBUTE_SYNC_MEMOPS (the only settable pointer attribute) and
 // then issues further driver calls to prove the connection survived.
+//
+// The attribute is also allocator-sensitive: the driver only accepts it on
+// allocations whose backing supports it, and rejects a virtual-memory backing
+// with CUDA_ERROR_NOT_SUPPORTED. Both cuMemAlloc and cuMemAllocManaged
+// pointers are covered so a change to how the server backs either allocator
+// cannot silently make the attribute unsettable.
 
 #include <cuda.h>
 
@@ -145,6 +151,27 @@ int main() {
     return 1;
   }
   CHECK(cuMemGetInfo(&free_bytes, &total_bytes));
+
+  // cuMemAllocManaged is backed by a different server-side allocator than
+  // cuMemAlloc, so it has to round-trip the attribute on its own.
+  CUdeviceptr managed = 0;
+  CHECK(cuMemAllocManaged(&managed, 4096, CU_MEM_ATTACH_GLOBAL));
+  static const int wanted_values[] = {1, 0};
+  for (int wanted : wanted_values) {
+    sync_memops = wanted;
+    CHECK(cuPointerSetAttribute(&sync_memops, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                                managed));
+    observed = -1;
+    CHECK(cuPointerGetAttribute(&observed, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+                                managed));
+    if (observed != wanted) {
+      std::fprintf(stderr,
+                   "managed SYNC_MEMOPS read back as %d after setting %d\n",
+                   observed, wanted);
+      return 1;
+    }
+  }
+  CHECK(cuMemFree(managed));
 
   CHECK(cuMemFree(ptr));
   CHECK(cuDevicePrimaryCtxRelease(device));


### PR DESCRIPTION
Fixes #582.

`cuPointerSetAttribute(CU_POINTER_ATTRIBUTE_SYNC_MEMOPS)` returned `CUDA_ERROR_NOT_SUPPORTED` for `cuMemAllocManaged` pointers because the server backed managed allocations inside an identity VA arena with `cuMemCreate`/`cuMemMap`. The driver only accepts SYNC_MEMOPS on allocations whose backing supports it and rejects a virtual-memory backing outright, so the attribute was unsettable on every managed pointer while plain `cuMemAlloc` pointers worked.

#575 replaced that VMM backing with a native `cuMemAllocManaged` steered into the arena, which fixed the call. It merged seven minutes after this issue was filed, so the fix was never linked to it.

Verified by building both sides at b23618f8 (the commit the issue was filed against) and at 10da07ba (#575):

```
# b23618f8
cuMemAllocManaged: get -> CUDA_SUCCESS (v=0)
cuMemAllocManaged: set(1) -> CUDA_ERROR_NOT_SUPPORTED

# 10da07ba
cuMemAllocManaged: get -> CUDA_SUCCESS (v=1)
cuMemAllocManaged: set(1) -> CUDA_SUCCESS
```

The repo's own `test_pointer_set_attribute` only covered `cuMemAlloc`, so nothing here would have caught the managed path breaking again. This extends it to round-trip the attribute on a `cuMemAllocManaged` pointer too, and drops the cuda-python deselect.

Both checked against a server on inferable-node-008:

- `test_pointer_set_attribute` passes on this branch and fails on a b23618f8 client/server pair with `801 (CUDA_ERROR_NOT_SUPPORTED)` at the new managed set.
- `test_cuda.py::test_cuda_pointer_attr` passes through the shim; the rest of `test_cuda.py` is unchanged (3 failures, all the already-tracked #578/#579 graph ones).