### PR TITLE
Fix mapped host sync/free lifetime race

### DIFF
--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -1509,20 +1509,33 @@ extern "C" CUresult lupine_sync_mapped_device_to_host() {
       continue;
     }
     bool invalidated = false;
-    bool give_up = false;
-    for (int attempt = 0; !invalidated && !give_up; ++attempt) {
+    bool skip = false;
+    lupine_host_allocation *fallback_allocation = nullptr;
+    for (int attempt = 0;
+         !invalidated && !skip && fallback_allocation == nullptr; ++attempt) {
       {
         std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
         auto it = lupine_mutable_host_allocations_locked().find(mapping.host);
         if (it == lupine_mutable_host_allocations_locked().end()) {
+          skip = true;
           break;
         }
         auto &allocation = it->second;
+        auto hold_for_fallback = [&] {
+          // cuMemFreeHost waits for this reference before unmapping either
+          // client view, so the response can still land through the W alias.
+          __atomic_add_fetch(&allocation.pending_dirty_ranges, 1,
+                             __ATOMIC_ACQ_REL);
+          fallback_allocation = &allocation;
+        };
         conn_t *conn = lupine_route_remote_conn(
             lupine_route_from_identity(allocation.route_id));
-        if (!allocation.tracking_enabled || conn == nullptr ||
-            __atomic_load_n(&allocation.retiring, __ATOMIC_ACQUIRE) != 0) {
-          give_up = true;
+        if (__atomic_load_n(&allocation.retiring, __ATOMIC_ACQUIRE) != 0) {
+          skip = true;
+          break;
+        }
+        if (!allocation.tracking_enabled || conn == nullptr) {
+          hold_for_fallback();
           break;
         }
         sig_atomic_t previous =
@@ -1545,25 +1558,27 @@ extern "C" CUresult lupine_sync_mapped_device_to_host() {
             } else {
               __atomic_store_n(&allocation.device_stale, previous,
                                __ATOMIC_RELEASE);
-              give_up = true;
+              hold_for_fallback();
             }
           }
         }
-      }
-      if (!invalidated && !give_up) {
-        if (attempt >= LUPINE_MAPPED_INVALIDATE_MAX_ATTEMPTS) {
-          give_up = true;
-        } else {
-          sched_yield();
+        if (!invalidated && fallback_allocation == nullptr &&
+            attempt >= LUPINE_MAPPED_INVALIDATE_MAX_ATTEMPTS) {
+          hold_for_fallback();
         }
       }
+      if (!invalidated && !skip && fallback_allocation == nullptr) {
+        sched_yield();
+      }
     }
-    if (invalidated) {
+    if (invalidated || skip) {
       continue;
     }
     CUresult result = cuMemcpyDtoH_v2(
         static_cast<unsigned char *>(mapping.host) + mapping.data_offset,
         mapping.device_ptr + mapping.data_offset, mapping.data_bytes);
+    __atomic_sub_fetch(&fallback_allocation->pending_dirty_ranges, 1,
+                       __ATOMIC_RELEASE);
     if (result != CUDA_SUCCESS) {
       return result;
     }

--- a/test/test_host_free_sync_race.cu
+++ b/test/test_host_free_sync_race.cu
@@ -1,0 +1,94 @@
+// A stream synchronization snapshots all mapped host allocations so it can
+// invalidate device-written mirrors. A concurrent cudaFreeHost must not let
+// that synchronization use an allocation after its client views are unmapped.
+#include <atomic>
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <thread>
+#include <vector>
+
+static constexpr int kGuardAllocations = 64;
+static constexpr int kIterations = 1000;
+static constexpr size_t kBytes = 4096;
+
+static int fail(cudaError_t error, const char *operation) {
+  if (error == cudaSuccess) {
+    return 0;
+  }
+  printf("RESULT: ERROR %s: %s\n", operation, cudaGetErrorString(error));
+  return 1;
+}
+
+int main() {
+  int device_count = 0;
+  if (fail(cudaGetDeviceCount(&device_count), "cudaGetDeviceCount") ||
+      device_count == 0) {
+    return 2;
+  }
+
+  cudaStream_t stream = nullptr;
+  if (fail(cudaStreamCreate(&stream), "cudaStreamCreate")) {
+    return 2;
+  }
+
+  // Keep enough live mappings that a synchronize has meaningful work between
+  // taking its snapshot and reaching the newly allocated tail entry.
+  std::vector<void *> guards;
+  guards.reserve(kGuardAllocations);
+  for (int i = 0; i < kGuardAllocations; ++i) {
+    void *host = nullptr;
+    if (fail(cudaMallocHost(&host, kBytes), "guard cudaMallocHost")) {
+      return 2;
+    }
+    guards.push_back(host);
+  }
+
+  std::atomic<bool> stop{false};
+  std::atomic<cudaError_t> sync_error{cudaSuccess};
+  std::thread synchronizer([&] {
+    while (!stop.load(std::memory_order_acquire)) {
+      cudaError_t error = cudaStreamSynchronize(stream);
+      if (error != cudaSuccess) {
+        sync_error.store(error, std::memory_order_release);
+        break;
+      }
+    }
+  });
+
+  int result = 0;
+  for (int i = 0; i < kIterations; ++i) {
+    unsigned char *host = nullptr;
+    if (fail(cudaMallocHost(reinterpret_cast<void **>(&host), kBytes),
+             "racing cudaMallocHost")) {
+      result = 2;
+      break;
+    }
+    host[0] = static_cast<unsigned char>(i);
+    if (fail(cudaFreeHost(host), "racing cudaFreeHost")) {
+      result = 2;
+      break;
+    }
+  }
+
+  stop.store(true, std::memory_order_release);
+  synchronizer.join();
+  cudaError_t synchronize_result = sync_error.load(std::memory_order_acquire);
+  if (synchronize_result != cudaSuccess) {
+    fail(synchronize_result, "concurrent cudaStreamSynchronize");
+    result = 2;
+  }
+
+  for (void *host : guards) {
+    if (fail(cudaFreeHost(host), "guard cudaFreeHost")) {
+      result = 2;
+    }
+  }
+  if (fail(cudaStreamDestroy(stream), "cudaStreamDestroy")) {
+    result = 2;
+  }
+
+  if (result == 0) {
+    printf("RESULT: PASS\n");
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

- skip mapped-host snapshots that were removed or began retiring before synchronization invalidates them
- hold a lifetime reference while the D2H fallback writes through a live allocation alias
- add a GPU integration regression that races pinned-host allocation/free with synchronization of an unrelated stream

## Root cause

`lupine_sync_mapped_device_to_host()` snapshots all mapped host allocations. With concurrent CUDA calls, another thread could complete `cuMemFreeHost()` between that snapshot and the registry lookup. The missing/retiring path fell through to the D2H fallback with stale snapshot pointers, so the RPC response could write through an alias that had already been unmapped.

The new test widens that snapshot window with stable guard allocations. It SIGSEGVs immediately on the unfixed client and passes with this change.

## Testing

- `test_host_free_sync_race`: baseline SIGSEGV; patched `RESULT: PASS`
- `nvJPEGEncMultipleInstances -s 2 -j 2 -r 1`: baseline 4/50 SIGSEGV; patched 140/140 passes on `inferable-node-006` (RTX 4090)
- `ctest --test-dir build-repro --output-on-failure`: 13/13 passed, with 3 expected GPU-less skips
- `clang-format --dry-run --Werror cuda_client_memcpy.cpp test/test_host_free_sync_race.cu`
- `git diff --check`