### PR TITLE
Add ROCm scatter memcpy operation

### DIFF
--- a/.github/workflows/build-hip.yml
+++ b/.github/workflows/build-hip.yml
@@ -45,3 +45,39 @@ jobs:
             test -e /opt/rocm/lib/libamdhip64.so
             ! ldd /opt/lupine/bin/lupine_driver_server | grep -q "not found"
           '
+
+  ops-device-code:
+    name: HIP device code
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # The image builds above copy HIP headers only, so nothing there compiles
+    # ops. Build it against a real ROCm toolchain instead. No runner has an AMD
+    # GPU, so this is a compile check; smemcpy_test itself is run on hardware.
+    container:
+      image: rocm/dev-ubuntu-24.04:7.2.4
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y cmake ninja-build libnghttp2-dev libssl-dev
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLUPINE_BUILD_CUDA=OFF \
+            -DLUPINE_BUILD_NVML=OFF \
+            -DLUPINE_BUILD_HIP=ON \
+            -DBUILD_TESTING=ON
+
+      - name: Verify ops selected the HIP toolchain
+        run: grep -q '^CMAKE_HIP_COMPILER:' build/CMakeCache.txt
+
+      # Naming the targets is itself the assertion that ops was added: if the
+      # HIP probe had failed, ops would be skipped and these would not exist.
+      - name: Build the HIP scatter memcpy and its test
+        run: cmake --build build --target lupine_hip_smemcpy hip_smemcpy_test

--- a/.github/workflows/build-hip.yml
+++ b/.github/workflows/build-hip.yml
@@ -45,39 +45,3 @@ jobs:
             test -e /opt/rocm/lib/libamdhip64.so
             ! ldd /opt/lupine/bin/lupine_driver_server | grep -q "not found"
           '
-
-  ops-device-code:
-    name: HIP device code
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    # The image builds above copy HIP headers only, so nothing there compiles
-    # ops. Build it against a real ROCm toolchain instead. No runner has an AMD
-    # GPU, so this is a compile check; smemcpy_test itself is run on hardware.
-    container:
-      image: rocm/dev-ubuntu-24.04:7.2.4
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Install build dependencies
-        run: |
-          apt-get update
-          apt-get install -y cmake ninja-build libnghttp2-dev libssl-dev
-
-      - name: Configure
-        run: |
-          cmake -S . -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DLUPINE_BUILD_CUDA=OFF \
-            -DLUPINE_BUILD_NVML=OFF \
-            -DLUPINE_BUILD_HIP=ON \
-            -DBUILD_TESTING=ON
-
-      - name: Verify ops selected the HIP toolchain
-        run: grep -q '^CMAKE_HIP_COMPILER:' build/CMakeCache.txt
-
-      # Naming the targets is itself the assertion that ops was added: if the
-      # HIP probe had failed, ops would be skipped and these would not exist.
-      - name: Build the HIP scatter memcpy and its test
-        run: cmake --build build --target lupine_hip_smemcpy hip_smemcpy_test

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -90,7 +90,7 @@ jobs:
             "-DCUDAToolkit_ROOT=$env:CUDA_PATH"
 
       - name: Build
-        run: cmake --build build/windows-server --config Release --target lupine_driver_server lupine_smemcpy --parallel
+        run: cmake --build build/windows-server --config Release --target lupine_driver_server lupine_cuda_smemcpy --parallel
 
       - name: Verify the executable is self-contained
         shell: pwsh

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
           git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
       - name: Run clang-format on diff
         run: >
-          git diff --name-only origin/${{ github.base_ref }} | grep -E '\.(cpp|h|cu)$' | grep -v '^third_party/' > changed_files.txt || true
+          git diff --name-only origin/${{ github.base_ref }} | grep -E '\.(cpp|h|cu|hip)$' | grep -v '^third_party/' > changed_files.txt || true
 
           while read file; do
             echo "Checking $file"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,13 +139,9 @@ endif()
 # ops holds device code, so each backend needs a real offline compiler rather
 # than the headers and driver stub the rest of the server builds against. The
 # CUDA and HIP operations are independent, and either may be built alone.
-set(LUPINE_OPS_CUDA OFF)
-set(LUPINE_OPS_HIP OFF)
-
 if(LUPINE_BUILD_SERVER AND LUPINE_BUILD_CUDA AND
    NOT LUPINE_CUDA_DRIVER_LIBRARY)
     enable_language(CUDA)
-    set(LUPINE_OPS_CUDA ON)
 endif()
 
 if(LUPINE_BUILD_SERVER AND LUPINE_BUILD_HIP AND
@@ -166,11 +162,12 @@ if(LUPINE_BUILD_SERVER AND LUPINE_BUILD_HIP AND
     check_language(HIP)
     if(CMAKE_HIP_COMPILER)
         enable_language(HIP)
-        set(LUPINE_OPS_HIP ON)
     endif()
 endif()
 
-if(LUPINE_OPS_CUDA OR LUPINE_OPS_HIP)
+get_property(lupine_enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+if("CUDA" IN_LIST lupine_enabled_languages OR
+   "HIP" IN_LIST lupine_enabled_languages)
     add_subdirectory(ops)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,9 +136,41 @@ if(LUPINE_BUILD_SERVER AND
         "LUPINE_BUILD_SERVER requires at least one available backend")
 endif()
 
+# ops holds device code, so each backend needs a real offline compiler rather
+# than the headers and driver stub the rest of the server builds against. The
+# CUDA and HIP operations are independent, and either may be built alone.
+set(LUPINE_OPS_CUDA OFF)
+set(LUPINE_OPS_HIP OFF)
+
 if(LUPINE_BUILD_SERVER AND LUPINE_BUILD_CUDA AND
    NOT LUPINE_CUDA_DRIVER_LIBRARY)
     enable_language(CUDA)
+    set(LUPINE_OPS_CUDA ON)
+endif()
+
+if(LUPINE_BUILD_SERVER AND LUPINE_BUILD_HIP AND
+   NOT CMAKE_VERSION VERSION_LESS 3.21)
+    # hipcc defaults to gfx906 alone, which loads but never runs on a newer
+    # card, and clang's "native" needs /dev/kfd, so it fails on GPU-less
+    # builders and under WSL. Ship a fat binary covering the supported CDNA and
+    # RDNA targets instead. This must precede the compiler probe so the probe
+    # and the build agree on the targets.
+    if(NOT CMAKE_HIP_ARCHITECTURES)
+        set(CMAKE_HIP_ARCHITECTURES
+            gfx90a gfx942 gfx1030 gfx1100 gfx1101 gfx1102 gfx1200 gfx1201)
+    endif()
+    # The HIP SDK check above only needs headers, which is all the client shim
+    # and the server dispatch require. Device code additionally needs a HIP
+    # compiler, so the operation is built only where one exists.
+    include(CheckLanguage)
+    check_language(HIP)
+    if(CMAKE_HIP_COMPILER)
+        enable_language(HIP)
+        set(LUPINE_OPS_HIP ON)
+    endif()
+endif()
+
+if(LUPINE_OPS_CUDA OR LUPINE_OPS_HIP)
     add_subdirectory(ops)
 endif()
 

--- a/ops/CMakeLists.txt
+++ b/ops/CMakeLists.txt
@@ -1,18 +1,41 @@
-add_library(lupine_smemcpy STATIC smemcpy.cu)
-target_include_directories(lupine_smemcpy PUBLIC ${PROJECT_SOURCE_DIR})
-set_target_properties(lupine_smemcpy PROPERTIES
-    CUDA_STANDARD 17
-    CUDA_STANDARD_REQUIRED ON
-    POSITION_INDEPENDENT_CODE ON)
-
-if(BUILD_TESTING)
-    add_executable(smemcpy_test smemcpy_test.cu)
-    target_link_libraries(smemcpy_test PRIVATE lupine_smemcpy)
-    set_target_properties(smemcpy_test PROPERTIES
+if(LUPINE_OPS_CUDA)
+    add_library(lupine_smemcpy STATIC smemcpy.cu)
+    target_include_directories(lupine_smemcpy PUBLIC ${PROJECT_SOURCE_DIR})
+    set_target_properties(lupine_smemcpy PROPERTIES
         CUDA_STANDARD 17
-        CUDA_STANDARD_REQUIRED ON)
-    add_test(NAME smemcpy_test COMMAND smemcpy_test)
-    set_tests_properties(smemcpy_test PROPERTIES
-        SKIP_RETURN_CODE 77
-        TIMEOUT 120)
+        CUDA_STANDARD_REQUIRED ON
+        POSITION_INDEPENDENT_CODE ON)
+
+    if(BUILD_TESTING)
+        add_executable(smemcpy_test smemcpy_test.cu)
+        target_link_libraries(smemcpy_test PRIVATE lupine_smemcpy)
+        set_target_properties(smemcpy_test PROPERTIES
+            CUDA_STANDARD 17
+            CUDA_STANDARD_REQUIRED ON)
+        add_test(NAME smemcpy_test COMMAND smemcpy_test)
+        set_tests_properties(smemcpy_test PROPERTIES
+            SKIP_RETURN_CODE 77
+            TIMEOUT 120)
+    endif()
+endif()
+
+if(LUPINE_OPS_HIP)
+    add_library(lupine_hip_smemcpy STATIC hip_smemcpy.hip)
+    target_include_directories(lupine_hip_smemcpy PUBLIC ${PROJECT_SOURCE_DIR})
+    set_target_properties(lupine_hip_smemcpy PROPERTIES
+        HIP_STANDARD 17
+        HIP_STANDARD_REQUIRED ON
+        POSITION_INDEPENDENT_CODE ON)
+
+    if(BUILD_TESTING)
+        add_executable(hip_smemcpy_test hip_smemcpy_test.hip)
+        target_link_libraries(hip_smemcpy_test PRIVATE lupine_hip_smemcpy)
+        set_target_properties(hip_smemcpy_test PROPERTIES
+            HIP_STANDARD 17
+            HIP_STANDARD_REQUIRED ON)
+        add_test(NAME hip_smemcpy_test COMMAND hip_smemcpy_test)
+        set_tests_properties(hip_smemcpy_test PROPERTIES
+            SKIP_RETURN_CODE 77
+            TIMEOUT 120)
+    endif()
 endif()

--- a/ops/CMakeLists.txt
+++ b/ops/CMakeLists.txt
@@ -1,14 +1,16 @@
-if(LUPINE_OPS_CUDA)
-    add_library(lupine_smemcpy STATIC smemcpy.cu)
-    target_include_directories(lupine_smemcpy PUBLIC ${PROJECT_SOURCE_DIR})
-    set_target_properties(lupine_smemcpy PROPERTIES
+get_property(enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+
+if("CUDA" IN_LIST enabled_languages)
+    add_library(lupine_cuda_smemcpy STATIC smemcpy.cu)
+    target_include_directories(lupine_cuda_smemcpy PUBLIC ${PROJECT_SOURCE_DIR})
+    set_target_properties(lupine_cuda_smemcpy PROPERTIES
         CUDA_STANDARD 17
         CUDA_STANDARD_REQUIRED ON
         POSITION_INDEPENDENT_CODE ON)
 
     if(BUILD_TESTING)
         add_executable(smemcpy_test smemcpy_test.cu)
-        target_link_libraries(smemcpy_test PRIVATE lupine_smemcpy)
+        target_link_libraries(smemcpy_test PRIVATE lupine_cuda_smemcpy)
         set_target_properties(smemcpy_test PROPERTIES
             CUDA_STANDARD 17
             CUDA_STANDARD_REQUIRED ON)
@@ -19,7 +21,7 @@ if(LUPINE_OPS_CUDA)
     endif()
 endif()
 
-if(LUPINE_OPS_HIP)
+if("HIP" IN_LIST enabled_languages)
     add_library(lupine_hip_smemcpy STATIC hip_smemcpy.hip)
     target_include_directories(lupine_hip_smemcpy PUBLIC ${PROJECT_SOURCE_DIR})
     set_target_properties(lupine_hip_smemcpy PROPERTIES

--- a/ops/README.md
+++ b/ops/README.md
@@ -209,3 +209,109 @@ be accessed once and with coalesced operations:
 - [Volta Tuning Guide: Memory Throughput](https://docs.nvidia.com/cuda/volta-tuning-guide/index.html#memory-throughput)
 - [Ampere Tuning Guide: Memory System](https://docs.nvidia.com/cuda/ampere-tuning-guide/index.html#memory-system)
 - [Hopper Tuning Guide: Memory System](https://docs.nvidia.com/cuda/hopper-tuning-guide/index.html#memory-system)
+
+# ROCm scatter memcpy
+
+`hip_smemcpy.hip` is the same operation for AMD GPUs. It is a separate kernel,
+not a portability layer over `smemcpy.cu`: the two hardware families reward
+different code, and keeping them apart lets each be tuned without regressing
+the other. The contract is identical — a packed, device-visible source
+fragment scattered into a pitched 2D or 3D destination — and the parameter
+struct differs only in that addresses are plain unsigned integers, because
+`hipDeviceptr_t` is `void *` and cannot carry the operation's arithmetic.
+
+## What differs from the CUDA operation
+
+**No atomic paths.** The CUDA dispatcher routes one- to three-byte rows through
+`atomicCAS` on selected NVIDIA parts, because a scattered warp store there is
+decomposed into serialized L1TEX wavefronts while atomics pass through to the
+L2 atomic hardware. That is an NVIDIA memory-system property. The whole CAS
+apparatus — the per-product table, the four destination-byte-offset kernel
+variants, the whole-row and word-containment rules — is absent here.
+
+**No device query.** With no per-product table, dispatch depends only on the
+descriptor. `lupine_hip_smemcpy_prepare_launch` is a pure function; there is no
+device property lookup and no cache.
+
+**No wave-width dependency.** The CUDA narrow kernels stagger stores across
+lane groups within a warp. On gfx1100 that measured as noise, winning and
+losing across repeats of the same shape, because these kernels are bound by
+mapped-read request rate rather than by their stores. Leaving it out means
+nothing here depends on the wave being 32 or 64 lanes wide, so the same source
+is correct on RDNA and CDNA without an architecture table.
+
+**Wide loads everywhere.** This is the change that matters on AMD.
+
+## Wide loads
+
+A one- to three-byte row sends every useful byte to a different destination
+sector, so no store can be widened. The load can be. Each thread pulls one
+aligned 8-byte word through the host link and unpacks it into that many
+scattered byte stores, rather than issuing the same bytes as separate loads.
+The scalar prefix that reaches a 128-byte source boundary is what makes the
+wide load aligned, and the bulk loop never reads past the fragment.
+
+Measured on an RX 7900 XTX (gfx1100), 8 MiB per copy, GB/s:
+
+| Shape | Byte loads | 8-byte loads |
+| --- | --- | --- |
+| width 1, pitch 64 | 2.49 | 6.42 |
+| width 2, pitch 256 | 2.45 | 6.19 |
+| width 3, pitch 256 | 2.86 | 6.44 |
+| width 5, pitch 13 | 2.28 | 6.43 |
+| width 33, pitch 67 | 2.30 | 6.44 |
+| width 1023, pitch 2047 | 2.29 | 6.45 |
+
+The same treatment applies to the general `width > 3` fallback, which is why
+the last three rows move as much as the narrow ones. Eight bytes beat both four
+and sixteen across widths and pitches.
+
+## Throughput
+
+End to end through the dispatcher on the same part, 8 MiB per copy:
+
+| Shape | GB/s |
+| --- | --- |
+| packed 4096 | 6.38 |
+| pitched vector, width 64, pitch 128 | 6.43 |
+| narrow width 1, pitch 64 | 6.42 |
+| narrow width 1, pitch 256 | 5.45 |
+| narrow width 1, pitch 512 | 3.74 |
+| narrow width 3, pitch 256 | 6.44 |
+| general width 127, pitch 255 | 6.44 |
+| general width 1023, pitch 2047 | 6.45 |
+
+A packed contiguous copy reaches 6.38 GB/s on this link, so almost every
+scattered shape now runs at the same rate as one. The exception is a one-byte
+row on a 512-byte pitch, where each useful byte necessarily causes its own
+destination sector transaction; that shape stays store-bound at 3.74 GB/s.
+Widening the destination representation is the only remaining lever there, as
+on NVIDIA.
+
+## Build
+
+CMake enables the HIP operation when a HIP compiler is found. The probe is a
+real try-compile, so the header-only container build — which copies HIP headers
+but no compiler — skips it. The CUDA and HIP operations are independent and
+either may be built alone.
+
+The build defaults to a fat binary over the supported CDNA and RDNA targets.
+`hipcc` alone emits `gfx906`, which loads but never runs on a newer card, and
+clang's `native` needs `/dev/kfd`, so it fails on GPU-less builders and under
+WSL. Override with `CMAKE_HIP_ARCHITECTURES`.
+
+## Correctness testing
+
+`hip_smemcpy_test` mirrors `smemcpy_test` case for case, comparing against
+native `hipMemcpy`, `hipMemcpy2DAsync`, and `hipMemcpy3DAsync` references
+rather than CUDA ones. The 156 comparisons plus the invalid-parameter checks
+pass on an RX 7900 XTX. Sizes around every load and vector boundary matter more
+here than on NVIDIA, since the unpacked wide load has its own prefix, bulk, and
+tail boundaries.
+
+```sh
+cmake --build build --target hip_smemcpy_test
+ctest --test-dir build -R hip_smemcpy_test --output-on-failure
+```
+
+GPU-less test hosts return CTest skip code 77.

--- a/ops/hip_smemcpy.h
+++ b/ops/hip_smemcpy.h
@@ -1,0 +1,67 @@
+#ifndef LUPINE_OPS_HIP_SMEMCPY_H
+#define LUPINE_OPS_HIP_SMEMCPY_H
+
+#include <hip/hip_runtime_api.h>
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Describes a packed fragment of a logically 3D byte region. The source is a
+// device-visible address, normally a mapped pinned-host ring slot. Destination
+// points at logical coordinate (0, 0, 0); its row and slice strides retain the
+// discontinuities that were removed while packing the source.
+//
+// Addresses are unsigned integers rather than hipDeviceptr_t, which is void *
+// and cannot carry the offset and alignment arithmetic this operation performs
+// on them.
+//
+// There is no alignment requirement for correctness. A 128-byte-aligned ring
+// base and slot stride minimize the scalar prefix. Matching the low four bits
+// of source and the first destination coordinate enables 16-byte accesses when
+// the destination width and strides also permit them. See ops/README.md.
+typedef struct lupine_hip_smemcpy_params {
+  unsigned long long destination;
+  unsigned long long source;
+  size_t logical_offset;
+  size_t bytes;
+  size_t width;
+  size_t rows;
+  size_t destination_row_stride;
+  size_t destination_slice_stride;
+} lupine_hip_smemcpy_params;
+
+// Fully describes the kernel launch selected for a set of parameters. Pass the
+// address of params as the kernel's sole argument. The prepared parameters may
+// be rebased relative to the input.
+typedef struct lupine_hip_smemcpy_launch {
+  lupine_hip_smemcpy_params params;
+  const void *kernel;
+  unsigned int blocks;
+  unsigned int threads;
+} lupine_hip_smemcpy_launch;
+
+// Selects the best safe implementation and launch geometry. Unlike the CUDA
+// operation this needs no device query: the AMD dispatch depends only on the
+// descriptor. This is useful to graph code constructing or updating an
+// equivalent kernel node.
+hipError_t
+lupine_hip_smemcpy_prepare_launch(const lupine_hip_smemcpy_params *params,
+                                  lupine_hip_smemcpy_launch *launch);
+
+// Enqueues one scatter copy. Source byte i is written to the pitched
+// destination coordinate represented by logical_offset + i.
+hipError_t lupine_hip_smemcpy_async(const lupine_hip_smemcpy_params *params,
+                                    hipStream_t stream);
+
+// Returns the fully general scalar kernel. Prefer prepare_launch: this symbol
+// is retained for graph code that controls its own launch geometry.
+const void *lupine_hip_smemcpy_kernel(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ops/hip_smemcpy.hip
+++ b/ops/hip_smemcpy.hip
@@ -1,0 +1,522 @@
+#include "ops/hip_smemcpy.h"
+
+#include <hip/hip_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+constexpr unsigned int kThreadsPerBlock = 256;
+constexpr size_t kMaximumBlocks = 65535;
+constexpr size_t kSourceTransactionAlignment = 128;
+// Every scatter kernel below pulls the source through one wide load per
+// thread. Measured on gfx1100, 8 bytes held ~6.4 GB/s across narrow and
+// general shapes alike, ahead of both 4- and 16-byte loads.
+constexpr size_t kScatterLoadBytes = 8;
+
+template <size_t Bytes> struct word_type;
+template <> struct word_type<1> {
+  using type = unsigned char;
+};
+template <> struct word_type<2> {
+  using type = unsigned short;
+};
+template <> struct word_type<4> {
+  using type = unsigned int;
+};
+template <> struct word_type<8> {
+  using type = unsigned long long;
+};
+template <> struct word_type<16> {
+  using type = uint4;
+};
+
+__host__ __device__ __forceinline__ size_t
+source_prefix(unsigned long long source, size_t bytes) {
+  size_t prefix =
+      (-static_cast<size_t>(source)) & (kSourceTransactionAlignment - 1);
+  return prefix < bytes ? prefix : bytes;
+}
+
+__device__ __forceinline__ void
+scatter_byte(const lupine_hip_smemcpy_params &params,
+             unsigned char *__restrict__ destination, size_t index,
+             unsigned char value) {
+  size_t logical = params.logical_offset + index;
+  size_t row_index = logical / params.width;
+  size_t x = logical - row_index * params.width;
+  size_t slice = row_index / params.rows;
+  size_t row = row_index - slice * params.rows;
+  destination[slice * params.destination_slice_stride +
+              row * params.destination_row_stride + x] = value;
+}
+
+__device__ __forceinline__ void
+scatter_2d_byte(const lupine_hip_smemcpy_params &params,
+                unsigned char *__restrict__ destination, size_t index,
+                unsigned char value) {
+  size_t logical = params.logical_offset + index;
+  size_t row = logical / params.width;
+  size_t x = logical - row * params.width;
+  destination[row * params.destination_row_stride + x] = value;
+}
+
+template <size_t Width>
+__device__ __forceinline__ void
+scatter_narrow_store(const lupine_hip_smemcpy_params &params,
+                     unsigned char *__restrict__ destination, size_t index,
+                     unsigned char value) {
+  size_t logical = params.logical_offset + index;
+  size_t row = logical / Width;
+  size_t x = logical - row * Width;
+  destination[row * params.destination_row_stride + x] = value;
+}
+
+template <size_t Width>
+__device__ __forceinline__ void
+scatter_narrow_3d_store(const lupine_hip_smemcpy_params &params,
+                        unsigned char *__restrict__ destination, size_t index,
+                        unsigned char value) {
+  size_t logical = params.logical_offset + index;
+  size_t row_index = logical / Width;
+  size_t x = logical - row_index * Width;
+  size_t slice = row_index / params.rows;
+  size_t row = row_index - slice * params.rows;
+  destination[slice * params.destination_slice_stride +
+              row * params.destination_row_stride + x] = value;
+}
+
+template <size_t WordBytes>
+__global__ void smemcpy_linear_kernel(lupine_hip_smemcpy_params params) {
+  using word = typename word_type<WordBytes>::type;
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination) +
+      params.logical_offset;
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    destination[thread] = source[thread];
+  }
+
+  size_t bulk_bytes = (params.bytes - prefix) & ~(WordBytes - 1);
+  for (size_t index = prefix + thread * WordBytes; index < prefix + bulk_bytes;
+       index += step * WordBytes) {
+    *reinterpret_cast<word *>(destination + index) =
+        *reinterpret_cast<const word *>(source + index);
+  }
+
+  size_t tail = params.bytes - prefix - bulk_bytes;
+  if (thread < tail) {
+    size_t index = prefix + bulk_bytes + thread;
+    destination[index] = source[index];
+  }
+}
+
+template <size_t WordBytes>
+__global__ void
+smemcpy_pitched_vector_kernel(lupine_hip_smemcpy_params params) {
+  using word = typename word_type<WordBytes>::type;
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_byte(params, destination, thread, source[thread]);
+  }
+
+  size_t bulk_bytes = (params.bytes - prefix) & ~(WordBytes - 1);
+  for (size_t index = prefix + thread * WordBytes; index < prefix + bulk_bytes;
+       index += step * WordBytes) {
+    size_t logical = params.logical_offset + index;
+    size_t row_index = logical / params.width;
+    size_t x = logical - row_index * params.width;
+    size_t slice = row_index / params.rows;
+    size_t row = row_index - slice * params.rows;
+    auto *output = destination + slice * params.destination_slice_stride +
+                   row * params.destination_row_stride + x;
+    *reinterpret_cast<word *>(output) =
+        *reinterpret_cast<const word *>(source + index);
+  }
+
+  size_t tail = params.bytes - prefix - bulk_bytes;
+  if (thread < tail) {
+    size_t index = prefix + bulk_bytes + thread;
+    scatter_byte(params, destination, index, source[index]);
+  }
+}
+
+template <size_t LoadBytes>
+__global__ void smemcpy_2d_kernel(lupine_hip_smemcpy_params params) {
+  using word = typename word_type<LoadBytes>::type;
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_2d_byte(params, destination, thread, source[thread]);
+  }
+
+  size_t bulk_bytes = (params.bytes - prefix) & ~(LoadBytes - 1);
+  for (size_t index = prefix + thread * LoadBytes; index < prefix + bulk_bytes;
+       index += step * LoadBytes) {
+    word packed = *reinterpret_cast<const word *>(source + index);
+    const auto *unpacked = reinterpret_cast<const unsigned char *>(&packed);
+#pragma unroll
+    for (size_t byte = 0; byte < LoadBytes; ++byte) {
+      scatter_2d_byte(params, destination, index + byte, unpacked[byte]);
+    }
+  }
+
+  size_t tail = params.bytes - prefix - bulk_bytes;
+  if (thread < tail) {
+    size_t index = prefix + bulk_bytes + thread;
+    scatter_2d_byte(params, destination, index, source[index]);
+  }
+}
+
+template <size_t LoadBytes>
+__global__ void smemcpy_3d_kernel(lupine_hip_smemcpy_params params) {
+  using word = typename word_type<LoadBytes>::type;
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_byte(params, destination, thread, source[thread]);
+  }
+
+  size_t bulk_bytes = (params.bytes - prefix) & ~(LoadBytes - 1);
+  for (size_t index = prefix + thread * LoadBytes; index < prefix + bulk_bytes;
+       index += step * LoadBytes) {
+    word packed = *reinterpret_cast<const word *>(source + index);
+    const auto *unpacked = reinterpret_cast<const unsigned char *>(&packed);
+#pragma unroll
+    for (size_t byte = 0; byte < LoadBytes; ++byte) {
+      scatter_byte(params, destination, index + byte, unpacked[byte]);
+    }
+  }
+
+  size_t tail = params.bytes - prefix - bulk_bytes;
+  if (thread < tail) {
+    size_t index = prefix + bulk_bytes + thread;
+    scatter_byte(params, destination, index, source[index]);
+  }
+}
+
+// A row one to three bytes wide sends every useful byte to a different
+// destination sector, so no store can be widened. The load can be: these
+// kernels are bound by how many mapped-read requests they issue, not by the
+// stores. Each thread pulls one aligned kScatterLoadBytes-wide word through the
+// host link and unpacks it into that many scattered byte stores, which
+// measured 2.5x the throughput of issuing the same bytes as separate loads.
+// The scalar prefix reaching a 128-byte source boundary is what makes the wide
+// load aligned.
+//
+// Unlike the CUDA operation there is no lane-group staggering around the
+// stores. That mitigates NVIDIA's serialized L1TEX store wavefronts; on
+// gfx1100 it measured as noise, winning and losing across repeats of the same
+// shape. Leaving it out keeps the operation free of any wave-width dependency,
+// so it is correct on wave32 and wave64 alike without an architecture table.
+template <size_t Width, size_t LoadBytes>
+__global__ void smemcpy_narrow_2d_kernel(lupine_hip_smemcpy_params params) {
+  using word = typename word_type<LoadBytes>::type;
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_narrow_store<Width>(params, destination, thread, source[thread]);
+  }
+
+  size_t bulk_bytes = (params.bytes - prefix) & ~(LoadBytes - 1);
+  for (size_t index = prefix + thread * LoadBytes; index < prefix + bulk_bytes;
+       index += step * LoadBytes) {
+    word packed = *reinterpret_cast<const word *>(source + index);
+    const auto *unpacked = reinterpret_cast<const unsigned char *>(&packed);
+#pragma unroll
+    for (size_t byte = 0; byte < LoadBytes; ++byte) {
+      scatter_narrow_store<Width>(params, destination, index + byte,
+                                  unpacked[byte]);
+    }
+  }
+
+  size_t tail = params.bytes - prefix - bulk_bytes;
+  if (thread < tail) {
+    size_t index = prefix + bulk_bytes + thread;
+    scatter_narrow_store<Width>(params, destination, index, source[index]);
+  }
+}
+
+template <size_t Width, size_t LoadBytes>
+__global__ void smemcpy_narrow_3d_kernel(lupine_hip_smemcpy_params params) {
+  using word = typename word_type<LoadBytes>::type;
+  const auto *__restrict__ source =
+      reinterpret_cast<const unsigned char *>(params.source);
+  auto *__restrict__ destination =
+      reinterpret_cast<unsigned char *>(params.destination);
+  size_t thread = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  size_t step = static_cast<size_t>(gridDim.x) * blockDim.x;
+  size_t prefix = source_prefix(params.source, params.bytes);
+
+  if (thread < prefix) {
+    scatter_narrow_3d_store<Width>(params, destination, thread, source[thread]);
+  }
+
+  size_t bulk_bytes = (params.bytes - prefix) & ~(LoadBytes - 1);
+  for (size_t index = prefix + thread * LoadBytes; index < prefix + bulk_bytes;
+       index += step * LoadBytes) {
+    word packed = *reinterpret_cast<const word *>(source + index);
+    const auto *unpacked = reinterpret_cast<const unsigned char *>(&packed);
+#pragma unroll
+    for (size_t byte = 0; byte < LoadBytes; ++byte) {
+      scatter_narrow_3d_store<Width>(params, destination, index + byte,
+                                     unpacked[byte]);
+    }
+  }
+
+  size_t tail = params.bytes - prefix - bulk_bytes;
+  if (thread < tail) {
+    size_t index = prefix + bulk_bytes + thread;
+    scatter_narrow_3d_store<Width>(params, destination, index, source[index]);
+  }
+}
+
+size_t blocks_for(size_t bytes, size_t bytes_per_thread) {
+  size_t block_bytes = kThreadsPerBlock * bytes_per_thread;
+  size_t blocks = bytes / block_bytes + (bytes % block_bytes != 0);
+  return std::min(std::max<size_t>(blocks, 1), kMaximumBlocks);
+}
+
+bool packed_destination(const lupine_hip_smemcpy_params &params,
+                        size_t slice_bytes) {
+  return params.destination_row_stride == params.width &&
+         params.destination_slice_stride == slice_bytes;
+}
+
+unsigned long long destination_at(const lupine_hip_smemcpy_params &params,
+                                  size_t logical) {
+  size_t row_index = logical / params.width;
+  size_t x = logical - row_index * params.width;
+  size_t slice = row_index / params.rows;
+  size_t row = row_index - slice * params.rows;
+  return params.destination + slice * params.destination_slice_stride +
+         row * params.destination_row_stride + x;
+}
+
+template <size_t WordBytes>
+bool can_vectorize_pitched(const lupine_hip_smemcpy_params &params,
+                           unsigned long long first_destination) {
+  constexpr size_t mask = WordBytes - 1;
+  return (params.width & mask) == 0 && (params.destination & mask) == 0 &&
+         (params.destination_row_stride & mask) == 0 &&
+         (params.destination_slice_stride & mask) == 0 &&
+         ((params.source ^ first_destination) & mask) == 0;
+}
+
+template <size_t WordBytes>
+void set_linear_launch(lupine_hip_smemcpy_launch *launch) {
+  launch->kernel =
+      reinterpret_cast<const void *>(smemcpy_linear_kernel<WordBytes>);
+  launch->blocks =
+      static_cast<unsigned int>(blocks_for(launch->params.bytes, WordBytes));
+}
+
+template <size_t WordBytes>
+void set_pitched_vector_launch(lupine_hip_smemcpy_launch *launch) {
+  launch->kernel =
+      reinterpret_cast<const void *>(smemcpy_pitched_vector_kernel<WordBytes>);
+  launch->blocks =
+      static_cast<unsigned int>(blocks_for(launch->params.bytes, WordBytes));
+}
+
+void select_linear_launch(lupine_hip_smemcpy_launch *launch,
+                          unsigned long long first_destination) {
+  uintptr_t different_alignment =
+      static_cast<uintptr_t>(launch->params.source ^ first_destination);
+  if ((different_alignment & 15) == 0) {
+    set_linear_launch<16>(launch);
+  } else if ((different_alignment & 7) == 0) {
+    set_linear_launch<8>(launch);
+  } else if ((different_alignment & 3) == 0) {
+    set_linear_launch<4>(launch);
+  } else if ((different_alignment & 1) == 0) {
+    set_linear_launch<2>(launch);
+  } else {
+    set_linear_launch<1>(launch);
+  }
+}
+
+bool select_pitched_vector_launch(lupine_hip_smemcpy_launch *launch,
+                                  unsigned long long first_destination) {
+  if (can_vectorize_pitched<16>(launch->params, first_destination)) {
+    set_pitched_vector_launch<16>(launch);
+  } else if (can_vectorize_pitched<8>(launch->params, first_destination)) {
+    set_pitched_vector_launch<8>(launch);
+  } else if (can_vectorize_pitched<4>(launch->params, first_destination)) {
+    set_pitched_vector_launch<4>(launch);
+  } else if (can_vectorize_pitched<2>(launch->params, first_destination)) {
+    set_pitched_vector_launch<2>(launch);
+  } else {
+    return false;
+  }
+  return true;
+}
+
+void set_narrow_2d_launch(lupine_hip_smemcpy_launch *launch, size_t width) {
+  constexpr size_t load = kScatterLoadBytes;
+  switch (width) {
+  case 1:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_2d_kernel<1, load>);
+    break;
+  case 2:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_2d_kernel<2, load>);
+    break;
+  default:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_2d_kernel<3, load>);
+    break;
+  }
+  launch->blocks =
+      static_cast<unsigned int>(blocks_for(launch->params.bytes, load));
+}
+
+void set_narrow_3d_launch(lupine_hip_smemcpy_launch *launch, size_t width) {
+  constexpr size_t load = kScatterLoadBytes;
+  switch (width) {
+  case 1:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_3d_kernel<1, load>);
+    break;
+  case 2:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_3d_kernel<2, load>);
+    break;
+  default:
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_narrow_3d_kernel<3, load>);
+    break;
+  }
+  launch->blocks =
+      static_cast<unsigned int>(blocks_for(launch->params.bytes, load));
+}
+
+} // namespace
+
+extern "C" const void *lupine_hip_smemcpy_kernel(void) {
+  return reinterpret_cast<const void *>(smemcpy_3d_kernel<kScatterLoadBytes>);
+}
+
+extern "C" hipError_t
+lupine_hip_smemcpy_prepare_launch(const lupine_hip_smemcpy_params *params,
+                                  lupine_hip_smemcpy_launch *launch) {
+  if (params == nullptr || launch == nullptr || params->width == 0 ||
+      params->rows == 0 ||
+      (params->bytes != 0 &&
+       (params->source == 0 || params->destination == 0)) ||
+      params->width > std::numeric_limits<size_t>::max() / params->rows ||
+      params->bytes >
+          std::numeric_limits<size_t>::max() - params->logical_offset) {
+    return hipErrorInvalidValue;
+  }
+
+  launch->params = *params;
+  launch->kernel =
+      reinterpret_cast<const void *>(smemcpy_3d_kernel<kScatterLoadBytes>);
+  launch->blocks = 0;
+  launch->threads = kThreadsPerBlock;
+  if (params->bytes == 0) {
+    return hipSuccess;
+  }
+
+  size_t slice_bytes = params->width * params->rows;
+  unsigned long long first_destination =
+      destination_at(*params, params->logical_offset);
+  if (packed_destination(*params, slice_bytes)) {
+    select_linear_launch(launch, first_destination);
+    return hipSuccess;
+  }
+
+  // Always prefer a vector store where the shape admits one. A width that
+  // vectorizes cleanly gains more from wide stores than a narrow kernel gains
+  // from batching its mapped reads.
+  if (select_pitched_vector_launch(launch, first_destination)) {
+    return hipSuccess;
+  }
+
+  size_t first_row_index = params->logical_offset / params->width;
+  size_t first_slice = first_row_index / params->rows;
+  size_t last_logical = params->logical_offset + params->bytes - 1;
+  size_t last_row_index = last_logical / params->width;
+  size_t last_slice = last_row_index / params->rows;
+
+  if (first_slice == last_slice) {
+    size_t first_row = first_row_index - first_slice * params->rows;
+    size_t first_x = params->logical_offset - first_row_index * params->width;
+    launch->params.destination =
+        params->destination + first_slice * params->destination_slice_stride +
+        first_row * params->destination_row_stride;
+    launch->params.logical_offset = first_x;
+    if (params->width <= 3) {
+      set_narrow_2d_launch(launch, params->width);
+    } else {
+      launch->kernel =
+          reinterpret_cast<const void *>(smemcpy_2d_kernel<kScatterLoadBytes>);
+      launch->blocks = static_cast<unsigned int>(
+          blocks_for(params->bytes, kScatterLoadBytes));
+    }
+    return hipSuccess;
+  }
+
+  if (first_slice != 0) {
+    launch->params.destination +=
+        first_slice * params->destination_slice_stride;
+    launch->params.logical_offset -= first_slice * slice_bytes;
+  }
+  if (params->width <= 3) {
+    set_narrow_3d_launch(launch, params->width);
+  } else {
+    launch->kernel =
+        reinterpret_cast<const void *>(smemcpy_3d_kernel<kScatterLoadBytes>);
+    launch->blocks =
+        static_cast<unsigned int>(blocks_for(params->bytes, kScatterLoadBytes));
+  }
+  return hipSuccess;
+}
+
+extern "C" hipError_t
+lupine_hip_smemcpy_async(const lupine_hip_smemcpy_params *params,
+                         hipStream_t stream) {
+  lupine_hip_smemcpy_launch launch = {};
+  hipError_t result = lupine_hip_smemcpy_prepare_launch(params, &launch);
+  if (result != hipSuccess || launch.blocks == 0) {
+    return result;
+  }
+
+  void *arguments[] = {&launch.params};
+  return hipLaunchKernel(launch.kernel, dim3(launch.blocks),
+                         dim3(launch.threads), arguments, 0, stream);
+}

--- a/ops/hip_smemcpy_test.hip
+++ b/ops/hip_smemcpy_test.hip
@@ -1,0 +1,548 @@
+#include "ops/hip_smemcpy.h"
+
+#include <hip/hip_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+namespace {
+
+constexpr unsigned char kUntouched = 0xcd;
+constexpr size_t kSourceBytes = 8 * 1024 * 1024 + 4096;
+
+bool check_hip(hipError_t status, const char *expression,
+               const char *case_name) {
+  if (status == hipSuccess) {
+    return true;
+  }
+  std::fprintf(stderr, "%s: %s failed: %s\n", case_name, expression,
+               hipGetErrorString(status));
+  return false;
+}
+
+#define CHECK_CASE(name, call)                                                 \
+  do {                                                                         \
+    if (!check_hip((call), #call, (name))) {                                   \
+      return false;                                                            \
+    }                                                                          \
+  } while (0)
+
+struct device_buffer {
+  unsigned char *data = nullptr;
+
+  ~device_buffer() {
+    if (data != nullptr) {
+      (void)hipFree(data);
+    }
+  }
+};
+
+template <typename NativeCopy>
+bool compare_with_native(const char *name, size_t allocation_bytes,
+                         size_t destination_offset, const unsigned char *host,
+                         unsigned long long mapped, size_t source_offset,
+                         lupine_hip_smemcpy_params params, hipStream_t stream,
+                         NativeCopy native_copy) {
+  if (allocation_bytes == 0 || source_offset > kSourceBytes ||
+      params.bytes > kSourceBytes - source_offset) {
+    std::fprintf(stderr, "%s: invalid test extent\n", name);
+    return false;
+  }
+
+  device_buffer expected;
+  device_buffer actual;
+  CHECK_CASE(name, hipMalloc(&expected.data, allocation_bytes));
+  CHECK_CASE(name, hipMalloc(&actual.data, allocation_bytes));
+  CHECK_CASE(name, hipMemsetAsync(expected.data, kUntouched, allocation_bytes,
+                                  stream));
+  CHECK_CASE(name,
+             hipMemsetAsync(actual.data, kUntouched, allocation_bytes, stream));
+  CHECK_CASE(name, native_copy(expected.data));
+
+  params.destination =
+      reinterpret_cast<unsigned long long>(actual.data + destination_offset);
+  params.source = mapped + source_offset;
+  CHECK_CASE(name, lupine_hip_smemcpy_async(&params, stream));
+  CHECK_CASE(name, hipStreamSynchronize(stream));
+
+  std::vector<unsigned char> expected_host(allocation_bytes);
+  std::vector<unsigned char> actual_host(allocation_bytes);
+  CHECK_CASE(name, hipMemcpy(expected_host.data(), expected.data,
+                             allocation_bytes, hipMemcpyDeviceToHost));
+  CHECK_CASE(name, hipMemcpy(actual_host.data(), actual.data, allocation_bytes,
+                             hipMemcpyDeviceToHost));
+  if (expected_host == actual_host) {
+    return true;
+  }
+
+  size_t mismatch = 0;
+  while (mismatch < allocation_bytes &&
+         expected_host[mismatch] == actual_host[mismatch]) {
+    ++mismatch;
+  }
+  std::fprintf(stderr,
+               "%s: mismatch at physical byte %zu: native=0x%02x "
+               "scatter=0x%02x\n",
+               name, mismatch, expected_host[mismatch], actual_host[mismatch]);
+  return false;
+}
+
+struct linear_case {
+  size_t logical_bytes;
+  size_t logical_offset;
+  size_t bytes;
+  size_t source_offset;
+  size_t destination_offset;
+};
+
+bool run_linear_case(const linear_case &test, const unsigned char *host,
+                     unsigned long long mapped, hipStream_t stream) {
+  char name[192];
+  std::snprintf(name, sizeof(name),
+                "hipMemcpyAsync 1D total=%zu offset=%zu bytes=%zu src=%zu "
+                "dst=%zu",
+                test.logical_bytes, test.logical_offset, test.bytes,
+                test.source_offset, test.destination_offset);
+  if (test.logical_offset > test.logical_bytes ||
+      test.bytes > test.logical_bytes - test.logical_offset) {
+    std::fprintf(stderr, "%s: invalid case\n", name);
+    return false;
+  }
+
+  lupine_hip_smemcpy_params params = {};
+  params.logical_offset = test.logical_offset;
+  params.bytes = test.bytes;
+  params.width = test.logical_bytes;
+  params.rows = 1;
+  params.destination_row_stride = test.logical_bytes;
+  params.destination_slice_stride = test.logical_bytes;
+  size_t allocation_bytes = test.destination_offset + test.logical_bytes;
+  return compare_with_native(
+      name, allocation_bytes, test.destination_offset, host, mapped,
+      test.source_offset, params, stream, [&](unsigned char *destination) {
+        return hipMemcpyAsync(destination + test.destination_offset +
+                                  test.logical_offset,
+                              host + test.source_offset, test.bytes,
+                              hipMemcpyHostToDevice, stream);
+      });
+}
+
+struct plane_case {
+  size_t width;
+  size_t rows;
+  size_t pitch;
+  size_t source_offset;
+  size_t destination_offset;
+};
+
+bool run_plane_case(const plane_case &test, const unsigned char *host,
+                    unsigned long long mapped, hipStream_t stream) {
+  char name[192];
+  std::snprintf(name, sizeof(name),
+                "hipMemcpy2DAsync width=%zu rows=%zu pitch=%zu src=%zu "
+                "dst=%zu",
+                test.width, test.rows, test.pitch, test.source_offset,
+                test.destination_offset);
+  if (test.width == 0 || test.rows == 0 || test.pitch < test.width) {
+    std::fprintf(stderr, "%s: invalid case\n", name);
+    return false;
+  }
+
+  size_t logical_bytes = test.width * test.rows;
+  size_t allocation_bytes =
+      test.destination_offset + (test.rows - 1) * test.pitch + test.width;
+  lupine_hip_smemcpy_params params = {};
+  params.bytes = logical_bytes;
+  params.width = test.width;
+  params.rows = test.rows;
+  params.destination_row_stride = test.pitch;
+  params.destination_slice_stride = test.pitch * test.rows;
+  return compare_with_native(
+      name, allocation_bytes, test.destination_offset, host, mapped,
+      test.source_offset, params, stream, [&](unsigned char *destination) {
+        return hipMemcpy2DAsync(destination + test.destination_offset,
+                                test.pitch, host + test.source_offset,
+                                test.width, test.width, test.rows,
+                                hipMemcpyHostToDevice, stream);
+      });
+}
+
+struct volume_case {
+  size_t width;
+  size_t rows;
+  size_t slices;
+  size_t pitch;
+  size_t destination_slice_rows;
+  size_t source_offset;
+  size_t destination_offset;
+};
+
+bool run_volume_case(const volume_case &test, const unsigned char *host,
+                     unsigned long long mapped, hipStream_t stream) {
+  char name[224];
+  std::snprintf(name, sizeof(name),
+                "hipMemcpy3DAsync width=%zu rows=%zu slices=%zu pitch=%zu "
+                "slice_rows=%zu src=%zu dst=%zu",
+                test.width, test.rows, test.slices, test.pitch,
+                test.destination_slice_rows, test.source_offset,
+                test.destination_offset);
+  if (test.width == 0 || test.rows == 0 || test.slices == 0 ||
+      test.pitch < test.width || test.destination_slice_rows < test.rows) {
+    std::fprintf(stderr, "%s: invalid case\n", name);
+    return false;
+  }
+
+  size_t slice_stride = test.pitch * test.destination_slice_rows;
+  size_t allocation_bytes = test.destination_offset +
+                            (test.slices - 1) * slice_stride +
+                            (test.rows - 1) * test.pitch + test.width;
+  lupine_hip_smemcpy_params params = {};
+  params.bytes = test.width * test.rows * test.slices;
+  params.width = test.width;
+  params.rows = test.rows;
+  params.destination_row_stride = test.pitch;
+  params.destination_slice_stride = slice_stride;
+  return compare_with_native(
+      name, allocation_bytes, test.destination_offset, host, mapped,
+      test.source_offset, params, stream, [&](unsigned char *destination) {
+        hipMemcpy3DParms copy = {};
+        copy.srcPtr = make_hipPitchedPtr(
+            const_cast<unsigned char *>(host + test.source_offset), test.width,
+            test.width, test.rows);
+        copy.dstPtr = make_hipPitchedPtr(destination + test.destination_offset,
+                                         test.pitch, test.width,
+                                         test.destination_slice_rows);
+        copy.extent = make_hipExtent(test.width, test.rows, test.slices);
+        copy.kind = hipMemcpyHostToDevice;
+        return hipMemcpy3DAsync(&copy, stream);
+      });
+}
+
+struct fragment_case {
+  size_t width;
+  size_t rows;
+  size_t slices;
+  size_t row_stride;
+  size_t slice_stride;
+  size_t logical_offset;
+  size_t bytes;
+  size_t source_offset;
+  size_t destination_offset;
+};
+
+bool run_fragment_case(const fragment_case &test, const unsigned char *host,
+                       unsigned long long mapped, hipStream_t stream) {
+  char name[256];
+  std::snprintf(name, sizeof(name),
+                "fragment width=%zu rows=%zu slices=%zu row_stride=%zu "
+                "slice_stride=%zu offset=%zu bytes=%zu src=%zu dst=%zu",
+                test.width, test.rows, test.slices, test.row_stride,
+                test.slice_stride, test.logical_offset, test.bytes,
+                test.source_offset, test.destination_offset);
+  size_t logical_bytes = test.width * test.rows * test.slices;
+  if (test.width == 0 || test.rows == 0 || test.slices == 0 ||
+      test.row_stride < test.width ||
+      test.slice_stride < test.row_stride * test.rows ||
+      test.logical_offset > logical_bytes ||
+      test.bytes > logical_bytes - test.logical_offset) {
+    std::fprintf(stderr, "%s: invalid case\n", name);
+    return false;
+  }
+
+  size_t allocation_bytes = test.destination_offset +
+                            (test.slices - 1) * test.slice_stride +
+                            (test.rows - 1) * test.row_stride + test.width;
+  lupine_hip_smemcpy_params params = {};
+  params.logical_offset = test.logical_offset;
+  params.bytes = test.bytes;
+  params.width = test.width;
+  params.rows = test.rows;
+  params.destination_row_stride = test.row_stride;
+  params.destination_slice_stride = test.slice_stride;
+  return compare_with_native(
+      name, allocation_bytes, test.destination_offset, host, mapped,
+      test.source_offset, params, stream, [&](unsigned char *destination) {
+        size_t logical = test.logical_offset;
+        size_t copied = 0;
+        while (copied < test.bytes) {
+          size_t row_index = logical / test.width;
+          size_t x = logical - row_index * test.width;
+          size_t slice = row_index / test.rows;
+          size_t row = row_index - slice * test.rows;
+          size_t chunk = std::min(test.bytes - copied, test.width - x);
+          hipError_t status = hipMemcpyAsync(
+              destination + test.destination_offset +
+                  slice * test.slice_stride + row * test.row_stride + x,
+              host + test.source_offset + copied, chunk, hipMemcpyHostToDevice,
+              stream);
+          if (status != hipSuccess) {
+            return status;
+          }
+          logical += chunk;
+          copied += chunk;
+        }
+        return hipSuccess;
+      });
+}
+
+bool expect_invalid(const char *name, const lupine_hip_smemcpy_params &params) {
+  lupine_hip_smemcpy_launch launch = {};
+  hipError_t status = lupine_hip_smemcpy_prepare_launch(&params, &launch);
+  if (status == hipErrorInvalidValue) {
+    return true;
+  }
+  std::fprintf(stderr, "%s: expected hipErrorInvalidValue, got %s\n", name,
+               hipGetErrorString(status));
+  return false;
+}
+
+bool run_parameter_validation() {
+  lupine_hip_smemcpy_launch launch = {};
+  lupine_hip_smemcpy_params params = {};
+  if (lupine_hip_smemcpy_prepare_launch(nullptr, &launch) !=
+          hipErrorInvalidValue ||
+      lupine_hip_smemcpy_prepare_launch(&params, nullptr) !=
+          hipErrorInvalidValue) {
+    std::fputs("null parameter validation failed\n", stderr);
+    return false;
+  }
+
+  params.rows = 1;
+  if (!expect_invalid("zero width", params)) {
+    return false;
+  }
+  params.width = 1;
+  params.rows = 0;
+  if (!expect_invalid("zero rows", params)) {
+    return false;
+  }
+  params.rows = 1;
+  params.bytes = 1;
+  if (!expect_invalid("null nonempty pointers", params)) {
+    return false;
+  }
+  params.source = 1;
+  params.destination = 1;
+  params.width = std::numeric_limits<size_t>::max();
+  params.rows = 2;
+  if (!expect_invalid("width times rows overflow", params)) {
+    return false;
+  }
+  params.width = 1;
+  params.rows = 1;
+  params.logical_offset = std::numeric_limits<size_t>::max();
+  params.bytes = 1;
+  if (!expect_invalid("logical extent overflow", params)) {
+    return false;
+  }
+
+  params = {};
+  params.width = 1;
+  params.rows = 1;
+  if (lupine_hip_smemcpy_prepare_launch(&params, &launch) != hipSuccess ||
+      launch.blocks != 0 ||
+      lupine_hip_smemcpy_async(&params, nullptr) != hipSuccess) {
+    std::fputs("zero-byte copy validation failed\n", stderr);
+    return false;
+  }
+  return true;
+}
+
+bool unavailable_hip(hipError_t status) {
+  return status == hipErrorNoDevice || status == hipErrorInsufficientDriver ||
+         status == hipErrorInitializationError;
+}
+
+} // namespace
+
+int main() {
+  hipError_t status = hipSetDeviceFlags(hipDeviceMapHost);
+  if (unavailable_hip(status)) {
+    std::printf("SKIP: HIP unavailable: %s\n", hipGetErrorString(status));
+    return 77;
+  }
+  if (!check_hip(status, "hipSetDeviceFlags", "initialization")) {
+    return 1;
+  }
+
+  int device_count = 0;
+  status = hipGetDeviceCount(&device_count);
+  if (unavailable_hip(status) || (status == hipSuccess && device_count == 0)) {
+    std::printf("SKIP: no HIP device available\n");
+    return 77;
+  }
+  if (!check_hip(status, "hipGetDeviceCount", "initialization")) {
+    return 1;
+  }
+  hipDeviceProp_t properties = {};
+  if (!check_hip(hipGetDeviceProperties(&properties, 0),
+                 "hipGetDeviceProperties", "initialization")) {
+    return 1;
+  }
+  if (!properties.canMapHostMemory) {
+    std::printf("SKIP: %s cannot map host memory\n", properties.name);
+    return 77;
+  }
+
+  unsigned char *host = nullptr;
+  if (!check_hip(hipHostMalloc(&host, kSourceBytes, hipHostMallocMapped),
+                 "hipHostMalloc", "initialization")) {
+    return 1;
+  }
+  for (size_t index = 0; index < kSourceBytes; ++index) {
+    host[index] = static_cast<unsigned char>(
+        (index * 131U + (index >> 7) * 29U + 17U) & 0xffU);
+  }
+  unsigned char *mapped_pointer = nullptr;
+  if (!check_hip(hipHostGetDevicePointer(
+                     reinterpret_cast<void **>(&mapped_pointer), host, 0),
+                 "hipHostGetDevicePointer", "initialization")) {
+    (void)hipHostFree(host);
+    return 1;
+  }
+  unsigned long long mapped =
+      reinterpret_cast<unsigned long long>(mapped_pointer);
+  hipStream_t stream = nullptr;
+  if (!check_hip(hipStreamCreate(&stream), "hipStreamCreate",
+                 "initialization")) {
+    (void)hipHostFree(host);
+    return 1;
+  }
+
+  const linear_case linear_cases[] = {
+      {1, 0, 1, 0, 0},
+      {2, 0, 2, 1, 0},
+      {3, 1, 1, 3, 1},
+      {7, 0, 7, 7, 3},
+      {15, 2, 11, 1, 5},
+      {16, 0, 16, 0, 0},
+      {17, 0, 17, 1, 0},
+      {31, 3, 27, 5, 9},
+      {32, 0, 32, 16, 0},
+      {63, 1, 61, 31, 7},
+      {64, 0, 64, 0, 0},
+      {127, 9, 111, 63, 13},
+      {128, 0, 128, 128, 0},
+      {129, 1, 127, 127, 1},
+      {255, 17, 223, 255, 15},
+      {256, 0, 256, 256, 0},
+      {4095, 31, 4001, 4095, 17},
+      {4096, 0, 4096, 0, 0},
+      {4097, 1, 4095, 1, 31},
+      {4 * 1024 * 1024, 0, 4 * 1024 * 1024, 0, 0},
+      {4 * 1024 * 1024 + 257, 127, 4 * 1024 * 1024, 63, 1},
+  };
+  for (const linear_case &test : linear_cases) {
+    if (!run_linear_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  const plane_case plane_cases[] = {
+      {1, 4097, 64, 0, 0},    {1, 4097, 128, 1, 1},     {1, 4097, 192, 31, 2},
+      {1, 4097, 256, 127, 3}, {1, 4097, 512, 255, 0},   {2, 2053, 64, 0, 0},
+      {2, 2053, 128, 1, 1},   {2, 2053, 256, 3, 2},     {2, 2053, 256, 5, 3},
+      {2, 2053, 512, 31, 0},  {3, 1367, 64, 0, 0},      {3, 1367, 128, 1, 1},
+      {3, 1367, 256, 2, 2},   {3, 1367, 256, 3, 1},     {3, 1367, 512, 31, 0},
+      {4, 1025, 64, 0, 0},    {7, 587, 64, 1, 3},       {8, 513, 64, 8, 0},
+      {15, 277, 64, 15, 1},   {16, 257, 64, 16, 0},     {31, 133, 64, 31, 7},
+      {32, 129, 64, 32, 0},   {33, 127, 128, 1, 9},     {63, 67, 128, 63, 3},
+      {64, 65, 128, 64, 0},   {127, 37, 256, 127, 11},  {128, 33, 256, 128, 0},
+      {129, 31, 258, 1, 1},   {255, 19, 510, 255, 13},  {256, 17, 512, 256, 0},
+      {257, 17, 514, 31, 7},  {4095, 3, 8190, 4095, 1}, {4096, 3, 8192, 0, 0},
+      {4097, 3, 8194, 1, 15},
+  };
+  for (const plane_case &test : plane_cases) {
+    if (!run_plane_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  const volume_case volume_cases[] = {
+      {1, 17, 5, 64, 17, 0, 0},      {1, 17, 5, 64, 19, 1, 1},
+      {2, 129, 4, 256, 129, 3, 2},   {2, 129, 4, 256, 132, 5, 3},
+      {3, 97, 5, 256, 97, 1, 1},     {3, 97, 5, 256, 99, 2, 2},
+      {4, 19, 7, 64, 23, 7, 3},      {7, 13, 5, 64, 15, 31, 5},
+      {16, 11, 4, 32, 13, 16, 0},    {31, 7, 3, 64, 9, 1, 7},
+      {64, 64, 8, 256, 66, 64, 0},   {127, 32, 7, 256, 35, 127, 9},
+      {128, 17, 6, 256, 19, 128, 0}, {129, 15, 5, 258, 18, 1, 1},
+      {256, 8, 4, 512, 10, 256, 0},  {4096, 4, 3, 8192, 6, 0, 0},
+  };
+  for (const volume_case &test : volume_cases) {
+    if (!run_volume_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  const fragment_case fragment_cases[] = {
+      {64, 5, 3, 80, 480, 3, 811, 3, 0},
+      {24, 7, 4, 40, 320, 5, 523, 5, 0},
+      {12, 9, 3, 20, 200, 7, 271, 3, 0},
+      {6, 11, 4, 10, 120, 1, 241, 1, 0},
+      {37, 11, 5, 61, 793, 398, 430, 17, 9},
+      {5, 13, 4, 19, 267, 83, 31, 7, 3},
+      {1, 257, 3, 17, 4385, 251, 281, 31, 7},
+      {1, 257, 3, 256, 66304, 11, 173, 31, 0},
+      {1, 257, 3, 256, 66304, 251, 281, 17, 1},
+      {1, 257, 3, 256, 65792, 251, 281, 9, 3},
+      {2, 129, 4, 18, 2340, 247, 293, 15, 5},
+      {3, 97, 5, 19, 1901, 283, 337, 1, 11},
+      {2, 129, 4, 256, 33024, 0, 1032, 0, 0},
+      {2, 129, 4, 256, 33024, 0, 1032, 1, 1},
+      {2, 129, 4, 256, 33024, 0, 1032, 3, 2},
+      {2, 129, 4, 256, 33024, 0, 1032, 5, 3},
+      {3, 97, 5, 256, 24832, 0, 1455, 0, 0},
+      {3, 97, 5, 256, 24832, 0, 1455, 1, 1},
+      {3, 97, 5, 256, 24832, 0, 1455, 2, 2},
+      {3, 97, 5, 256, 24896, 0, 1455, 3, 0},
+      {31, 7, 3, 31, 217, 19, 401, 9, 13},
+  };
+  for (const fragment_case &test : fragment_cases) {
+    if (!run_fragment_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  uint32_t random = 0x9e3779b9U;
+  constexpr int random_cases = 64;
+  for (int test_index = 0; test_index < random_cases; ++test_index) {
+    auto next = [&] {
+      random = random * 1664525U + 1013904223U;
+      return random;
+    };
+    fragment_case test = {};
+    test.width = 1 + next() % 257;
+    test.rows = 1 + next() % 33;
+    test.slices = 1 + next() % 7;
+    test.row_stride = test.width + next() % 129;
+    test.slice_stride = test.row_stride * test.rows + next() % 65;
+    size_t logical_bytes = test.width * test.rows * test.slices;
+    test.logical_offset = next() % logical_bytes;
+    test.bytes = 1 + next() % (logical_bytes - test.logical_offset);
+    test.source_offset = next() % 128;
+    test.destination_offset = next() % 32;
+    if (!run_fragment_case(test, host, mapped, stream)) {
+      return 1;
+    }
+  }
+
+  if (!run_parameter_validation()) {
+    return 1;
+  }
+  if (!check_hip(hipStreamDestroy(stream), "hipStreamDestroy", "cleanup") ||
+      !check_hip(hipHostFree(host), "hipHostFree", "cleanup")) {
+    return 1;
+  }
+
+  std::printf("PASS: %s: %zu native 1D, %zu native 2D, %zu native 3D, "
+              "%zu fragmented comparisons plus parameter validation\n",
+              properties.name, sizeof(linear_cases) / sizeof(linear_cases[0]),
+              sizeof(plane_cases) / sizeof(plane_cases[0]),
+              sizeof(volume_cases) / sizeof(volume_cases[0]),
+              sizeof(fragment_cases) / sizeof(fragment_cases[0]) +
+                  random_cases);
+  return 0;
+}


### PR DESCRIPTION
`ops/hip_smemcpy.hip` is the scatter memcpy for AMD GPUs. It is a separate
kernel rather than a portability layer over `smemcpy.cu`, so the two hardware
families can be tuned independently. `ops/smemcpy.cu`, `ops/smemcpy.h`, and
`ops/smemcpy_test.cu` are byte-for-byte unchanged.

Verified on an RX 7900 XTX (gfx1100): 156 comparisons plus the
invalid-parameter checks pass, byte for byte against native `hipMemcpy`,
`hipMemcpy2DAsync`, and `hipMemcpy3DAsync` references.

## Forking pays for itself immediately

Three pieces of the CUDA operation exist only to work around NVIDIA memory-system
behavior, and dropping them makes the AMD kernel simpler, not poorer:

- **The `atomicCAS` narrow-row paths.** They exist because a scattered warp
  store on NVIDIA is decomposed into serialized L1TEX wavefronts while atomics
  pass through to L2 atomic hardware. The per-product table, the four
  destination-byte-offset kernel variants, and the word-containment rules are
  all absent here.
- **The device query.** With no per-product table, dispatch depends only on the
  descriptor, so `prepare_launch` is a pure function — no property lookup, no
  thread-local cache, no error path.
- **Lane-group store staggering.** On gfx1100 this measured as noise, winning
  and losing across repeats of the same shape. Dropping it means nothing
  depends on the wave being 32 or 64 lanes, so one source is correct on RDNA
  and CDNA with no architecture table.

## What AMD actually wanted: wide loads

The narrow kernels turned out to be bound by mapped-read *request rate*, not by
their stores. A one- to three-byte row scatters every byte to a different
sector so no store can be widened — but the load can. Each thread now pulls one
aligned 8-byte word through the host link and unpacks it into that many
scattered byte stores. The existing 128-byte scalar prefix is what makes that
load aligned, and the bulk loop never reads past the fragment.

Measured on the 7900 XTX, 8 MiB per copy, GB/s:

| Shape | Byte loads | 8-byte loads |
| --- | --- | --- |
| width 1, pitch 64 | 2.49 | 6.42 |
| width 2, pitch 256 | 2.45 | 6.19 |
| width 3, pitch 256 | 2.86 | 6.44 |
| width 5, pitch 13 | 2.28 | 6.43 |
| width 33, pitch 67 | 2.30 | 6.44 |
| width 1023, pitch 2047 | 2.29 | 6.45 |

The same treatment applies to the general `width > 3` fallback, which is why
the wide shapes move as much as the narrow ones. Eight bytes beat both four and
sixteen across widths and pitches.

End to end through the dispatcher, a packed contiguous copy reaches 6.38 GB/s
on this link — so almost every scattered shape now runs at the same rate as
one. The exception is a one-byte row on a 512-byte pitch (3.74 GB/s), where
each useful byte necessarily causes its own destination sector transaction;
widening the destination representation is the only remaining lever, as on
NVIDIA.

## Build

CMake enables the HIP operation when a HIP compiler is found. The probe is a
real try-compile, so the header-only container build — HIP headers, no compiler
— skips it exactly as it does today. CUDA and HIP ops are independent and
either may be built alone.

The build defaults to a fat binary over the supported CDNA and RDNA targets.
`hipcc` alone emits `gfx906`, which loads but never runs on a newer card, and
clang's `native` needs `/dev/kfd`, so it fails on GPU-less builders and under
WSL. Override with `CMAKE_HIP_ARCHITECTURES`.

## CI

Nothing in CI compiled HIP device code, so this would have rotted silently.
Adds an `ops-device-code` job to `build-hip.yml` building against a real ROCm
toolchain in `rocm/dev-ubuntu-24.04:7.2.4`; the job steps were validated
locally in that image. No runner has an AMD GPU, so it is a compile check —
`hip_smemcpy_test` is run on hardware. Also extends the clang-format filter to
`.hip` so the new sources stay covered.
