### PR TITLE
Serve HTTP/1.x requests on the RPC port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ endif()
 add_library(lupine_rpc_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch.cpp
 )
 lupine_internal_target(lupine_rpc_core)
 target_include_directories(lupine_rpc_core
@@ -449,6 +450,13 @@ if(BUILD_TESTING AND NOT WIN32)
     add_test(NAME h2_test COMMAND h2_test)
     lupine_scaled_timeout(h2_timeout 30)
     set_tests_properties(h2_test PROPERTIES TIMEOUT ${h2_timeout})
+
+    add_executable(dispatch_test ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_test.cpp)
+    target_link_libraries(dispatch_test PRIVATE lupine_rpc_core)
+    lupine_apply_sanitizer(dispatch_test)
+    add_test(NAME dispatch_test COMMAND dispatch_test)
+    lupine_scaled_timeout(dispatch_timeout 30)
+    set_tests_properties(dispatch_test PROPERTIES TIMEOUT ${dispatch_timeout})
 endif()
 
 # Linux-only, not merely Unix: these pair sockets with socketpair(), place

--- a/dispatch.cpp
+++ b/dispatch.cpp
@@ -1,0 +1,186 @@
+// Protocol dispatch for the server's single listening port. Lupine clients
+// speak prior-knowledge HTTP/2 and always open with the fixed 24-byte client
+// preface, so the first bytes of a connection identify the protocol without
+// consuming anything. Everything else on the port is treated as one plain
+// HTTP/1.x request so that curl, load balancer health checks, and future
+// HTTP/1.1-only consumers such as Prometheus can share the RPC port. The
+// RPC/non-RPC split is decided by the request route, not the HTTP version:
+// this file only detects the framing.
+
+#include "dispatch.h"
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include "lupine_log.h"
+
+namespace {
+
+constexpr char kH2Preface[] = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+constexpr size_t kH2PrefaceLength = sizeof(kH2Preface) - 1;
+// Bounds how long a connection may sit unidentified. Lupine clients send the
+// preface immediately after connecting, so only a silent or dribbling peer
+// ever waits this long.
+constexpr int kDispatchTimeoutMs = 5000;
+constexpr size_t kMaxHttp1RequestBytes = 8192;
+
+int remaining_ms(std::chrono::steady_clock::time_point deadline) {
+  auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+      deadline - std::chrono::steady_clock::now());
+  return static_cast<int>(remaining.count());
+}
+
+int wait_readable(lupine_socket_t fd, int timeout_ms) {
+#ifdef _WIN32
+  fd_set readable;
+  FD_ZERO(&readable);
+  FD_SET(fd, &readable);
+  timeval timeout = {timeout_ms / 1000, (timeout_ms % 1000) * 1000};
+  return select(0, &readable, nullptr, nullptr, &timeout);
+#else
+  struct pollfd descriptor = {fd, POLLIN, 0};
+  return poll(&descriptor, 1, timeout_ms);
+#endif
+}
+
+ssize_t peek_bytes(lupine_socket_t fd, unsigned char *data, size_t size) {
+#ifdef _WIN32
+  return recv(fd, reinterpret_cast<char *>(data), static_cast<int>(size),
+              MSG_PEEK);
+#else
+  return recv(fd, data, size, MSG_PEEK);
+#endif
+}
+
+bool send_all(lupine_socket_t fd, const std::string &data) {
+  size_t offset = 0;
+  while (offset < data.size()) {
+    struct iovec buffer = {const_cast<char *>(data.data()) + offset,
+                           data.size() - offset};
+    ssize_t sent = lupine_socket_sendv(fd, &buffer, 1);
+    if (sent <= 0) {
+      return false;
+    }
+    offset += static_cast<size_t>(sent);
+  }
+  return true;
+}
+
+std::string http1_response(int status, const char *reason,
+                           const std::string &body, bool include_body,
+                           const rpc_http2_server_metadata *metadata) {
+  std::string response = "HTTP/1.1 " + std::to_string(status) + " " + reason +
+                         "\r\n";
+  if (metadata != nullptr && metadata->backend_version != nullptr &&
+      metadata->backend_version[0] != '\0') {
+    // Same header the HTTP/2 version probe answers with, so an HTTP/1.1
+    // client learns the backend version the same way.
+    response += "x-lupine-cuda-version: ";
+    response += metadata->backend_version;
+    response += "\r\n";
+  }
+  response += "content-type: text/plain\r\n";
+  response += "content-length: " + std::to_string(body.size()) + "\r\n";
+  response += "connection: close\r\n\r\n";
+  if (include_body) {
+    response += body;
+  }
+  return response;
+}
+
+int serve_http1(lupine_socket_t fd, const rpc_http2_server_metadata *metadata,
+                std::chrono::steady_clock::time_point deadline) {
+  std::string request;
+  while (request.find("\r\n\r\n") == std::string::npos) {
+    if (request.size() >= kMaxHttp1RequestBytes) {
+      return -1;
+    }
+    int timeout_ms = remaining_ms(deadline);
+    if (timeout_ms <= 0 || wait_readable(fd, timeout_ms) <= 0) {
+      return -1;
+    }
+    char chunk[1024];
+    ssize_t received = lupine_socket_recv(fd, chunk, sizeof(chunk));
+    if (received < 0 && lupine_socket_error_is_intr()) {
+      continue;
+    }
+    if (received <= 0) {
+      return -1;
+    }
+    request.append(chunk, static_cast<size_t>(received));
+  }
+
+  std::string line = request.substr(0, request.find("\r\n"));
+  size_t method_end = line.find(' ');
+  size_t path_end =
+      method_end == std::string::npos ? std::string::npos
+                                      : line.find(' ', method_end + 1);
+  if (path_end == std::string::npos) {
+    send_all(fd, http1_response(400, "Bad Request", "bad request\n", true,
+                                metadata));
+    return 1;
+  }
+  std::string method = line.substr(0, method_end);
+  std::string path = line.substr(method_end + 1, path_end - method_end - 1);
+  LUPINE_LOG_DEBUG("HTTP/1.1 " << method << " " << path);
+
+  bool head = method == "HEAD";
+  if (path == "/" && (head || method == "GET")) {
+    send_all(fd, http1_response(200, "OK", "lupine\n", !head, metadata));
+  } else {
+    send_all(fd,
+             http1_response(404, "Not Found", "not found\n", !head, metadata));
+  }
+  return 1;
+}
+
+} // namespace
+
+int lupine_h2_preface_check(const unsigned char *data, size_t len) {
+  size_t compare = len < kH2PrefaceLength ? len : kH2PrefaceLength;
+  if (memcmp(data, kH2Preface, compare) != 0) {
+    return -1;
+  }
+  return len >= kH2PrefaceLength ? 1 : 0;
+}
+
+int lupine_connection_dispatch(lupine_socket_t connfd,
+                               const rpc_http2_server_metadata *metadata) {
+  auto deadline = std::chrono::steady_clock::now() +
+                  std::chrono::milliseconds(kDispatchTimeoutMs);
+  bool waited_for_first_byte = false;
+  for (;;) {
+    int timeout_ms = remaining_ms(deadline);
+    if (timeout_ms <= 0) {
+      return -1;
+    }
+    if (!waited_for_first_byte) {
+      if (wait_readable(connfd, timeout_ms) <= 0) {
+        return -1;
+      }
+      waited_for_first_byte = true;
+    }
+    unsigned char data[kH2PrefaceLength];
+    ssize_t received = peek_bytes(connfd, data, sizeof(data));
+    if (received < 0 && lupine_socket_error_is_intr()) {
+      continue;
+    }
+    if (received <= 0) {
+      return -1;
+    }
+    int verdict =
+        lupine_h2_preface_check(data, static_cast<size_t>(received));
+    if (verdict > 0) {
+      return 0;
+    }
+    if (verdict < 0) {
+      return serve_http1(connfd, metadata, deadline);
+    }
+    // A preface prefix shorter than 24 bytes: the bytes stay queued because
+    // of MSG_PEEK, so polling reports readable immediately. Sleep instead of
+    // spinning while the remainder is in flight.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}

--- a/dispatch.cpp
+++ b/dispatch.cpp
@@ -6,6 +6,11 @@
 // HTTP/1.1-only consumers such as Prometheus can share the RPC port. The
 // RPC/non-RPC split is decided by the request route, not the HTTP version:
 // this file only detects the framing.
+//
+// Reads block without an application deadline. Dispatch runs inside the
+// per-connection child, so a stalled peer only occupies its own child until
+// the keepalive options from lupine_socket_apply_transport_options declare
+// the peer dead and recv fails.
 
 #include "dispatch.h"
 
@@ -20,30 +25,7 @@ namespace {
 
 constexpr char kH2Preface[] = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 constexpr size_t kH2PrefaceLength = sizeof(kH2Preface) - 1;
-// Bounds how long a connection may sit unidentified. Lupine clients send the
-// preface immediately after connecting, so only a silent or dribbling peer
-// ever waits this long.
-constexpr int kDispatchTimeoutMs = 5000;
 constexpr size_t kMaxHttp1RequestBytes = 8192;
-
-int remaining_ms(std::chrono::steady_clock::time_point deadline) {
-  auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
-      deadline - std::chrono::steady_clock::now());
-  return static_cast<int>(remaining.count());
-}
-
-int wait_readable(lupine_socket_t fd, int timeout_ms) {
-#ifdef _WIN32
-  fd_set readable;
-  FD_ZERO(&readable);
-  FD_SET(fd, &readable);
-  timeval timeout = {timeout_ms / 1000, (timeout_ms % 1000) * 1000};
-  return select(0, &readable, nullptr, nullptr, &timeout);
-#else
-  struct pollfd descriptor = {fd, POLLIN, 0};
-  return poll(&descriptor, 1, timeout_ms);
-#endif
-}
 
 ssize_t peek_bytes(lupine_socket_t fd, unsigned char *data, size_t size) {
 #ifdef _WIN32
@@ -90,15 +72,11 @@ std::string http1_response(int status, const char *reason,
   return response;
 }
 
-int serve_http1(lupine_socket_t fd, const rpc_http2_server_metadata *metadata,
-                std::chrono::steady_clock::time_point deadline) {
+int serve_http1(lupine_socket_t fd,
+                const rpc_http2_server_metadata *metadata) {
   std::string request;
   while (request.find("\r\n\r\n") == std::string::npos) {
     if (request.size() >= kMaxHttp1RequestBytes) {
-      return -1;
-    }
-    int timeout_ms = remaining_ms(deadline);
-    if (timeout_ms <= 0 || wait_readable(fd, timeout_ms) <= 0) {
       return -1;
     }
     char chunk[1024];
@@ -148,20 +126,7 @@ int lupine_h2_preface_check(const unsigned char *data, size_t len) {
 
 int lupine_connection_dispatch(lupine_socket_t connfd,
                                const rpc_http2_server_metadata *metadata) {
-  auto deadline = std::chrono::steady_clock::now() +
-                  std::chrono::milliseconds(kDispatchTimeoutMs);
-  bool waited_for_first_byte = false;
   for (;;) {
-    int timeout_ms = remaining_ms(deadline);
-    if (timeout_ms <= 0) {
-      return -1;
-    }
-    if (!waited_for_first_byte) {
-      if (wait_readable(connfd, timeout_ms) <= 0) {
-        return -1;
-      }
-      waited_for_first_byte = true;
-    }
     unsigned char data[kH2PrefaceLength];
     ssize_t received = peek_bytes(connfd, data, sizeof(data));
     if (received < 0 && lupine_socket_error_is_intr()) {
@@ -176,11 +141,11 @@ int lupine_connection_dispatch(lupine_socket_t connfd,
       return 0;
     }
     if (verdict < 0) {
-      return serve_http1(connfd, metadata, deadline);
+      return serve_http1(connfd, metadata);
     }
     // A preface prefix shorter than 24 bytes: the bytes stay queued because
-    // of MSG_PEEK, so polling reports readable immediately. Sleep instead of
-    // spinning while the remainder is in flight.
+    // of MSG_PEEK, so another blocking peek returns immediately. Sleep
+    // instead of spinning while the remainder is in flight.
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 }

--- a/dispatch.h
+++ b/dispatch.h
@@ -17,8 +17,10 @@ int lupine_h2_preface_check(const unsigned char *data, size_t len);
 // in place for the nghttp2 session and returns 0. Anything else is answered
 // as a single HTTP/1.x request (HEAD / and GET / mirror the HTTP/2 version
 // probe; every other path is a 404) and returns 1 with the connection fully
-// served. Returns -1 when the peer sends nothing decidable in time or the
-// socket fails; the caller closes the socket for every nonzero result.
+// served. Returns -1 when the peer disconnects before the protocol is
+// decidable or the socket fails; the caller closes the socket for every
+// nonzero result. Reads block: a stalled peer holds only its own
+// per-connection child until the transport keepalive declares it dead.
 int lupine_connection_dispatch(lupine_socket_t connfd,
                                const rpc_http2_server_metadata *metadata);
 

--- a/dispatch.h
+++ b/dispatch.h
@@ -1,0 +1,25 @@
+#ifndef LUPINE_DISPATCH_H
+#define LUPINE_DISPATCH_H
+
+#include <cstddef>
+
+#include "lupine_platform.h"
+#include "rpc.h"
+
+// Classifies the first bytes of an accepted connection against the fixed
+// 24-byte HTTP/2 client connection preface. Returns 1 when `data` begins with
+// the complete preface, -1 when it can never become the preface, and 0 when
+// more bytes are needed to decide.
+int lupine_h2_preface_check(const unsigned char *data, size_t len);
+
+// Decides what protocol an accepted connection speaks before any RPC state
+// exists. The socket is only peeked at: an HTTP/2 preface leaves every byte
+// in place for the nghttp2 session and returns 0. Anything else is answered
+// as a single HTTP/1.x request (HEAD / and GET / mirror the HTTP/2 version
+// probe; every other path is a 404) and returns 1 with the connection fully
+// served. Returns -1 when the peer sends nothing decidable in time or the
+// socket fails; the caller closes the socket for every nonzero result.
+int lupine_connection_dispatch(lupine_socket_t connfd,
+                               const rpc_http2_server_metadata *metadata);
+
+#endif

--- a/dispatch_test.cpp
+++ b/dispatch_test.cpp
@@ -1,0 +1,182 @@
+// Covers the single-port protocol dispatch: an HTTP/2 preface must reach the
+// RPC path with nothing consumed, and anything else must be answered as one
+// HTTP/1.x request. Uses socketpair(), so this test is Unix-only like h2_test.
+
+#include "dispatch.h"
+
+#include <cstring>
+#include <stdio.h>
+#include <string>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+
+namespace {
+
+int failures = 0;
+
+void check(bool ok, const char *what) {
+  printf("%-5s %s\n", ok ? "ok" : "FAIL", what);
+  if (!ok) {
+    ++failures;
+  }
+}
+
+constexpr char kPreface[] = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+constexpr size_t kPrefaceLength = sizeof(kPreface) - 1;
+const rpc_http2_server_metadata kMetadata = {"13.0-test"};
+
+bool make_pair(int fds[2]) {
+  return socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0;
+}
+
+std::string read_response(int fd) {
+  std::string response;
+  char chunk[1024];
+  for (;;) {
+    ssize_t received = read(fd, chunk, sizeof(chunk));
+    if (received <= 0) {
+      break;
+    }
+    response.append(chunk, static_cast<size_t>(received));
+  }
+  return response;
+}
+
+void test_preface_check() {
+  const unsigned char *preface =
+      reinterpret_cast<const unsigned char *>(kPreface);
+  check(lupine_h2_preface_check(preface, kPrefaceLength) == 1,
+        "complete preface matches");
+  check(lupine_h2_preface_check(preface, 10) == 0,
+        "preface prefix is undecided");
+  check(lupine_h2_preface_check(
+            reinterpret_cast<const unsigned char *>("GET / HTTP/1.1"), 14) ==
+            -1,
+        "http/1.1 request line is rejected");
+  check(lupine_h2_preface_check(
+            reinterpret_cast<const unsigned char *>("POST / HTTP/1.1"), 15) ==
+            -1,
+        "POST diverges from PRI before the preface completes");
+}
+
+void test_preface_reaches_rpc_with_nothing_consumed() {
+  int fds[2];
+  if (!make_pair(fds)) {
+    check(false, "socketpair");
+    return;
+  }
+  std::string sent = std::string(kPreface) + "SETTINGS-bytes";
+  check(write(fds[1], sent.data(), sent.size()) ==
+            static_cast<ssize_t>(sent.size()),
+        "client writes preface");
+  check(lupine_connection_dispatch(fds[0], &kMetadata) == 0,
+        "preface dispatches to rpc");
+  char data[64] = {};
+  ssize_t received = read(fds[0], data, sent.size());
+  check(received == static_cast<ssize_t>(sent.size()) &&
+            memcmp(data, sent.data(), sent.size()) == 0,
+        "dispatch consumed nothing");
+  close(fds[0]);
+  close(fds[1]);
+}
+
+void test_split_preface_still_dispatches_to_rpc() {
+  int fds[2];
+  if (!make_pair(fds)) {
+    check(false, "socketpair");
+    return;
+  }
+  std::thread client([&]() {
+    write(fds[1], kPreface, 9);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    write(fds[1], kPreface + 9, kPrefaceLength - 9);
+  });
+  check(lupine_connection_dispatch(fds[0], &kMetadata) == 0,
+        "split preface dispatches to rpc");
+  client.join();
+  close(fds[0]);
+  close(fds[1]);
+}
+
+void test_http1_get_root() {
+  int fds[2];
+  if (!make_pair(fds)) {
+    check(false, "socketpair");
+    return;
+  }
+  const char request[] = "GET / HTTP/1.1\r\nhost: lupine\r\n\r\n";
+  write(fds[1], request, sizeof(request) - 1);
+  check(lupine_connection_dispatch(fds[0], &kMetadata) == 1,
+        "http/1.1 request is served here");
+  close(fds[0]);
+  std::string response = read_response(fds[1]);
+  check(response.rfind("HTTP/1.1 200 OK\r\n", 0) == 0, "GET / returns 200");
+  check(response.find("x-lupine-cuda-version: 13.0-test\r\n") !=
+            std::string::npos,
+        "GET / reports the backend version");
+  check(response.find("\r\n\r\nlupine\n") != std::string::npos,
+        "GET / has a body");
+  close(fds[1]);
+}
+
+void test_http1_head_root_has_no_body() {
+  int fds[2];
+  if (!make_pair(fds)) {
+    check(false, "socketpair");
+    return;
+  }
+  const char request[] = "HEAD / HTTP/1.1\r\n\r\n";
+  write(fds[1], request, sizeof(request) - 1);
+  check(lupine_connection_dispatch(fds[0], &kMetadata) == 1,
+        "HEAD / is served here");
+  close(fds[0]);
+  std::string response = read_response(fds[1]);
+  check(response.rfind("HTTP/1.1 200 OK\r\n", 0) == 0, "HEAD / returns 200");
+  check(response.find("\r\n\r\n") == response.size() - 4,
+        "HEAD / has no body");
+  close(fds[1]);
+}
+
+void test_http1_unknown_path_is_404() {
+  int fds[2];
+  if (!make_pair(fds)) {
+    check(false, "socketpair");
+    return;
+  }
+  const char request[] = "GET /metrics HTTP/1.1\r\n\r\n";
+  write(fds[1], request, sizeof(request) - 1);
+  check(lupine_connection_dispatch(fds[0], &kMetadata) == 1,
+        "unknown path is served here");
+  close(fds[0]);
+  std::string response = read_response(fds[1]);
+  check(response.rfind("HTTP/1.1 404 Not Found\r\n", 0) == 0,
+        "unknown path returns 404");
+  close(fds[1]);
+}
+
+void test_closed_peer_fails_dispatch() {
+  int fds[2];
+  if (!make_pair(fds)) {
+    check(false, "socketpair");
+    return;
+  }
+  close(fds[1]);
+  check(lupine_connection_dispatch(fds[0], &kMetadata) == -1,
+        "closed peer fails dispatch");
+  close(fds[0]);
+}
+
+} // namespace
+
+int main() {
+  test_preface_check();
+  test_preface_reaches_rpc_with_nothing_consumed();
+  test_split_preface_still_dispatches_to_rpc();
+  test_http1_get_root();
+  test_http1_head_root_has_no_body();
+  test_http1_unknown_path_is_404();
+  test_closed_peer_fails_dispatch();
+  printf("\ndispatch_test: %s\n", failures == 0 ? "PASS" : "FAIL");
+  return failures == 0 ? 0 : 1;
+}

--- a/server.cpp
+++ b/server.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #endif
 
+#include "dispatch.h"
 #include "ipc.h"
 #include "lupine_log.h"
 #include "rpc.h"
@@ -167,6 +168,26 @@ int rpc_server_dispatch(const rpc_handler_registry &handlers, conn_t *conn,
 
 int client_handler(lupine_socket_t connfd) {
   const rpc_handler_registry &handlers = lupine_rpc_handlers();
+  const rpc_http2_server_metadata metadata = {
+#ifdef LUPINE_BACKEND_VERSION
+      LUPINE_BACKEND_VERSION,
+#else
+      nullptr,
+#endif
+  };
+
+  // Identify the protocol before any RPC state exists: HTTP/2 preface means
+  // an RPC client, anything else is answered as plain HTTP/1.x and the
+  // connection is done.
+  if (lupine_connection_dispatch(connfd, &metadata) != 0) {
+    lupine_socket_close(connfd);
+#ifdef LUPINE_BUILD_CUDA_BACKEND
+    return lupine_server_checkpoint_child_finish();
+#else
+    return 0;
+#endif
+  }
+
   conn_t conn = {};
   if (rpc_conn_init(&conn, connfd, 1) < 0) {
     LUPINE_LOG_ERROR("Error initializing connection synchronization.");
@@ -177,13 +198,6 @@ int client_handler(lupine_socket_t connfd) {
 #endif
   }
 
-  const rpc_http2_server_metadata metadata = {
-#ifdef LUPINE_BACKEND_VERSION
-      LUPINE_BACKEND_VERSION,
-#else
-      nullptr,
-#endif
-  };
   int http2_init_result = rpc_http2_server_init_with_metadata(&conn, &metadata);
   if (http2_init_result < 0) {
     LUPINE_LOG_ERROR("Error initializing HTTP/2 connection.");


### PR DESCRIPTION
Follows the single-port discussion in #523.

## What changed

The connection child now peeks at the first bytes of an accepted connection before any RPC state exists:

- the fixed 24-byte HTTP/2 client preface proceeds into the existing nghttp2 path, with nothing consumed and `h2.cpp` untouched
- anything else is answered as a single HTTP/1.x request: `HEAD /` and `GET /` mirror the HTTP/2 version probe (including `x-lupine-cuda-version`), every other path returns 404
- undecidable connections time out after 5s

The RPC/non-RPC split stays a routing decision rather than an HTTP version one: the peek only detects framing, and both layers route by path (`POST /` is RPC). HTTP/1.1-only consumers such as Prometheus get answered on the same port, an HTTP/2 client asking for `GET /metrics` would land on the same route once it exists, and an HTTP/3 listener can later feed the same seam via Alt-Svc.

`/metrics` itself is intentionally not here; #523 can drop its separate `LUPINE_METRICS_PORT` listener and register the endpoint on this seam instead.

## Validation

- new `dispatch_test` covers: full/split preface reaching the RPC path with nothing consumed, `GET /` and `HEAD /` responses, 404 for unknown paths, closed-peer failure
- `dispatch_test`, `transport_test`, and `h2_test` pass locally (core-only build, macOS)
- GPU integration is CI-only for me; happy to iterate if the L4 jobs catch anything
