### PR TITLE
test: enable passing nvJPEG resize samples

### DIFF
--- a/test/cuda-library-samples/known_failures.txt
+++ b/test/cuda-library-samples/known_failures.txt
@@ -10,10 +10,6 @@ cuFFT/lto_callback_window_1d/bin/r2c_c2r_legacy_callback_example
 cuFFT/lto_callback_window_1d/bin/r2c_c2r_lto_callback_example
 cuFFT/lto_callback_window_1d/bin/r2c_c2r_lto_nvrtc_callback_example
 
-# #597 nvJPEG resize buffer overflow
-nvJPEG/Image-Resize/imageResize
-nvJPEG/Image-Resize-WaterMark/imageResizeWatermark
-
 # #598 nvJPEG multiple decoder instances
 nvJPEG/nvJPEG-Decoder-MultipleInstances/nvJPEGDecMultipleInstances
 


### PR DESCRIPTION
## Summary

- remove the two nvJPEG resize samples from the known-failure list
- leave the nvJPEG MultipleInstances sample for #598 ignored
- make no runtime or dirty-tracking changes

## Why

Issue #597 no longer reproduces on current `main`; both resize samples pass through the shim after the newer pageable D2H work. The proposed plain-pinned-memory tracking change for #598 has been removed so its design can be reconsidered separately.

## Tests

- `nvJPEG/Image-Resize/imageResize`: PASS
- `nvJPEG/Image-Resize-WaterMark/imageResizeWatermark`: PASS

Closes #597