### PR TITLE
Reuse drained HTTP/2 staging buffers

### DIFF
--- a/h2.cpp
+++ b/h2.cpp
@@ -37,6 +37,8 @@ constexpr size_t kH2EncodeChunkBytes = 4 * 1024 * 1024;
 constexpr size_t kH2ProviderMinFrameBytes = 16 * 1024;
 constexpr size_t kH2ProviderMaxFrameBytes = 1024 * 1024;
 constexpr size_t kH2DecodeBufferBytes = 64 * 1024;
+// Retained capacity for drained staging buffers, a few frames' worth.
+constexpr size_t kH2StagingPoolBytes = 4 * 1024 * 1024;
 // Linux restarts slow start after an idle period of one retransmission
 // timeout. Keeping response waits below the usual 200 ms minimum RTO avoids
 // collapsing the congestion window between bursts on high-latency links.
@@ -84,6 +86,12 @@ struct h2_transport {
   rpc_http2_read_stats read_stats = {};
   uint64_t staged_bytes = 0;
   uint64_t window_held = 0;
+  // Drained staging buffers, kept for their capacity. A saturated stream
+  // stages one buffer per DATA frame, and reallocating each one costs more
+  // than the copy into it. Capped because a reader that falls behind can stage
+  // far more than it will ever need again.
+  std::vector<h2_buffer> buffer_pool;
+  size_t buffer_pool_bytes = 0;
   // LZ4F_compressBound includes a full worst-case block even for tiny input.
   // Writes are serialized, so retain one connection-wide workspace and track
   // its valid prefix separately instead of resizing/zeroing it per RPC.
@@ -156,6 +164,12 @@ void receive_bytes(h2_transport *transport, int32_t stream_id,
     return;
   }
   h2_buffer buffer;
+  if (!transport->buffer_pool.empty()) {
+    buffer = std::move(transport->buffer_pool.back());
+    transport->buffer_pool.pop_back();
+    transport->buffer_pool_bytes -= buffer.data.capacity();
+  }
+  buffer.offset = 0;
   buffer.data.assign(data, data + len);
   stream.local_out.push_back(std::move(buffer));
   transport->read_stats.staged_bytes += len;
@@ -1098,6 +1112,11 @@ int rpc_http2_read_stream(conn_t *conn, int32_t stream_id, void *data,
     transport->read_stats.staged_read_bytes += chunk;
     transport->staged_bytes -= chunk;
     if (front.offset == front.data.size()) {
+      if (transport->buffer_pool_bytes + front.data.capacity() <=
+          kH2StagingPoolBytes) {
+        transport->buffer_pool_bytes += front.data.capacity();
+        transport->buffer_pool.push_back(std::move(front));
+      }
       stream.local_out.pop_front();
     }
   }


### PR DESCRIPTION
`receive_bytes` allocated a fresh `std::vector` for every staged chunk — one per DATA frame, so a 2 GiB transfer whose reader falls behind allocates and frees ~32k buffers. Drained buffers now go back to a per-transport free list and are refilled in place, capped at 4 MiB of retained capacity so a reader that falls a long way behind does not pin what it will never need again.

Measured on a 2 GiB single-stream transfer over TCP loopback, medians of 7 interleaved runs:

| shape | baseline | pooled |
| --- | --- | --- |
| reader posts the whole destination first (what `rpc_read` does) | 0.94s | 0.94s |
| reader consumes 64 KiB at a time while the writer floods | 1.85s | 1.79s |
| reader consumes 1 MiB at a time while the writer floods | 1.56s | **1.05s (1.49x)** |

The direct path is untouched, as expected: it never stages. The win is on the staging path, which is what a reader behind the sender hits — including `rpc_read_pitched`, which reads a row at a time.

Uncapped the same benchmark gives 1.64x on the last row; the 4 MiB cap trades that for bounded retention.

All 7 test binaries pass.