### PR TITLE
Time each h2_test case and give the suite a bandwidth-aware timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,7 +454,10 @@ if(BUILD_TESTING AND NOT WIN32)
     target_link_libraries(h2_test PRIVATE lupine_rpc_core)
     lupine_apply_sanitizer(h2_test)
     add_test(NAME h2_test COMMAND h2_test)
-    lupine_scaled_timeout(h2_timeout 30)
+    # test_payload_larger_than_flow_control_window moves >2 GiB over loopback,
+    # so the suite is bandwidth-bound: it runs in ~4s here and has been measured
+    # anywhere from 6s to 29s on a contended macos-26-intel runner (issue #664).
+    lupine_scaled_timeout(h2_timeout 180)
     set_tests_properties(h2_test PROPERTIES TIMEOUT ${h2_timeout})
 
     add_executable(dispatch_test ${CMAKE_CURRENT_SOURCE_DIR}/dispatch_test.cpp)

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -58,12 +58,18 @@ struct h2_pair {
 };
 
 // Announce each case before it runs so a hang in CI names the case that hung
-// rather than just timing out the suite.
+// rather than just timing out the suite, and time it so a suite that creeps up
+// on its timeout names the case that got slow.
 #define RUN_CASE(call)                                                         \
   do {                                                                         \
     printf("  -> %s\n", #call);                                                \
     fflush(stdout);                                                            \
+    auto case_start = std::chrono::steady_clock::now();                        \
     call;                                                                      \
+    printf("     %.2f s\n", std::chrono::duration<double>(                     \
+                                std::chrono::steady_clock::now() - case_start) \
+                                .count());                                     \
+    fflush(stdout);                                                            \
   } while (0)
 
 void require(bool condition, const char *message) {


### PR DESCRIPTION
Fixes #664.

`h2_test` is not deadlocking. Its runtime on `macos-26-intel` is a continuous distribution that has grown into its 30s ctest timeout:

| run | h2_test |
| --- | --- |
| 33156894255 | 5.95s |
| 33155569184 | 7.81s |
| 33151935394 | 11.40s |
| 33149704237 | 12.56s |
| 33155931329 | 17.24s |
| 33153231805 | 20.17s |
| 33150202708 | 26.49s |
| 33150501549 | 27.86s |
| 33151142128 | 28.66s |
| 33155107217 | 29.26s |
| 33152428671, 33152959664, 33153858076, 33154681623 | timeout at 30.5s |

Passing runs reach 29.26s, so the timeouts are the tail of that distribution rather than a separate failure mode. `test_payload_larger_than_flow_control_window` moves more than 2 GiB over loopback to exceed the connection flow-control window, which is 2.64s of the 4.13s suite on Linux; on a contended shared Intel Mac that bandwidth varies about fivefold.

So: raise the suite timeout to 180s, and time each case so the next time the suite creeps toward its ceiling the log names which case got slow rather than only the case that was running when the clock ran out.