### PR TITLE
Add optimized CUDA scatter memcpy operation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,12 @@ if(LUPINE_BUILD_SERVER AND
         "LUPINE_BUILD_SERVER requires at least one available backend")
 endif()
 
+if(LUPINE_BUILD_SERVER AND LUPINE_BUILD_CUDA AND
+   NOT LUPINE_CUDA_DRIVER_LIBRARY)
+    enable_language(CUDA)
+    add_subdirectory(ops)
+endif()
+
 function(lupine_internal_target target)
     set_target_properties(${target} PROPERTIES
         POSITION_INDEPENDENT_CODE ON

--- a/ops/CMakeLists.txt
+++ b/ops/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(lupine_smemcpy STATIC smemcpy.cu)
+target_include_directories(lupine_smemcpy PUBLIC ${PROJECT_SOURCE_DIR})
+set_target_properties(lupine_smemcpy PROPERTIES
+    CUDA_STANDARD 17
+    CUDA_STANDARD_REQUIRED ON
+    POSITION_INDEPENDENT_CODE ON)
+
+if(BUILD_TESTING)
+    add_executable(smemcpy_test smemcpy_test.cu)
+    target_link_libraries(smemcpy_test PRIVATE lupine_smemcpy)
+    set_target_properties(smemcpy_test PROPERTIES
+        CUDA_STANDARD 17
+        CUDA_STANDARD_REQUIRED ON)
+    add_test(NAME smemcpy_test COMMAND smemcpy_test)
+    set_tests_properties(smemcpy_test PROPERTIES
+        SKIP_RETURN_CODE 77
+        TIMEOUT 120)
+endif()

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,211 @@
+# Scatter memcpy
+
+`smemcpy.cu` copies a packed, device-visible source fragment into a pitched 2D
+or 3D destination. It is intended for HtoD ring slots mapped into the GPU
+address space: the network side fills one contiguous slot and this operation
+restores the destination's row and slice discontinuities.
+
+`logical_offset` is the fragment's byte offset in the packed logical region.
+The caller owns both extents and must keep the fragment within them. There is
+no pointer, width, or stride alignment requirement for correctness.
+
+## Dispatch
+
+Call `lupine_smemcpy_prepare_launch` instead of constructing a kernel launch
+from `lupine_smemcpy_kernel` when possible. The prepared launch selects among:
+
+- packed 16-, 8-, 4-, 2-, and 1-byte copies;
+- pitched 16-, 8-, 4-, and 2-byte copies when no vector can cross a row;
+- a rebased 2D kernel when the fragment remains in one slice;
+- architecture- and product-tuned, padding-preserving atomic paths for
+  one- to three-byte rows;
+- latency-hiding narrow-row kernels for widths of one to three bytes; and
+- a general byte-addressed 3D fallback.
+
+The vector paths peel at most 127 initial bytes so full mapped-host transactions
+begin on a 128-byte boundary. The packed 16-byte path compiles to one
+`LDG.E.128` and one `STG.E.128` per thread on SM 7.5 and SM 8.9.
+
+## Alignment for maximum throughput
+
+Correctness never depends on alignment. For the fastest 16-byte packed path,
+the source and the destination coordinate of the fragment must have the same
+low four address bits:
+
+```text
+(source ^ destination_at(logical_offset)) & 15 == 0
+```
+
+For the pitched 16-byte path, all of the following are also required:
+
+- `destination`, `width`, `destination_row_stride`, and
+  `destination_slice_stride` are multiples of 16; and
+- the source and first destination coordinate are congruent modulo 16.
+
+The dispatcher automatically falls back through 8, 4, 2, and 1-byte accesses.
+CUDA allocations are strongly aligned, but an application-provided destination
+offset can still break congruence.
+
+### Narrow rows and atomic padding updates
+
+A one-byte row with a 256-byte pitch is a pathological ordinary store pattern:
+each useful byte occupies a different 32-byte sector. On selected GPUs, the
+dispatcher instead updates the aligned 32-bit word containing that byte with
+`atomicCAS`. This preserves the other three bytes while routing the update
+through the L2 atomic path rather than serialized L1TEX store wavefronts.
+For two- and three-byte rows, one CAS updates the entire useful row and preserves
+the remaining bytes in the word.
+
+The selection is deliberately architecture and product specific. The measured
+power-of-two pitch ranges and simultaneous CAS lane counts are:
+
+| GPU target | Width 1 | Width 2 | Width 3 |
+| --- | --- | --- | --- |
+| Pascal GP100 (SM 6.0) | 128–512: 4 | 64: 8; 128–512: 4 | 64: 8; 128–512: 4 |
+| Volta (SM 7.0) | 128–512: 4 | 64: 16; 128: 8; 256–512: 4 | 64–128: 16; 256–512: 4 |
+| Turing (SM 7.5) | 64: 8; 128–512: 4 | 128–256: 4 | 64: 16; 128–512: 4 |
+| Ampere A100-class (SM 8.0) | 256–512: 8 | ordinary stores | ordinary stores |
+| NVIDIA L4 (SM 8.9) | 64: 16; 128–512: 8 | 64–512: 16 | 64–512: 16 |
+
+An entry such as `128–512: 4` means pitches 128, 256, and 512 bytes with four
+active CAS lanes per warp group. Other pitches and widths use ordinary stores.
+
+Ada is not enabled solely by compute capability: the full-link L4 benefits,
+whereas the tested RTX 4090 is already limited by its PCIe x2 mapped-source
+bandwidth and loses throughput with CAS. Unmeasured SM variants, including
+Hopper, retain ordinary byte stores until measured.
+
+There is no destination pointer alignment requirement. Four kernel variants
+encode the destination's byte offset within its naturally aligned 32-bit word,
+the first row uses scalar stores when aligning down would precede the supplied
+destination pointer, and the final copied row is always scalar. Thus no source
+or destination headroom is needed beyond the normal pitched extent. Widths two
+and three take this path only for whole-row fragments whose useful bytes fit
+within one aligned 32-bit word; a row that crosses a word boundary falls back
+automatically. Interior atomic updates preserve padding values but do read and
+atomically rewrite their containing words. Do not concurrently modify those
+destination words from another stream, the host, or another device.
+
+For fragments crossing slice boundaries, the atomic path additionally requires
+`destination_slice_stride == rows * destination_row_stride`. Slice layouts with
+extra gaps and non-power-of-two row pitches use the ordinary byte-store kernel;
+their Turing L2 partition behavior made the atomic path slower in profiling.
+These restrictions are performance dispatch rules, not pointer-alignment
+requirements.
+
+## Mitigating an unknown destination shape
+
+Use a 128-byte-aligned ring base and round each slot stride to a multiple of
+128. If the destination is not known when the ring is allocated, reserve 15
+bytes of source headroom per slot. Once the copy descriptor is known, start the
+payload at:
+
+```text
+source = slot_base + (destination_at(logical_offset) & 15)
+```
+
+This makes the source and first destination coordinate congruent without
+moving the payload. Round the total slot size, including headroom, back to 128
+bytes. The kernel's short scalar prefix then reaches the next 128-byte source
+boundary before entering the vector loop.
+
+When source chunking is under Lupine's control, prefer 128-byte-multiple chunk
+sizes and begin a new chunk at a destination coordinate aligned to 16 bytes.
+That keeps every ring slot 128-byte aligned and avoids even the short prefix.
+The dispatcher evaluates the actual destination descriptor at launch time, so
+an unknown pitch only changes which vector width is chosen; it does not require
+a separate precompiled shape. Preserve the packed representation until that
+descriptor is available, then cache the prepared launch by width, strides,
+relative alignment, and GPU architecture.
+
+If destination padding is owned by the caller and may be overwritten, another
+option is to receive directly into a source slot with the same row and slice
+gaps, then copy the entire physical span. Use this only when padding inflation
+is small: it increases ring traffic and is not valid for CUDA memcpy semantics
+when padding must remain untouched. For normal application-owned destinations,
+the packed source plus scatter kernel is the safe path.
+
+For extremely sparse destinations, the largest win is to avoid materializing
+the gaps. Copy the packed bytes into a compact device allocation and either
+teach the consumer to use a compact view or fuse the scatter address calculation
+into the first consuming kernel. A separate compact HtoD copy followed by an
+unfused scatter usually loses because it adds another full pass; fusion removes
+the pathological standalone store entirely.
+
+If destination allocation is under partial control, bucket narrow shapes onto
+the power-of-two pitches in the architecture table. Prefer 128 or 256 bytes
+when the eventual GPU is also unknown: 128 activates GP100, Volta, Turing, and
+L4, while 256 additionally activates A100. If padding may be overwritten and
+the physical/logical size ratio is modest, receiving a shape-expanded source
+and copying the entire physical span can convert the operation back into a
+contiguous transfer. Do not use that strategy for a one-byte/256-byte-pitch
+tensor: its 256x traffic inflation is worse than the scatter.
+
+If receive placement cannot be changed after the destination becomes known,
+do not realign an already received large payload with another host copy. The
+128-byte prefix peel keeps the scalar fallback close to peak: on the test RTX
+4090, arbitrary relative alignment reached about 3.13 GB/s versus 3.18 GB/s for
+the vector path. Splitting a wide transfer into one launch per row is also
+usually counterproductive; native 2D/3D setup overhead can dominate narrow or
+deeply sliced shapes.
+
+For small fragments, kernel launch cost dominates. Batch adjacent packed
+fragments into one ring slot/launch when ordering permits. On the measured
+systems the scatter path approaches link bandwidth by roughly 256 KiB to 1
+MiB, while transfers of only a few KiB are primarily launch-bound.
+
+## Correctness testing
+
+`smemcpy_test` initializes two identical device allocations, writes one with a
+native CUDA copy and the other with scatter memcpy, then compares every byte of
+the physical allocations. Padding begins with a sentinel value, so the test
+also detects writes outside the logical region.
+
+The suite contains 156 comparisons plus invalid-parameter checks:
+
+- 21 packed and fragmented `cudaMemcpyAsync` 1D references;
+- 34 full-plane `cudaMemcpy2DAsync` references;
+- 16 full-volume `cudaMemcpy3DAsync` references with regular and gapped slice
+  strides; and
+- 85 targeted and deterministic-random fragmented references assembled from
+  native 1D row copies.
+
+Sizes around every vector boundary, mapped-source and destination offsets,
+power-of-two and irregular pitches, one- to three-byte atomic rows, tight
+allocation tails, partial rows, and cross-slice fragments are covered. Build
+and run it directly or through CTest:
+
+```sh
+cmake --build build --target smemcpy_test
+ctest --test-dir build -R smemcpy_test --output-on-failure
+```
+
+GPU-less test hosts return CTest skip code 77.
+
+## Performance rationale
+
+Nsight Compute on the SM 7.5 one-byte-row case reports that the ordinary kernel
+had no eligible warp for about 97.6% of scheduler cycles: each warp's byte store
+touched 32 destination sectors. The atomic kernel reduced an 8 MiB copy to
+2.09 ms (about 4.0 GB/s under the profiler), reduced no-eligible cycles to
+88.8%, and reached 88.9% of measured DRAM throughput. The useful-byte rate is
+still far below packed HtoD because each byte necessarily causes a full-sector
+destination transaction; without changing the destination representation,
+that traffic amplification is the remaining bound.
+
+On A100, Nsight Compute measured 448 GB/s of memory-system throughput for the
+ordinary pitch-256 kernel versus 908 GB/s for the eight-lane CAS kernel. Warp
+cycles per issued instruction fell from about 1531 to 279. This agrees with
+Nsight Compute's model: a scattered warp store is decomposed into serialized
+L1TEX wavefronts, while atomics are passed through to the L2 atomic hardware.
+
+The implementation follows NVIDIA's guidance that mapped pinned memory should
+be accessed once and with coalesced operations:
+
+- [CUDA C++ Best Practices Guide: Zero Copy](https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#zero-copy)
+- [CUDA C++ Programming Guide: Device Memory Accesses](https://docs.nvidia.com/cuda/archive/13.0.0/cuda-c-programming-guide/index.html#device-memory-accesses)
+- [Nsight Compute Profiling Guide: Memory Workload Analysis](https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#memory-workload-analysis)
+- [Pascal Tuning Guide: Atomic Memory Operations](https://docs.nvidia.com/cuda/pascal-tuning-guide/index.html#atomic-memory-operations)
+- [Volta Tuning Guide: Memory Throughput](https://docs.nvidia.com/cuda/volta-tuning-guide/index.html#memory-throughput)
+- [Ampere Tuning Guide: Memory System](https://docs.nvidia.com/cuda/ampere-tuning-guide/index.html#memory-system)
+- [Hopper Tuning Guide: Memory System](https://docs.nvidia.com/cuda/hopper-tuning-guide/index.html#memory-system)

--- a/ops/smemcpy.cu
+++ b/ops/smemcpy.cu
@@ -1,0 +1,826 @@
+#include "ops/smemcpy.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+namespace {
+
+constexpr unsigned int kThreadsPerBlock = 256;
+constexpr size_t kMaximumBlocks = 65535;
+constexpr size_t kSourceTransactionAlignment = 128;
+constexpr size_t kNarrowItemsPerThread = 4;
+
+template <size_t Bytes> struct word_type;
+template <> struct word_type<1> {
+  using type = unsigned char;
+};
+template <> struct word_type<2> {
+  using type = unsigned short;
+};
+template <> struct word_type<4> {
+  using type = unsigned int;
+};
+template <> struct word_type<8> {
+  using type = unsigned long long;
+};
+template <> struct word_type<16> {
+  using type = uint4;
+};
+
+__host__ __device__ __forceinline__ size_t source_prefix(CUdeviceptr source,
+                                                         size_t bytes) {
+  size_t prefix =
+      (-static_cast<size_t>(source)) & (kSourceTransactionAlignment - 1);
+  return prefix < bytes ? prefix : bytes;
+}
+
+__device__ __forceinline__ void
+scatter_byte(const lupine_smemcpy_params &params,
+             const unsigned char *__restrict__ source,
+             unsigned char *__restrict__ destination, size_t index) {
+  size_t logical = params.logical_offset + index;
+  size_t row_index = logical / params.width;
+  size_t x = logical - row_index * params.width;
+  size_t slice = row_index / params.rows;
+  size_t row = row_index - slice * params.rows;
+  destination[slice * params.destination_slice_stride +
+              row * params.destination_row_stride + x] = source[index];
+}
+
+__device__ __forceinline__ void
+scatter_2d_byte(const lupine_smemcpy_params &params,
+                const unsigned char *__restrict__ source,
+                unsigned char *__restrict__ destination, size_t index) {
+  size_t logical = params.logical_offset + index;
+  size_t row = logical / params.width;
+  size_t x = logical - row * params.width;
+  destination[row * params.destination_row_stride + x] = source[index];
+}
+
+template <size_t Width>
+__device__ __forceinline__ void
+scatter_narrow_store(const lupine_smemcpy_params &params,
+                     unsigned char *__restrict__ destination, size_t index,
+                     unsigned char value) {
+  size_t logical = params.logical_offset + index;
+  size_t row = logical / Width;
+  size_t x = logical - row * Width;
+  destination[row * params.destination_row_stride + x] = value;
+}
+
+template <size_t Width>
+__device__ __forceinline__ void
+scatter_narrow_3d_store(const lupine_smemcpy_params &params,
+                        unsigned char *__restrict__ destination, size_t index,
+                        unsigned char value) {
+  size_t logical = params.logical_offset + index;
+  size_t row_index = logical / Width;
+  size_t x = logical - row_index * Width;
+  size_t slice = row_index / params.rows;
+  size_t row = row_index - slice * params.rows;
+  destination[slice * params.destination_slice_stride +
+              row * params.destination_row_stride + x] = value;
+}
+
+template <unsigned int ByteOffset>
+__device__ __forceinline__ void
+atomic_store_byte(unsigned char *__restrict__ destination,
+                  const unsigned char *__restrict__ accessible_begin,
+                  unsigned char value) {
+  static_assert(ByteOffset < sizeof(unsigned int));
+  if constexpr (ByteOffset != 0) {
+    if (destination < accessible_begin + ByteOffset) {
+      *destination = value;
+      return;
+    }
+  }
+  auto *word = reinterpret_cast<unsigned int *>(destination - ByteOffset);
+  constexpr unsigned int shift = ByteOffset * 8;
+  constexpr unsigned int value_mask = 0xffU << shift;
+  unsigned int old = *word;
+  while (true) {
+    unsigned int replacement =
+        (old & ~value_mask) | (static_cast<unsigned int>(value) << shift);
+    unsigned int observed = atomicCAS(word, old, replacement);
+    if (observed == old) {
+      return;
+    }
+    old = observed;
+  }
+}
+
+template <size_t Width, unsigned int ByteOffset>
+__device__ __forceinline__ void
+atomic_store_row(unsigned char *__restrict__ destination,
+                 const unsigned char *__restrict__ accessible_begin,
+                 unsigned int value) {
+  static_assert(Width == 2 || Width == 3);
+  static_assert(ByteOffset + Width <= sizeof(unsigned int));
+  if constexpr (ByteOffset != 0) {
+    if (destination < accessible_begin + ByteOffset) {
+#pragma unroll
+      for (size_t x = 0; x < Width; ++x) {
+        destination[x] = static_cast<unsigned char>(value >> (x * 8));
+      }
+      return;
+    }
+  }
+  auto *word = reinterpret_cast<unsigned int *>(destination - ByteOffset);
+  constexpr unsigned int shift = ByteOffset * 8;
+  constexpr unsigned int value_mask = ((1U << (Width * 8)) - 1) << shift;
+  value <<= shift;
+  unsigned int old = *word;
+  while (true) {
+    unsigned int replacement = (old & ~value_mask) | value;
+    unsigned int observed = atomicCAS(word, old, replacement);
+    if (observed == old) {
+      return;
+    }
+    old = observed;
+  }
+}
+
+template <unsigned int ByteOffset>
+__device__ __forceinline__ void
+scatter_atomic_2d_store(const lupine_smemcpy_params &params,
+                        unsigned char *__restrict__ destination, size_t index,
+                        unsigned char value) {
+  size_t row = params.logical_offset + index;
+  atomic_store_byte<ByteOffset>(
+      destination + row * params.destination_row_stride, destination, value);
+}
+
+template <size_t WordBytes>
+__global__ void smemcpy_linear_kernel(lupine_smemcpy_params params) {
+  using word = typename word_type<WordBytes>::type;
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination) +
+      params.logical_offset;
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    destination[thread] = source[thread];
+  }
+
+  size_t bulk_bytes = (params.bytes - prefix) & ~(WordBytes - 1);
+  for (size_t index = prefix + thread * WordBytes; index < prefix + bulk_bytes;
+       index += step * WordBytes) {
+    *reinterpret_cast<word *>(destination + index) =
+        *reinterpret_cast<const word *>(source + index);
+  }
+
+  size_t tail = params.bytes - prefix - bulk_bytes;
+  if (thread < tail) {
+    size_t index = prefix + bulk_bytes + thread;
+    destination[index] = source[index];
+  }
+}
+
+template <size_t WordBytes>
+__global__ void smemcpy_pitched_vector_kernel(lupine_smemcpy_params params) {
+  using word = typename word_type<WordBytes>::type;
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_byte(params, source, destination, thread);
+  }
+
+  size_t bulk_bytes = (params.bytes - prefix) & ~(WordBytes - 1);
+  for (size_t index = prefix + thread * WordBytes; index < prefix + bulk_bytes;
+       index += step * WordBytes) {
+    size_t logical = params.logical_offset + index;
+    size_t row_index = logical / params.width;
+    size_t x = logical - row_index * params.width;
+    size_t slice = row_index / params.rows;
+    size_t row = row_index - slice * params.rows;
+    auto *output = destination + slice * params.destination_slice_stride +
+                   row * params.destination_row_stride + x;
+    *reinterpret_cast<word *>(output) =
+        *reinterpret_cast<const word *>(source + index);
+  }
+
+  size_t tail = params.bytes - prefix - bulk_bytes;
+  if (thread < tail) {
+    scatter_byte(params, source, destination, prefix + bulk_bytes + thread);
+  }
+}
+
+__global__ void smemcpy_2d_kernel(lupine_smemcpy_params params) {
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_2d_byte(params, source, destination, thread);
+  }
+  for (size_t index = prefix + thread; index < params.bytes; index += step) {
+    scatter_2d_byte(params, source, destination, index);
+  }
+}
+
+template <size_t Width, size_t Items>
+__global__ void smemcpy_narrow_2d_kernel(lupine_smemcpy_params params) {
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_narrow_store<Width>(params, destination, thread, source[thread]);
+  }
+
+  // Mapped host loads have PCIe-scale latency. Issue several independent,
+  // coalesced loads before consuming any of them so narrow, sector-scattered
+  // stores do not leave every resident warp waiting on the same dependency.
+  unsigned char values[Items];
+#pragma unroll
+  for (size_t item = 0; item < Items; ++item) {
+    size_t index = prefix + thread + item * step;
+    if (index < params.bytes) {
+      values[item] = source[index];
+    }
+  }
+#pragma unroll
+  for (size_t item = 0; item < Items; ++item) {
+    size_t index = prefix + thread + item * step;
+    if constexpr (Items == 1 || Width == 3) {
+      if (index < params.bytes) {
+        scatter_narrow_store<Width>(params, destination, index, values[item]);
+      }
+    } else {
+      constexpr unsigned int group_threads = Width == 1 ? 4 : 8;
+      unsigned int lane = threadIdx.x & (warpSize - 1);
+#pragma unroll
+      for (unsigned int group = 0; group < warpSize; group += group_threads) {
+        if (lane >= group && lane < group + group_threads &&
+            index < params.bytes) {
+          scatter_narrow_store<Width>(params, destination, index, values[item]);
+        }
+      }
+    }
+  }
+}
+
+template <size_t Width, size_t Items>
+__global__ void smemcpy_narrow_3d_kernel(lupine_smemcpy_params params) {
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_narrow_3d_store<Width>(params, destination, thread, source[thread]);
+  }
+  unsigned char values[Items];
+#pragma unroll
+  for (size_t item = 0; item < Items; ++item) {
+    size_t index = prefix + thread + item * step;
+    if (index < params.bytes) {
+      values[item] = source[index];
+    }
+  }
+#pragma unroll
+  for (size_t item = 0; item < Items; ++item) {
+    size_t index = prefix + thread + item * step;
+    if constexpr (Items == 1 || Width == 3) {
+      if (index < params.bytes) {
+        scatter_narrow_3d_store<Width>(params, destination, index,
+                                       values[item]);
+      }
+    } else {
+      constexpr unsigned int group_threads = Width == 1 ? 4 : 8;
+      unsigned int lane = threadIdx.x & (warpSize - 1);
+#pragma unroll
+      for (unsigned int group = 0; group < warpSize; group += group_threads) {
+        if (lane >= group && lane < group + group_threads &&
+            index < params.bytes) {
+          scatter_narrow_3d_store<Width>(params, destination, index,
+                                         values[item]);
+        }
+      }
+    }
+  }
+}
+
+template <unsigned int ByteOffset, unsigned int GroupThreads>
+__global__ void smemcpy_atomic_narrow_2d_kernel(lupine_smemcpy_params params) {
+  static_assert(GroupThreads == 4 || GroupThreads == 8 || GroupThreads == 16);
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    if (thread + 1 == params.bytes) {
+      scatter_narrow_store<1>(params, destination, thread, source[thread]);
+    } else {
+      scatter_atomic_2d_store<ByteOffset>(params, destination, thread,
+                                          source[thread]);
+    }
+  }
+  for (size_t index = prefix + thread; index < params.bytes; index += step) {
+    unsigned char value = source[index];
+    if (index + 1 == params.bytes) {
+      scatter_narrow_store<1>(params, destination, index, value);
+      continue;
+    }
+    unsigned int lane = threadIdx.x & (warpSize - 1);
+#pragma unroll
+    for (unsigned int group = 0; group < warpSize; group += GroupThreads) {
+      if (lane >= group && lane < group + GroupThreads) {
+        scatter_atomic_2d_store<ByteOffset>(params, destination, index, value);
+      }
+    }
+  }
+}
+
+template <size_t Width, unsigned int ByteOffset, unsigned int GroupThreads>
+__global__ void smemcpy_atomic_rows_kernel(lupine_smemcpy_params params) {
+  static_assert(Width == 2 || Width == 3);
+  static_assert(GroupThreads == 4 || GroupThreads == 8 || GroupThreads == 16);
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t copy_rows = params.bytes / Width;
+  unsigned int lane = threadIdx.x & (warpSize - 1);
+  for (size_t copy_row = thread; copy_row < copy_rows; copy_row += step) {
+    size_t source_index = copy_row * Width;
+    unsigned int value = 0;
+#pragma unroll
+    for (size_t x = 0; x < Width; ++x) {
+      value |= static_cast<unsigned int>(source[source_index + x]) << (x * 8);
+    }
+
+    size_t destination_row = params.logical_offset / Width + copy_row;
+    unsigned char *output =
+        destination + destination_row * params.destination_row_stride;
+    if (copy_row + 1 == copy_rows) {
+#pragma unroll
+      for (size_t x = 0; x < Width; ++x) {
+        output[x] = static_cast<unsigned char>(value >> (x * 8));
+      }
+      continue;
+    }
+#pragma unroll
+    for (unsigned int group = 0; group < warpSize; group += GroupThreads) {
+      if (lane >= group && lane < group + GroupThreads) {
+        atomic_store_row<Width, ByteOffset>(output, destination, value);
+      }
+    }
+  }
+}
+
+__global__ void smemcpy_3d_kernel(lupine_smemcpy_params params) {
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_byte(params, source, destination, thread);
+  }
+  for (size_t index = prefix + thread; index < params.bytes; index += step) {
+    scatter_byte(params, source, destination, index);
+  }
+}
+
+size_t blocks_for(size_t bytes, size_t bytes_per_thread) {
+  size_t block_bytes = kThreadsPerBlock * bytes_per_thread;
+  size_t blocks = bytes / block_bytes + (bytes % block_bytes != 0);
+  return std::min(std::max<size_t>(blocks, 1), kMaximumBlocks);
+}
+
+bool packed_destination(const lupine_smemcpy_params &params,
+                        size_t slice_bytes) {
+  return params.destination_row_stride == params.width &&
+         params.destination_slice_stride == slice_bytes;
+}
+
+CUdeviceptr destination_at(const lupine_smemcpy_params &params,
+                           size_t logical) {
+  size_t row_index = logical / params.width;
+  size_t x = logical - row_index * params.width;
+  size_t slice = row_index / params.rows;
+  size_t row = row_index - slice * params.rows;
+  return params.destination + slice * params.destination_slice_stride +
+         row * params.destination_row_stride + x;
+}
+
+template <size_t WordBytes>
+bool can_vectorize_pitched(const lupine_smemcpy_params &params,
+                           CUdeviceptr first_destination) {
+  constexpr size_t mask = WordBytes - 1;
+  return (params.width & mask) == 0 && (params.destination & mask) == 0 &&
+         (params.destination_row_stride & mask) == 0 &&
+         (params.destination_slice_stride & mask) == 0 &&
+         ((params.source ^ first_destination) & mask) == 0;
+}
+
+template <size_t WordBytes>
+void set_linear_launch(lupine_smemcpy_launch *launch) {
+  launch->kernel =
+      reinterpret_cast<const void *>(smemcpy_linear_kernel<WordBytes>);
+  launch->blocks =
+      static_cast<unsigned int>(blocks_for(launch->params.bytes, WordBytes));
+}
+
+template <size_t WordBytes>
+void set_pitched_vector_launch(lupine_smemcpy_launch *launch) {
+  launch->kernel =
+      reinterpret_cast<const void *>(smemcpy_pitched_vector_kernel<WordBytes>);
+  launch->blocks =
+      static_cast<unsigned int>(blocks_for(launch->params.bytes, WordBytes));
+}
+
+void select_linear_launch(lupine_smemcpy_launch *launch,
+                          CUdeviceptr first_destination) {
+  uintptr_t different_alignment =
+      static_cast<uintptr_t>(launch->params.source ^ first_destination);
+  if ((different_alignment & 15) == 0) {
+    set_linear_launch<16>(launch);
+  } else if ((different_alignment & 7) == 0) {
+    set_linear_launch<8>(launch);
+  } else if ((different_alignment & 3) == 0) {
+    set_linear_launch<4>(launch);
+  } else if ((different_alignment & 1) == 0) {
+    set_linear_launch<2>(launch);
+  } else {
+    set_linear_launch<1>(launch);
+  }
+}
+
+bool select_pitched_vector_launch(lupine_smemcpy_launch *launch,
+                                  CUdeviceptr first_destination) {
+  if (can_vectorize_pitched<16>(launch->params, first_destination)) {
+    set_pitched_vector_launch<16>(launch);
+  } else if (can_vectorize_pitched<8>(launch->params, first_destination)) {
+    set_pitched_vector_launch<8>(launch);
+  } else if (can_vectorize_pitched<4>(launch->params, first_destination)) {
+    set_pitched_vector_launch<4>(launch);
+  } else if (can_vectorize_pitched<2>(launch->params, first_destination)) {
+    set_pitched_vector_launch<2>(launch);
+  } else {
+    return false;
+  }
+  return true;
+}
+
+template <size_t Items>
+void set_narrow_2d_launch(lupine_smemcpy_launch *launch, size_t width) {
+  switch (width) {
+  case 1:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_2d_kernel<1, Items>);
+    break;
+  case 2:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_2d_kernel<2, Items>);
+    break;
+  default:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_2d_kernel<3, Items>);
+    break;
+  }
+  launch->blocks =
+      static_cast<unsigned int>(blocks_for(launch->params.bytes, Items));
+}
+
+template <size_t Items>
+void set_narrow_3d_launch(lupine_smemcpy_launch *launch, size_t width) {
+  switch (width) {
+  case 1:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_3d_kernel<1, Items>);
+    break;
+  case 2:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_3d_kernel<2, Items>);
+    break;
+  default:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_3d_kernel<3, Items>);
+    break;
+  }
+  launch->blocks =
+      static_cast<unsigned int>(blocks_for(launch->params.bytes, Items));
+}
+
+template <size_t Width, unsigned int ByteOffset, unsigned int GroupThreads>
+void set_atomic_narrow_launch(lupine_smemcpy_launch *launch) {
+  if constexpr (Width == 1) {
+    launch->kernel = reinterpret_cast<const void *>(
+        smemcpy_atomic_narrow_2d_kernel<ByteOffset, GroupThreads>);
+  } else {
+    launch->kernel = reinterpret_cast<const void *>(
+        smemcpy_atomic_rows_kernel<Width, ByteOffset, GroupThreads>);
+  }
+  launch->blocks =
+      static_cast<unsigned int>(blocks_for(launch->params.bytes, Width));
+}
+
+template <size_t Width, unsigned int GroupThreads>
+void select_atomic_narrow_launch_for_width(lupine_smemcpy_launch *launch) {
+  constexpr size_t mask = sizeof(unsigned int) - 1;
+  switch (launch->params.destination & mask) {
+  case 0:
+    set_atomic_narrow_launch<Width, 0, GroupThreads>(launch);
+    break;
+  case 1:
+    set_atomic_narrow_launch<Width, 1, GroupThreads>(launch);
+    break;
+  case 2:
+    if constexpr (Width <= 2) {
+      set_atomic_narrow_launch<Width, 2, GroupThreads>(launch);
+    }
+    break;
+  default:
+    if constexpr (Width == 1) {
+      set_atomic_narrow_launch<Width, 3, GroupThreads>(launch);
+    }
+    break;
+  }
+}
+
+template <unsigned int GroupThreads>
+void select_atomic_narrow_launch_for_group(lupine_smemcpy_launch *launch,
+                                           size_t width) {
+  switch (width) {
+  case 1:
+    select_atomic_narrow_launch_for_width<1, GroupThreads>(launch);
+    break;
+  case 2:
+    select_atomic_narrow_launch_for_width<2, GroupThreads>(launch);
+    break;
+  default:
+    select_atomic_narrow_launch_for_width<3, GroupThreads>(launch);
+    break;
+  }
+}
+
+void select_atomic_narrow_launch(lupine_smemcpy_launch *launch,
+                                 unsigned int group_threads, size_t width) {
+  if (group_threads == 16) {
+    select_atomic_narrow_launch_for_group<16>(launch, width);
+  } else if (group_threads == 8) {
+    select_atomic_narrow_launch_for_group<8>(launch, width);
+  } else {
+    select_atomic_narrow_launch_for_group<4>(launch, width);
+  }
+}
+
+enum class atomic_narrow_target {
+  none,
+  pascal,
+  volta,
+  turing,
+  ampere,
+  l4,
+};
+
+cudaError_t narrow_device_features(bool *latency_hiding,
+                                   atomic_narrow_target *atomic_target) {
+  int device = 0;
+  cudaError_t result = cudaGetDevice(&device);
+  if (result != cudaSuccess) {
+    return result;
+  }
+  static thread_local int cached_device = -1;
+  static thread_local int cached_major = 0;
+  static thread_local atomic_narrow_target cached_atomic_target =
+      atomic_narrow_target::none;
+  if (cached_device != device) {
+    cudaDeviceProp properties = {};
+    result = cudaGetDeviceProperties(&properties, device);
+    if (result != cudaSuccess) {
+      return result;
+    }
+    cached_major = properties.major;
+    cached_atomic_target = atomic_narrow_target::none;
+    if (properties.major == 6 && properties.minor == 0) {
+      cached_atomic_target = atomic_narrow_target::pascal;
+    } else if (properties.major == 7 && properties.minor == 0) {
+      cached_atomic_target = atomic_narrow_target::volta;
+    } else if (properties.major == 7 && properties.minor == 5) {
+      cached_atomic_target = atomic_narrow_target::turing;
+    } else if (properties.major == 8 && properties.minor == 0) {
+      cached_atomic_target = atomic_narrow_target::ampere;
+    } else if (properties.major == 8 && properties.minor == 9 &&
+               std::strcmp(properties.name, "NVIDIA L4") == 0) {
+      cached_atomic_target = atomic_narrow_target::l4;
+    }
+    cached_device = device;
+  }
+  // Pre-Ampere devices benefit from several independent mapped reads. Newer
+  // devices saturate the tested host links with one item per thread.
+  *latency_hiding = cached_major < 8;
+  *atomic_target = cached_atomic_target;
+  return cudaSuccess;
+}
+
+unsigned int atomic_group_threads(atomic_narrow_target target, size_t width,
+                                  size_t stride) {
+  // This is an empirical policy, not a compute-capability extrapolation.
+  if (stride < 64 || stride > 512 || (stride & (stride - 1)) != 0) {
+    return 0;
+  }
+  switch (target) {
+  case atomic_narrow_target::pascal:
+    if (width == 1) {
+      return stride >= 128 ? 4 : 0;
+    }
+    return stride == 64 ? 8 : 4;
+  case atomic_narrow_target::volta:
+    if (width == 1) {
+      return stride >= 128 ? 4 : 0;
+    }
+    if (stride == 64 || (width == 3 && stride == 128)) {
+      return 16;
+    }
+    return stride == 128 ? 8 : 4;
+  case atomic_narrow_target::turing:
+    if (width == 1) {
+      return stride == 64 ? 8 : 4;
+    }
+    if (width == 2) {
+      return stride == 128 || stride == 256 ? 4 : 0;
+    }
+    return stride == 64 ? 16 : 4;
+  case atomic_narrow_target::ampere:
+    return width == 1 && stride >= 256 ? 8 : 0;
+  case atomic_narrow_target::l4:
+    if (width == 1) {
+      return stride == 64 ? 16 : 8;
+    }
+    return 16;
+  case atomic_narrow_target::none:
+    return 0;
+  }
+  return 0;
+}
+
+bool rows_fit_atomic_word(const lupine_smemcpy_params &params,
+                          CUdeviceptr first_destination) {
+  bool owns_complete_rows = params.logical_offset % params.width == 0 &&
+                            params.bytes % params.width == 0;
+  size_t byte_offset = first_destination & (sizeof(unsigned int) - 1);
+  return params.width <= 3 && owns_complete_rows &&
+         byte_offset + params.width <= sizeof(unsigned int);
+}
+
+} // namespace
+
+extern "C" const void *lupine_smemcpy_kernel(void) {
+  return reinterpret_cast<const void *>(smemcpy_3d_kernel);
+}
+
+extern "C" cudaError_t
+lupine_smemcpy_prepare_launch(const lupine_smemcpy_params *params,
+                              lupine_smemcpy_launch *launch) {
+  if (params == nullptr || launch == nullptr || params->width == 0 ||
+      params->rows == 0 ||
+      (params->bytes != 0 &&
+       (params->source == 0 || params->destination == 0)) ||
+      params->width > std::numeric_limits<size_t>::max() / params->rows ||
+      params->bytes >
+          std::numeric_limits<size_t>::max() - params->logical_offset) {
+    return cudaErrorInvalidValue;
+  }
+
+  launch->params = *params;
+  launch->kernel = reinterpret_cast<const void *>(smemcpy_3d_kernel);
+  launch->blocks = 0;
+  launch->threads = kThreadsPerBlock;
+  if (params->bytes == 0) {
+    return cudaSuccess;
+  }
+
+  size_t slice_bytes = params->width * params->rows;
+  CUdeviceptr first_destination =
+      destination_at(*params, params->logical_offset);
+  if (packed_destination(*params, slice_bytes)) {
+    select_linear_launch(launch, first_destination);
+    return cudaSuccess;
+  }
+
+  size_t first_row_index = params->logical_offset / params->width;
+  size_t first_slice = first_row_index / params->rows;
+  size_t last_logical = params->logical_offset + params->bytes - 1;
+  size_t last_row_index = last_logical / params->width;
+  size_t last_slice = last_row_index / params->rows;
+  bool latency_hiding_narrow = false;
+  atomic_narrow_target atomic_target = atomic_narrow_target::none;
+  unsigned int atomic_threads = 0;
+  if (params->width <= 3) {
+    cudaError_t result =
+        narrow_device_features(&latency_hiding_narrow, &atomic_target);
+    if (result != cudaSuccess) {
+      return result;
+    }
+    atomic_threads = atomic_group_threads(atomic_target, params->width,
+                                          params->destination_row_stride);
+    if (atomic_threads != 0 &&
+        !rows_fit_atomic_word(*params, first_destination)) {
+      atomic_threads = 0;
+    }
+  }
+
+  bool regular_rows_across_slices =
+      params->destination_row_stride <=
+          std::numeric_limits<size_t>::max() / params->rows &&
+      params->destination_slice_stride ==
+          params->destination_row_stride * params->rows;
+  if (atomic_threads != 0 && first_slice != last_slice &&
+      !regular_rows_across_slices) {
+    atomic_threads = 0;
+  }
+
+  if (atomic_threads == 0 && !latency_hiding_narrow &&
+      select_pitched_vector_launch(launch, first_destination)) {
+    return cudaSuccess;
+  }
+
+  if (first_slice == last_slice) {
+    size_t first_row = first_row_index - first_slice * params->rows;
+    size_t first_x = params->logical_offset - first_row_index * params->width;
+    launch->params.destination =
+        params->destination + first_slice * params->destination_slice_stride +
+        first_row * params->destination_row_stride;
+    launch->params.logical_offset = first_x;
+    if (params->width <= 3) {
+      if (atomic_threads != 0) {
+        select_atomic_narrow_launch(launch, atomic_threads, params->width);
+      } else if (latency_hiding_narrow) {
+        set_narrow_2d_launch<kNarrowItemsPerThread>(launch, params->width);
+      } else {
+        set_narrow_2d_launch<1>(launch, params->width);
+      }
+    } else {
+      launch->kernel = reinterpret_cast<const void *>(smemcpy_2d_kernel);
+      launch->blocks = static_cast<unsigned int>(blocks_for(params->bytes, 1));
+    }
+    return cudaSuccess;
+  }
+
+  if (first_slice != 0) {
+    launch->params.destination +=
+        first_slice * params->destination_slice_stride;
+    launch->params.logical_offset -= first_slice * slice_bytes;
+  }
+  if (params->width <= 3) {
+    if (atomic_threads != 0) {
+      select_atomic_narrow_launch(launch, atomic_threads, params->width);
+    } else if (latency_hiding_narrow) {
+      set_narrow_3d_launch<kNarrowItemsPerThread>(launch, params->width);
+    } else {
+      set_narrow_3d_launch<1>(launch, params->width);
+    }
+  } else {
+    launch->kernel = reinterpret_cast<const void *>(smemcpy_3d_kernel);
+    launch->blocks = static_cast<unsigned int>(blocks_for(params->bytes, 1));
+  }
+  return cudaSuccess;
+}
+
+extern "C" cudaError_t lupine_smemcpy_async(const lupine_smemcpy_params *params,
+                                            cudaStream_t stream) {
+  lupine_smemcpy_launch launch = {};
+  cudaError_t result = lupine_smemcpy_prepare_launch(params, &launch);
+  if (result != cudaSuccess || launch.blocks == 0) {
+    return result;
+  }
+
+  void *arguments[] = {&launch.params};
+  return cudaLaunchKernel(launch.kernel, dim3(launch.blocks),
+                          dim3(launch.threads), arguments, 0, stream);
+}

--- a/ops/smemcpy.h
+++ b/ops/smemcpy.h
@@ -1,0 +1,67 @@
+#ifndef LUPINE_OPS_SMEMCPY_H
+#define LUPINE_OPS_SMEMCPY_H
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Describes a packed fragment of a logically 3D byte region. The source is a
+// device-visible address, normally a mapped pinned-host ring slot. Destination
+// points at logical coordinate (0, 0, 0); its row and slice strides retain the
+// discontinuities that were removed while packing the source.
+//
+// There is no alignment requirement for correctness. A 128-byte-aligned ring
+// base and slot stride minimize the scalar prefix. Matching the low four bits
+// of source and the first destination coordinate enables 16-byte accesses when
+// the destination width and strides also permit them. Each pitched row must be
+// fully readable and writable through destination_row_stride bytes; the
+// architecture-selected narrow-row fast path preserves padding but atomically
+// accesses its containing 4-byte word. Width-2/3 atomic rows must be whole and
+// must not cross that word. See ops/README.md.
+typedef struct lupine_smemcpy_params {
+  CUdeviceptr destination;
+  CUdeviceptr source;
+  size_t logical_offset;
+  size_t bytes;
+  size_t width;
+  size_t rows;
+  size_t destination_row_stride;
+  size_t destination_slice_stride;
+} lupine_smemcpy_params;
+
+// Fully describes the kernel launch selected for a set of parameters. Pass the
+// address of params as the kernel's sole argument. The prepared parameters may
+// be rebased relative to the input.
+typedef struct lupine_smemcpy_launch {
+  lupine_smemcpy_params params;
+  const void *kernel;
+  unsigned int blocks;
+  unsigned int threads;
+} lupine_smemcpy_launch;
+
+// Selects the best safe implementation and launch geometry for the current
+// CUDA device. This is useful to graph code constructing or updating an
+// equivalent kernel node.
+cudaError_t lupine_smemcpy_prepare_launch(const lupine_smemcpy_params *params,
+                                          lupine_smemcpy_launch *launch);
+
+// Enqueues one scatter copy. Source byte i is written to the pitched
+// destination coordinate represented by logical_offset + i.
+cudaError_t lupine_smemcpy_async(const lupine_smemcpy_params *params,
+                                 cudaStream_t stream);
+
+// Returns the fully general scalar kernel. Prefer prepare_launch: this symbol
+// is retained as a compatibility fallback for graph code that controls its own
+// launch geometry.
+const void *lupine_smemcpy_kernel(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ops/smemcpy_test.cu
+++ b/ops/smemcpy_test.cu
@@ -1,0 +1,547 @@
+#include "ops/smemcpy.h"
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+namespace {
+
+constexpr unsigned char kUntouched = 0xcd;
+constexpr size_t kSourceBytes = 8 * 1024 * 1024 + 4096;
+
+bool check_cuda(cudaError_t status, const char *expression,
+                const char *case_name) {
+  if (status == cudaSuccess) {
+    return true;
+  }
+  std::fprintf(stderr, "%s: %s failed: %s\n", case_name, expression,
+               cudaGetErrorString(status));
+  return false;
+}
+
+#define CHECK_CASE(name, call)                                                 \
+  do {                                                                         \
+    if (!check_cuda((call), #call, (name))) {                                  \
+      return false;                                                            \
+    }                                                                          \
+  } while (0)
+
+struct device_buffer {
+  unsigned char *data = nullptr;
+
+  ~device_buffer() {
+    if (data != nullptr) {
+      cudaFree(data);
+    }
+  }
+};
+
+template <typename NativeCopy>
+bool compare_with_native(const char *name, size_t allocation_bytes,
+                         size_t destination_offset, const unsigned char *host,
+                         CUdeviceptr mapped, size_t source_offset,
+                         lupine_smemcpy_params params, cudaStream_t stream,
+                         NativeCopy native_copy) {
+  if (allocation_bytes == 0 || source_offset > kSourceBytes ||
+      params.bytes > kSourceBytes - source_offset) {
+    std::fprintf(stderr, "%s: invalid test extent\n", name);
+    return false;
+  }
+
+  device_buffer expected;
+  device_buffer actual;
+  CHECK_CASE(name, cudaMalloc(&expected.data, allocation_bytes));
+  CHECK_CASE(name, cudaMalloc(&actual.data, allocation_bytes));
+  CHECK_CASE(name, cudaMemsetAsync(expected.data, kUntouched, allocation_bytes,
+                                   stream));
+  CHECK_CASE(
+      name, cudaMemsetAsync(actual.data, kUntouched, allocation_bytes, stream));
+  CHECK_CASE(name, native_copy(expected.data));
+
+  params.destination =
+      reinterpret_cast<CUdeviceptr>(actual.data + destination_offset);
+  params.source = mapped + source_offset;
+  CHECK_CASE(name, lupine_smemcpy_async(&params, stream));
+  CHECK_CASE(name, cudaStreamSynchronize(stream));
+
+  std::vector<unsigned char> expected_host(allocation_bytes);
+  std::vector<unsigned char> actual_host(allocation_bytes);
+  CHECK_CASE(name, cudaMemcpy(expected_host.data(), expected.data,
+                              allocation_bytes, cudaMemcpyDeviceToHost));
+  CHECK_CASE(name, cudaMemcpy(actual_host.data(), actual.data, allocation_bytes,
+                              cudaMemcpyDeviceToHost));
+  if (expected_host == actual_host) {
+    return true;
+  }
+
+  size_t mismatch = 0;
+  while (mismatch < allocation_bytes &&
+         expected_host[mismatch] == actual_host[mismatch]) {
+    ++mismatch;
+  }
+  std::fprintf(stderr,
+               "%s: mismatch at physical byte %zu: native=0x%02x "
+               "scatter=0x%02x\n",
+               name, mismatch, expected_host[mismatch], actual_host[mismatch]);
+  return false;
+}
+
+struct linear_case {
+  size_t logical_bytes;
+  size_t logical_offset;
+  size_t bytes;
+  size_t source_offset;
+  size_t destination_offset;
+};
+
+bool run_linear_case(const linear_case &test, const unsigned char *host,
+                     CUdeviceptr mapped, cudaStream_t stream) {
+  char name[192];
+  std::snprintf(name, sizeof(name),
+                "cudaMemcpyAsync 1D total=%zu offset=%zu bytes=%zu src=%zu "
+                "dst=%zu",
+                test.logical_bytes, test.logical_offset, test.bytes,
+                test.source_offset, test.destination_offset);
+  if (test.logical_offset > test.logical_bytes ||
+      test.bytes > test.logical_bytes - test.logical_offset) {
+    std::fprintf(stderr, "%s: invalid case\n", name);
+    return false;
+  }
+
+  lupine_smemcpy_params params = {};
+  params.logical_offset = test.logical_offset;
+  params.bytes = test.bytes;
+  params.width = test.logical_bytes;
+  params.rows = 1;
+  params.destination_row_stride = test.logical_bytes;
+  params.destination_slice_stride = test.logical_bytes;
+  size_t allocation_bytes = test.destination_offset + test.logical_bytes;
+  return compare_with_native(
+      name, allocation_bytes, test.destination_offset, host, mapped,
+      test.source_offset, params, stream, [&](unsigned char *destination) {
+        return cudaMemcpyAsync(destination + test.destination_offset +
+                                   test.logical_offset,
+                               host + test.source_offset, test.bytes,
+                               cudaMemcpyHostToDevice, stream);
+      });
+}
+
+struct plane_case {
+  size_t width;
+  size_t rows;
+  size_t pitch;
+  size_t source_offset;
+  size_t destination_offset;
+};
+
+bool run_plane_case(const plane_case &test, const unsigned char *host,
+                    CUdeviceptr mapped, cudaStream_t stream) {
+  char name[192];
+  std::snprintf(name, sizeof(name),
+                "cudaMemcpy2DAsync width=%zu rows=%zu pitch=%zu src=%zu "
+                "dst=%zu",
+                test.width, test.rows, test.pitch, test.source_offset,
+                test.destination_offset);
+  if (test.width == 0 || test.rows == 0 || test.pitch < test.width) {
+    std::fprintf(stderr, "%s: invalid case\n", name);
+    return false;
+  }
+
+  size_t logical_bytes = test.width * test.rows;
+  size_t allocation_bytes =
+      test.destination_offset + (test.rows - 1) * test.pitch + test.width;
+  lupine_smemcpy_params params = {};
+  params.bytes = logical_bytes;
+  params.width = test.width;
+  params.rows = test.rows;
+  params.destination_row_stride = test.pitch;
+  params.destination_slice_stride = test.pitch * test.rows;
+  return compare_with_native(
+      name, allocation_bytes, test.destination_offset, host, mapped,
+      test.source_offset, params, stream, [&](unsigned char *destination) {
+        return cudaMemcpy2DAsync(destination + test.destination_offset,
+                                 test.pitch, host + test.source_offset,
+                                 test.width, test.width, test.rows,
+                                 cudaMemcpyHostToDevice, stream);
+      });
+}
+
+struct volume_case {
+  size_t width;
+  size_t rows;
+  size_t slices;
+  size_t pitch;
+  size_t destination_slice_rows;
+  size_t source_offset;
+  size_t destination_offset;
+};
+
+bool run_volume_case(const volume_case &test, const unsigned char *host,
+                     CUdeviceptr mapped, cudaStream_t stream) {
+  char name[224];
+  std::snprintf(name, sizeof(name),
+                "cudaMemcpy3DAsync width=%zu rows=%zu slices=%zu pitch=%zu "
+                "slice_rows=%zu src=%zu dst=%zu",
+                test.width, test.rows, test.slices, test.pitch,
+                test.destination_slice_rows, test.source_offset,
+                test.destination_offset);
+  if (test.width == 0 || test.rows == 0 || test.slices == 0 ||
+      test.pitch < test.width || test.destination_slice_rows < test.rows) {
+    std::fprintf(stderr, "%s: invalid case\n", name);
+    return false;
+  }
+
+  size_t slice_stride = test.pitch * test.destination_slice_rows;
+  size_t allocation_bytes = test.destination_offset +
+                            (test.slices - 1) * slice_stride +
+                            (test.rows - 1) * test.pitch + test.width;
+  lupine_smemcpy_params params = {};
+  params.bytes = test.width * test.rows * test.slices;
+  params.width = test.width;
+  params.rows = test.rows;
+  params.destination_row_stride = test.pitch;
+  params.destination_slice_stride = slice_stride;
+  return compare_with_native(
+      name, allocation_bytes, test.destination_offset, host, mapped,
+      test.source_offset, params, stream, [&](unsigned char *destination) {
+        cudaMemcpy3DParms copy = {};
+        copy.srcPtr = make_cudaPitchedPtr(
+            const_cast<unsigned char *>(host + test.source_offset), test.width,
+            test.width, test.rows);
+        copy.dstPtr = make_cudaPitchedPtr(destination + test.destination_offset,
+                                          test.pitch, test.width,
+                                          test.destination_slice_rows);
+        copy.extent = make_cudaExtent(test.width, test.rows, test.slices);
+        copy.kind = cudaMemcpyHostToDevice;
+        return cudaMemcpy3DAsync(&copy, stream);
+      });
+}
+
+struct fragment_case {
+  size_t width;
+  size_t rows;
+  size_t slices;
+  size_t row_stride;
+  size_t slice_stride;
+  size_t logical_offset;
+  size_t bytes;
+  size_t source_offset;
+  size_t destination_offset;
+};
+
+bool run_fragment_case(const fragment_case &test, const unsigned char *host,
+                       CUdeviceptr mapped, cudaStream_t stream) {
+  char name[256];
+  std::snprintf(name, sizeof(name),
+                "fragment width=%zu rows=%zu slices=%zu row_stride=%zu "
+                "slice_stride=%zu offset=%zu bytes=%zu src=%zu dst=%zu",
+                test.width, test.rows, test.slices, test.row_stride,
+                test.slice_stride, test.logical_offset, test.bytes,
+                test.source_offset, test.destination_offset);
+  size_t logical_bytes = test.width * test.rows * test.slices;
+  if (test.width == 0 || test.rows == 0 || test.slices == 0 ||
+      test.row_stride < test.width ||
+      test.slice_stride < test.row_stride * test.rows ||
+      test.logical_offset > logical_bytes ||
+      test.bytes > logical_bytes - test.logical_offset) {
+    std::fprintf(stderr, "%s: invalid case\n", name);
+    return false;
+  }
+
+  size_t allocation_bytes = test.destination_offset +
+                            (test.slices - 1) * test.slice_stride +
+                            (test.rows - 1) * test.row_stride + test.width;
+  lupine_smemcpy_params params = {};
+  params.logical_offset = test.logical_offset;
+  params.bytes = test.bytes;
+  params.width = test.width;
+  params.rows = test.rows;
+  params.destination_row_stride = test.row_stride;
+  params.destination_slice_stride = test.slice_stride;
+  return compare_with_native(
+      name, allocation_bytes, test.destination_offset, host, mapped,
+      test.source_offset, params, stream, [&](unsigned char *destination) {
+        size_t logical = test.logical_offset;
+        size_t copied = 0;
+        while (copied < test.bytes) {
+          size_t row_index = logical / test.width;
+          size_t x = logical - row_index * test.width;
+          size_t slice = row_index / test.rows;
+          size_t row = row_index - slice * test.rows;
+          size_t chunk = std::min(test.bytes - copied, test.width - x);
+          cudaError_t status = cudaMemcpyAsync(
+              destination + test.destination_offset +
+                  slice * test.slice_stride + row * test.row_stride + x,
+              host + test.source_offset + copied, chunk, cudaMemcpyHostToDevice,
+              stream);
+          if (status != cudaSuccess) {
+            return status;
+          }
+          logical += chunk;
+          copied += chunk;
+        }
+        return cudaSuccess;
+      });
+}
+
+bool expect_invalid(const char *name, const lupine_smemcpy_params &params) {
+  lupine_smemcpy_launch launch = {};
+  cudaError_t status = lupine_smemcpy_prepare_launch(&params, &launch);
+  if (status == cudaErrorInvalidValue) {
+    return true;
+  }
+  std::fprintf(stderr, "%s: expected cudaErrorInvalidValue, got %s\n", name,
+               cudaGetErrorString(status));
+  return false;
+}
+
+bool run_parameter_validation() {
+  lupine_smemcpy_launch launch = {};
+  lupine_smemcpy_params params = {};
+  if (lupine_smemcpy_prepare_launch(nullptr, &launch) !=
+          cudaErrorInvalidValue ||
+      lupine_smemcpy_prepare_launch(&params, nullptr) !=
+          cudaErrorInvalidValue) {
+    std::fputs("null parameter validation failed\n", stderr);
+    return false;
+  }
+
+  params.rows = 1;
+  if (!expect_invalid("zero width", params)) {
+    return false;
+  }
+  params.width = 1;
+  params.rows = 0;
+  if (!expect_invalid("zero rows", params)) {
+    return false;
+  }
+  params.rows = 1;
+  params.bytes = 1;
+  if (!expect_invalid("null nonempty pointers", params)) {
+    return false;
+  }
+  params.source = 1;
+  params.destination = 1;
+  params.width = std::numeric_limits<size_t>::max();
+  params.rows = 2;
+  if (!expect_invalid("width times rows overflow", params)) {
+    return false;
+  }
+  params.width = 1;
+  params.rows = 1;
+  params.logical_offset = std::numeric_limits<size_t>::max();
+  params.bytes = 1;
+  if (!expect_invalid("logical extent overflow", params)) {
+    return false;
+  }
+
+  params = {};
+  params.width = 1;
+  params.rows = 1;
+  if (lupine_smemcpy_prepare_launch(&params, &launch) != cudaSuccess ||
+      launch.blocks != 0 ||
+      lupine_smemcpy_async(&params, nullptr) != cudaSuccess) {
+    std::fputs("zero-byte copy validation failed\n", stderr);
+    return false;
+  }
+  return true;
+}
+
+bool unavailable_cuda(cudaError_t status) {
+  return status == cudaErrorNoDevice || status == cudaErrorInsufficientDriver ||
+         status == cudaErrorInitializationError;
+}
+
+} // namespace
+
+int main() {
+  cudaError_t status = cudaSetDeviceFlags(cudaDeviceMapHost);
+  if (unavailable_cuda(status)) {
+    std::printf("SKIP: CUDA unavailable: %s\n", cudaGetErrorString(status));
+    return 77;
+  }
+  if (!check_cuda(status, "cudaSetDeviceFlags", "initialization")) {
+    return 1;
+  }
+
+  int device_count = 0;
+  status = cudaGetDeviceCount(&device_count);
+  if (unavailable_cuda(status) ||
+      (status == cudaSuccess && device_count == 0)) {
+    std::printf("SKIP: no CUDA device available\n");
+    return 77;
+  }
+  if (!check_cuda(status, "cudaGetDeviceCount", "initialization")) {
+    return 1;
+  }
+  cudaDeviceProp properties = {};
+  if (!check_cuda(cudaGetDeviceProperties(&properties, 0),
+                  "cudaGetDeviceProperties", "initialization")) {
+    return 1;
+  }
+  if (!properties.canMapHostMemory) {
+    std::printf("SKIP: %s cannot map host memory\n", properties.name);
+    return 77;
+  }
+
+  unsigned char *host = nullptr;
+  if (!check_cuda(cudaHostAlloc(&host, kSourceBytes, cudaHostAllocMapped),
+                  "cudaHostAlloc", "initialization")) {
+    return 1;
+  }
+  for (size_t index = 0; index < kSourceBytes; ++index) {
+    host[index] = static_cast<unsigned char>(
+        (index * 131U + (index >> 7) * 29U + 17U) & 0xffU);
+  }
+  unsigned char *mapped_pointer = nullptr;
+  if (!check_cuda(cudaHostGetDevicePointer(&mapped_pointer, host, 0),
+                  "cudaHostGetDevicePointer", "initialization")) {
+    cudaFreeHost(host);
+    return 1;
+  }
+  CUdeviceptr mapped = reinterpret_cast<CUdeviceptr>(mapped_pointer);
+  cudaStream_t stream = nullptr;
+  if (!check_cuda(cudaStreamCreate(&stream), "cudaStreamCreate",
+                  "initialization")) {
+    cudaFreeHost(host);
+    return 1;
+  }
+
+  const linear_case linear_cases[] = {
+      {1, 0, 1, 0, 0},
+      {2, 0, 2, 1, 0},
+      {3, 1, 1, 3, 1},
+      {7, 0, 7, 7, 3},
+      {15, 2, 11, 1, 5},
+      {16, 0, 16, 0, 0},
+      {17, 0, 17, 1, 0},
+      {31, 3, 27, 5, 9},
+      {32, 0, 32, 16, 0},
+      {63, 1, 61, 31, 7},
+      {64, 0, 64, 0, 0},
+      {127, 9, 111, 63, 13},
+      {128, 0, 128, 128, 0},
+      {129, 1, 127, 127, 1},
+      {255, 17, 223, 255, 15},
+      {256, 0, 256, 256, 0},
+      {4095, 31, 4001, 4095, 17},
+      {4096, 0, 4096, 0, 0},
+      {4097, 1, 4095, 1, 31},
+      {4 * 1024 * 1024, 0, 4 * 1024 * 1024, 0, 0},
+      {4 * 1024 * 1024 + 257, 127, 4 * 1024 * 1024, 63, 1},
+  };
+  for (const linear_case &test : linear_cases) {
+    if (!run_linear_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  const plane_case plane_cases[] = {
+      {1, 4097, 64, 0, 0},    {1, 4097, 128, 1, 1},     {1, 4097, 192, 31, 2},
+      {1, 4097, 256, 127, 3}, {1, 4097, 512, 255, 0},   {2, 2053, 64, 0, 0},
+      {2, 2053, 128, 1, 1},   {2, 2053, 256, 3, 2},     {2, 2053, 256, 5, 3},
+      {2, 2053, 512, 31, 0},  {3, 1367, 64, 0, 0},      {3, 1367, 128, 1, 1},
+      {3, 1367, 256, 2, 2},   {3, 1367, 256, 3, 1},     {3, 1367, 512, 31, 0},
+      {4, 1025, 64, 0, 0},    {7, 587, 64, 1, 3},       {8, 513, 64, 8, 0},
+      {15, 277, 64, 15, 1},   {16, 257, 64, 16, 0},     {31, 133, 64, 31, 7},
+      {32, 129, 64, 32, 0},   {33, 127, 128, 1, 9},     {63, 67, 128, 63, 3},
+      {64, 65, 128, 64, 0},   {127, 37, 256, 127, 11},  {128, 33, 256, 128, 0},
+      {129, 31, 258, 1, 1},   {255, 19, 510, 255, 13},  {256, 17, 512, 256, 0},
+      {257, 17, 514, 31, 7},  {4095, 3, 8190, 4095, 1}, {4096, 3, 8192, 0, 0},
+      {4097, 3, 8194, 1, 15},
+  };
+  for (const plane_case &test : plane_cases) {
+    if (!run_plane_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  const volume_case volume_cases[] = {
+      {1, 17, 5, 64, 17, 0, 0},      {1, 17, 5, 64, 19, 1, 1},
+      {2, 129, 4, 256, 129, 3, 2},   {2, 129, 4, 256, 132, 5, 3},
+      {3, 97, 5, 256, 97, 1, 1},     {3, 97, 5, 256, 99, 2, 2},
+      {4, 19, 7, 64, 23, 7, 3},      {7, 13, 5, 64, 15, 31, 5},
+      {16, 11, 4, 32, 13, 16, 0},    {31, 7, 3, 64, 9, 1, 7},
+      {64, 64, 8, 256, 66, 64, 0},   {127, 32, 7, 256, 35, 127, 9},
+      {128, 17, 6, 256, 19, 128, 0}, {129, 15, 5, 258, 18, 1, 1},
+      {256, 8, 4, 512, 10, 256, 0},  {4096, 4, 3, 8192, 6, 0, 0},
+  };
+  for (const volume_case &test : volume_cases) {
+    if (!run_volume_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  const fragment_case fragment_cases[] = {
+      {64, 5, 3, 80, 480, 3, 811, 3, 0},
+      {24, 7, 4, 40, 320, 5, 523, 5, 0},
+      {12, 9, 3, 20, 200, 7, 271, 3, 0},
+      {6, 11, 4, 10, 120, 1, 241, 1, 0},
+      {37, 11, 5, 61, 793, 398, 430, 17, 9},
+      {5, 13, 4, 19, 267, 83, 31, 7, 3},
+      {1, 257, 3, 17, 4385, 251, 281, 31, 7},
+      {1, 257, 3, 256, 66304, 11, 173, 31, 0},
+      {1, 257, 3, 256, 66304, 251, 281, 17, 1},
+      {1, 257, 3, 256, 65792, 251, 281, 9, 3},
+      {2, 129, 4, 18, 2340, 247, 293, 15, 5},
+      {3, 97, 5, 19, 1901, 283, 337, 1, 11},
+      {2, 129, 4, 256, 33024, 0, 1032, 0, 0},
+      {2, 129, 4, 256, 33024, 0, 1032, 1, 1},
+      {2, 129, 4, 256, 33024, 0, 1032, 3, 2},
+      {2, 129, 4, 256, 33024, 0, 1032, 5, 3},
+      {3, 97, 5, 256, 24832, 0, 1455, 0, 0},
+      {3, 97, 5, 256, 24832, 0, 1455, 1, 1},
+      {3, 97, 5, 256, 24832, 0, 1455, 2, 2},
+      {3, 97, 5, 256, 24896, 0, 1455, 3, 0},
+      {31, 7, 3, 31, 217, 19, 401, 9, 13},
+  };
+  for (const fragment_case &test : fragment_cases) {
+    if (!run_fragment_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  uint32_t random = 0x9e3779b9U;
+  constexpr int random_cases = 64;
+  for (int test_index = 0; test_index < random_cases; ++test_index) {
+    auto next = [&] {
+      random = random * 1664525U + 1013904223U;
+      return random;
+    };
+    fragment_case test = {};
+    test.width = 1 + next() % 257;
+    test.rows = 1 + next() % 33;
+    test.slices = 1 + next() % 7;
+    test.row_stride = test.width + next() % 129;
+    test.slice_stride = test.row_stride * test.rows + next() % 65;
+    size_t logical_bytes = test.width * test.rows * test.slices;
+    test.logical_offset = next() % logical_bytes;
+    test.bytes = 1 + next() % (logical_bytes - test.logical_offset);
+    test.source_offset = next() % 128;
+    test.destination_offset = next() % 32;
+    if (!run_fragment_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  if (!run_parameter_validation()) {
+    return 1;
+  }
+  if (!check_cuda(cudaStreamDestroy(stream), "cudaStreamDestroy", "cleanup") ||
+      !check_cuda(cudaFreeHost(host), "cudaFreeHost", "cleanup")) {
+    return 1;
+  }
+
+  std::printf("PASS: %s: %zu native 1D, %zu native 2D, %zu native 3D, "
+              "%zu fragmented comparisons plus parameter validation\n",
+              properties.name, sizeof(linear_cases) / sizeof(linear_cases[0]),
+              sizeof(plane_cases) / sizeof(plane_cases[0]),
+              sizeof(volume_cases) / sizeof(volume_cases[0]),
+              sizeof(fragment_cases) / sizeof(fragment_cases[0]) +
+                  random_cases);
+  return 0;
+}


### PR DESCRIPTION
## Summary

- add the optimized CUDA mapped-source scatter memcpy implementation under `ops/`
- dispatch aligned vector, scalar, and architecture-tuned narrow-row kernels
- support packed 1D, pitched 2D, and pitched/sliced 3D destinations without a destination-alignment requirement
- document source-layout and destination-shape mitigation guidance
- add a CTest correctness suite comparing scatter results against native CUDA copies

## Correctness coverage

The test compares the complete physical destination allocation, including sentinel-filled row and slice padding:

- 21 native `cudaMemcpyAsync` 1D comparisons
- 34 native `cudaMemcpy2DAsync` full-plane comparisons
- 16 native `cudaMemcpy3DAsync` full-volume comparisons, including regular and gapped slice strides
- 85 targeted and deterministic-random fragmented comparisons assembled from native row copies
- invalid-parameter validation

Coverage includes vector boundaries, source and destination offsets, regular and irregular pitches, 1–3 byte rows, tight allocation tails, partial rows, and cross-row/cross-slice fragments.

## Validation

- clean configure/build of `smemcpy_test`
- full local CTest suite: 9 passed, 3 expected environment skips, 0 failed
- all 156 comparisons passed on NVIDIA GeForce RTX 4090 (SM 8.9)
- all 156 comparisons passed on NVIDIA GeForce RTX 2070 SUPER (SM 7.5)
- Compute Sanitizer memcheck: 0 errors on both GPUs

The standalone performance benchmark has been removed from the PR.