### PR TITLE
Install nvcc on the Windows server runner

### DIFF
--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -24,10 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda:
-          - 13.3.1
-          - 12.9.1
-          - 11.8.0
+        include:
+          - cuda: 13.3.1
+          - cuda: 12.9.1
+          # The runner's MSVC postdates the host compilers CUDA 11.8 knows
+          # about, and nvcc rejects it outright without this.
+          - cuda: 11.8.0
+            cuda_flags: -allow-unsupported-compiler
 
     env:
       VCPKG_TARGET_TRIPLET: x64-windows-static
@@ -41,7 +44,9 @@ jobs:
         with:
           cuda: ${{ matrix.cuda }}
           method: network
-          sub-packages: '["cudart", "nvml_dev"]'
+          # nvcc and the MSBuild integration are what enable_language(CUDA)
+          # needs; without them CMake fails with "No CUDA toolset found".
+          sub-packages: '["cudart", "nvml_dev", "nvcc", "visual_studio_integration"]'
 
       - name: Set up vcpkg
         shell: pwsh
@@ -74,10 +79,11 @@ jobs:
             "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TARGET_TRIPLET" `
             "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" `
             "-DOPENSSL_USE_STATIC_LIBS=ON" `
+            "-DCMAKE_CUDA_FLAGS=${{ matrix.cuda_flags }}" `
             "-DCUDAToolkit_ROOT=$env:CUDA_PATH"
 
       - name: Build
-        run: cmake --build build/windows-server --config Release --target lupine_driver_server --parallel
+        run: cmake --build build/windows-server --config Release --target lupine_driver_server lupine_smemcpy --parallel
 
       - name: Verify the executable is self-contained
         shell: pwsh

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -25,12 +25,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # CUDA 13 split the nvcc headers out of the nvcc component, and
+          # cuda_runtime.h includes crt/host_config.h.
           - cuda: 13.3.1
+            crt_package: ', "crt"'
           - cuda: 12.9.1
-          # The runner's MSVC postdates the host compilers CUDA 11.8 knows
-          # about, and nvcc rejects it outright without this.
+          # The runner's MSVC both postdates the host compilers CUDA 11.8 knows
+          # about and static_asserts on nvcc this old from its own STL headers.
           - cuda: 11.8.0
-            cuda_flags: -allow-unsupported-compiler
+            cuda_flags: >-
+              -allow-unsupported-compiler
+              -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 
     env:
       VCPKG_TARGET_TRIPLET: x64-windows-static
@@ -46,7 +51,7 @@ jobs:
           method: network
           # nvcc and the MSBuild integration are what enable_language(CUDA)
           # needs; without them CMake fails with "No CUDA toolset found".
-          sub-packages: '["cudart", "nvml_dev", "nvcc", "visual_studio_integration"]'
+          sub-packages: '["cudart", "nvml_dev", "nvcc", "visual_studio_integration"${{ matrix.crt_package }}]'
 
       - name: Set up vcpkg
         shell: pwsh

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -25,17 +25,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # CUDA 13 split the nvcc headers out of the nvcc component, and
-          # cuda_runtime.h includes crt/host_config.h.
+          # CUDA 13 split the nvcc component: crt holds the host_config.h that
+          # cuda_runtime.h includes, and nvvm holds cicc, the device frontend.
           - cuda: 13.3.1
-            crt_package: ', "crt"'
+            extra_packages: ', "crt", "nvvm"'
           - cuda: 12.9.1
           # The runner's MSVC both postdates the host compilers CUDA 11.8 knows
           # about and static_asserts on nvcc this old from its own STL headers.
           - cuda: 11.8.0
             cuda_flags: >-
               -allow-unsupported-compiler
-              -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+              -Xcompiler=-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 
     env:
       VCPKG_TARGET_TRIPLET: x64-windows-static
@@ -51,7 +51,7 @@ jobs:
           method: network
           # nvcc and the MSBuild integration are what enable_language(CUDA)
           # needs; without them CMake fails with "No CUDA toolset found".
-          sub-packages: '["cudart", "nvml_dev", "nvcc", "visual_studio_integration"${{ matrix.crt_package }}]'
+          sub-packages: '["cudart", "nvml_dev", "nvcc", "visual_studio_integration"${{ matrix.extra_packages }}]'
 
       - name: Set up vcpkg
         shell: pwsh

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -33,12 +33,14 @@ jobs:
           # The runner's MSVC both postdates the host compilers CUDA 11.8 knows
           # about and static_asserts on nvcc this old from its own STL headers.
           - cuda: 11.8.0
-            cuda_flags: >-
-              -allow-unsupported-compiler
-              -Xcompiler=-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
+            cuda_flags: -allow-unsupported-compiler
+            host_defines: /D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 
     env:
       VCPKG_TARGET_TRIPLET: x64-windows-static
+      # MSBuild's CUDA integration drops defines passed through nvcc, so the
+      # STL version override has to reach cl.exe by its own environment.
+      CL: ${{ matrix.host_defines }}
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
`enable_language(CUDA)` landed in #661, but the Windows server-exe job installs only the `cudart` and `nvml_dev` sub-packages. Configure now fails on all three matrix legs with `No CUDA toolset found`, which is the only red workflow on main.

Install `nvcc` and `visual_studio_integration` so the CUDA language is actually available, and build `lupine_smemcpy` alongside the server so the Windows toolchain is exercised rather than just configured. CUDA 11.8's `host_config.h` rejects the runner's MSVC 19.44 outright, so that leg passes `-allow-unsupported-compiler`.

The published executable is unchanged: nothing links `lupine_smemcpy` yet.