### PR TITLE
Pipeline cross-server DtoD copies through the client

### DIFF
--- a/client_routing.h
+++ b/client_routing.h
@@ -50,6 +50,7 @@ extern "C" lupine_route lupine_route_for_graph(CUgraph graph);
 extern "C" lupine_route lupine_route_for_graph_node(CUgraphNode node);
 extern "C" lupine_route lupine_route_for_graph_exec(CUgraphExec exec);
 extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);
+extern "C" CUcontext lupine_context_for_deviceptr(CUdeviceptr ptr);
 
 extern "C" conn_t *lupine_rpc_conn_for_device(CUdevice *device);
 extern "C" conn_t *lupine_rpc_conn_for_current_context();

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -7937,13 +7937,25 @@ void *rpc_client_dispatch_thread(void *arg) {
       }
       size_t span = read.width + (read.rows - 1) * read.row_stride +
                     (read.slices - 1) * read.slice_stride;
-      read.source = static_cast<const unsigned char *>(
-          lupine_mapped_host_read_source(data, span));
       int request_id = rpc_read_end(conn);
       if (request_id < 0) {
         LUPINE_LOG_ERROR("Invalid host-memory side-effect request.");
         break;
       }
+
+      int device_source = lupine_write_cross_route_device_source(
+          conn, request_id, reinterpret_cast<CUdeviceptr>(data), read.width,
+          read.rows, read.row_stride, read.slices, read.slice_stride);
+      if (device_source < 0) {
+        LUPINE_LOG_ERROR("Failed to proxy cross-route device memory.");
+        break;
+      }
+      if (device_source == 0) {
+        continue;
+      }
+
+      read.source = static_cast<const unsigned char *>(
+          lupine_mapped_host_read_source(data, span));
 
       if (rpc_write_start_response(conn, request_id) < 0) {
         LUPINE_LOG_ERROR("Failed to return host-memory side effect.");

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -8104,8 +8104,9 @@ void *rpc_client_dispatch_thread(void *arg) {
       }
 
       int device_source = lupine_write_cross_route_device_source(
-          conn, request_id, reinterpret_cast<CUdeviceptr>(data), read.width,
-          read.rows, read.row_stride, read.slices, read.slice_stride);
+          conn, request_id,
+          reinterpret_cast<CUdeviceptr>(data) + read.logical_offset,
+          read.bytes);
       if (device_source < 0) {
         LUPINE_LOG_ERROR("Failed to proxy cross-route device memory.");
         break;

--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -2965,18 +2964,21 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
 // callback response with ordinary DtoH copies while the destination consumes
 // the other slot.
 struct lupine_cross_route_device_source {
+  static constexpr uint32_t slot_free = 0;
+  static constexpr uint32_t slot_ready = 1;
+
   struct slot {
     std::vector<unsigned char> storage;
     size_t size = 0;
-    bool ready = false;
+    std::atomic<uint32_t> state{slot_free};
   };
 
+  static_assert(std::atomic<uint32_t>::is_always_lock_free);
+  static_assert(std::atomic<CUresult>::is_always_lock_free);
+  static_assert(std::atomic<bool>::is_always_lock_free);
+
   ~lupine_cross_route_device_source() {
-    {
-      std::lock_guard<std::mutex> lock(mutex);
-      stopping = true;
-    }
-    condition.notify_all();
+    stopping.store(true, std::memory_order_release);
     if (worker.joinable()) {
       worker.join();
     }
@@ -2987,48 +2989,41 @@ struct lupine_cross_route_device_source {
   CUcontext source_context = nullptr;
   size_t bytes = 0;
   std::array<slot, 2> slots;
-  std::mutex mutex;
-  std::condition_variable condition;
   std::thread worker;
   size_t consumed_slots = 0;
   size_t consumed_bytes = 0;
-  CUresult error = CUDA_SUCCESS;
-  bool stopping = false;
+  std::atomic<CUresult> error{CUDA_SUCCESS};
+  std::atomic<bool> stopping{false};
 
   void produce() {
     CUresult context_result =
         lupine_set_current_context_on_route(source_route, source_context);
     if (context_result != CUDA_SUCCESS) {
-      std::lock_guard<std::mutex> lock(mutex);
-      error = context_result;
-      condition.notify_all();
+      error.store(context_result, std::memory_order_release);
       return;
     }
     size_t offset = 0;
     for (size_t slot_index = 0; offset < bytes; ++slot_index) {
       slot &entry = slots[slot_index % slots.size()];
-      {
-        std::unique_lock<std::mutex> lock(mutex);
-        condition.wait(lock, [&] { return stopping || !entry.ready; });
-        if (stopping) {
+      while (entry.state.load(std::memory_order_acquire) != slot_free) {
+        if (stopping.load(std::memory_order_acquire)) {
           return;
         }
-        entry.size = std::min(entry.storage.size(), bytes - offset);
+        std::this_thread::yield();
       }
+      if (stopping.load(std::memory_order_acquire)) {
+        return;
+      }
+      entry.size = std::min(entry.storage.size(), bytes - offset);
 
       CUresult result =
           cuMemcpyDtoH_v2(entry.storage.data(), source + offset, entry.size);
-      {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (result != CUDA_SUCCESS) {
-          error = result;
-          condition.notify_all();
-          return;
-        }
-        entry.ready = true;
+      if (result != CUDA_SUCCESS) {
+        error.store(result, std::memory_order_release);
+        return;
       }
+      entry.state.store(slot_ready, std::memory_order_release);
       offset += entry.size;
-      condition.notify_all();
     }
   }
 
@@ -3042,29 +3037,29 @@ struct lupine_cross_route_device_source {
   }
 
   int refill(rpc_write_cursor *cursor) {
-    std::unique_lock<std::mutex> lock(mutex);
     if (consumed_slots != 0) {
-      slots[(consumed_slots - 1) % slots.size()].ready = false;
-      condition.notify_all();
+      slots[(consumed_slots - 1) % slots.size()].state.store(
+          slot_free, std::memory_order_release);
     }
     if (consumed_bytes == bytes) {
       return 0;
     }
 
     slot &entry = slots[consumed_slots % slots.size()];
-    condition.wait(lock, [&] { return error != CUDA_SUCCESS || entry.ready; });
-    if (entry.ready) {
-      cursor->data = entry.storage.data();
-      cursor->size = entry.size;
-      ++consumed_slots;
-      consumed_bytes += entry.size;
-      return 1;
+    while (entry.state.load(std::memory_order_acquire) != slot_ready) {
+      CUresult source_error = error.load(std::memory_order_acquire);
+      if (source_error != CUDA_SUCCESS) {
+        LUPINE_LOG_ERROR(
+            "Cross-route DtoD source read failed: " << source_error);
+        return -1;
+      }
+      std::this_thread::yield();
     }
-    if (error != CUDA_SUCCESS) {
-      LUPINE_LOG_ERROR("Cross-route DtoD source read failed: " << error);
-      return -1;
-    }
-    return 0;
+    cursor->data = entry.storage.data();
+    cursor->size = entry.size;
+    ++consumed_slots;
+    consumed_bytes += entry.size;
+    return 1;
   }
 
   static int refill_cursor(void *opaque, rpc_write_cursor *cursor) {
@@ -3118,8 +3113,9 @@ extern "C" int lupine_write_cross_route_device_source(conn_t *destination_conn,
 
   rpc_write_cursor cursor(lupine_cross_route_device_source::refill_cursor,
                           &producer);
-  if (rpc_write_response_cursors(destination_conn, request_id, &cursor, 1) <
-      0) {
+  if (rpc_write_start_response(destination_conn, request_id) < 0 ||
+      rpc_write_cursors(destination_conn, &cursor, 1) < 0 ||
+      rpc_write_end(destination_conn) < 0) {
     return -1;
   }
   return 0;

--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -9,7 +9,6 @@
 #include <cstring>
 #include <map>
 #include <mutex>
-#include <thread>
 #ifndef _WIN32
 #include <fcntl.h>
 #include <sched.h>
@@ -2961,109 +2960,32 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
 
 // A destination server's ordinary HtoD callback treats its source address as
 // opaque. When that address belongs to another route, fill the unchanged
-// callback response with ordinary DtoH copies while the destination consumes
-// the other slot.
-struct lupine_cross_route_device_source {
-  static constexpr uint32_t slot_free = 0;
-  static constexpr uint32_t slot_ready = 1;
-
-  struct slot {
-    std::vector<unsigned char> storage;
-    size_t size = 0;
-    std::atomic<uint32_t> state{slot_free};
-  };
-
-  static_assert(std::atomic<uint32_t>::is_always_lock_free);
-  static_assert(std::atomic<CUresult>::is_always_lock_free);
-  static_assert(std::atomic<bool>::is_always_lock_free);
-
-  ~lupine_cross_route_device_source() {
-    stopping.store(true, std::memory_order_release);
-    if (worker.joinable()) {
-      worker.join();
-    }
-  }
-
-  CUdeviceptr source = 0;
-  lupine_route source_route;
-  CUcontext source_context = nullptr;
-  size_t bytes = 0;
-  std::array<slot, 2> slots;
-  std::thread worker;
-  size_t consumed_slots = 0;
-  size_t consumed_bytes = 0;
-  std::atomic<CUresult> error{CUDA_SUCCESS};
-  std::atomic<bool> stopping{false};
-
-  void produce() {
-    CUresult context_result =
-        lupine_set_current_context_on_route(source_route, source_context);
-    if (context_result != CUDA_SUCCESS) {
-      error.store(context_result, std::memory_order_release);
-      return;
-    }
-    size_t offset = 0;
-    for (size_t slot_index = 0; offset < bytes; ++slot_index) {
-      slot &entry = slots[slot_index % slots.size()];
-      while (entry.state.load(std::memory_order_acquire) != slot_free) {
-        if (stopping.load(std::memory_order_acquire)) {
-          return;
-        }
-        std::this_thread::yield();
-      }
-      if (stopping.load(std::memory_order_acquire)) {
-        return;
-      }
-      entry.size = std::min(entry.storage.size(), bytes - offset);
-
-      CUresult result =
-          cuMemcpyDtoH_v2(entry.storage.data(), source + offset, entry.size);
-      if (result != CUDA_SUCCESS) {
-        error.store(result, std::memory_order_release);
-        return;
-      }
-      entry.state.store(slot_ready, std::memory_order_release);
-      offset += entry.size;
-    }
-  }
-
-  bool start() {
-    try {
-      worker = std::thread(&lupine_cross_route_device_source::produce, this);
-    } catch (...) {
-      return false;
-    }
-    return true;
-  }
+// callback response with ordinary DtoH copies.
+struct lupine_cross_route_source_cursor {
+  CUdeviceptr address = 0;
+  size_t remaining = 0;
+  std::vector<unsigned char> storage;
 
   int refill(rpc_write_cursor *cursor) {
-    if (consumed_slots != 0) {
-      slots[(consumed_slots - 1) % slots.size()].state.store(
-          slot_free, std::memory_order_release);
-    }
-    if (consumed_bytes == bytes) {
+    if (remaining == 0) {
       return 0;
     }
 
-    slot &entry = slots[consumed_slots % slots.size()];
-    while (entry.state.load(std::memory_order_acquire) != slot_ready) {
-      CUresult source_error = error.load(std::memory_order_acquire);
-      if (source_error != CUDA_SUCCESS) {
-        LUPINE_LOG_ERROR(
-            "Cross-route DtoD source read failed: " << source_error);
-        return -1;
-      }
-      std::this_thread::yield();
+    size_t chunk = std::min(remaining, storage.size());
+    CUresult result = cuMemcpyDtoH_v2(storage.data(), address, chunk);
+    if (result != CUDA_SUCCESS) {
+      LUPINE_LOG_ERROR("Cross-route DtoD source read failed: " << result);
+      return -1;
     }
-    cursor->data = entry.storage.data();
-    cursor->size = entry.size;
-    ++consumed_slots;
-    consumed_bytes += entry.size;
+    cursor->data = storage.data();
+    cursor->size = chunk;
+    address += chunk;
+    remaining -= chunk;
     return 1;
   }
 
   static int refill_cursor(void *opaque, rpc_write_cursor *cursor) {
-    auto *source = static_cast<lupine_cross_route_device_source *>(opaque);
+    auto *source = static_cast<lupine_cross_route_source_cursor *>(opaque);
     return source == nullptr || cursor == nullptr ? -1 : source->refill(cursor);
   }
 };
@@ -3091,28 +3013,22 @@ extern "C" int lupine_write_cross_route_device_source(conn_t *destination_conn,
     return -1;
   }
 
-  lupine_cross_route_device_source producer;
-  producer.source = source;
-  producer.source_route = source_route;
-  producer.source_context = source_context;
-  producer.bytes = bytes;
+  lupine_cross_route_source_cursor source_cursor;
+  source_cursor.address = source;
+  source_cursor.remaining = bytes;
   try {
-    constexpr size_t source_chunk_bytes = LUPINE_RPC_TRANSFER_CHUNK_BYTES;
-    size_t remaining = producer.bytes;
-    for (auto &slot : producer.slots) {
-      size_t capacity = std::min(remaining, source_chunk_bytes);
-      slot.storage.resize(capacity);
-      remaining -= capacity;
-    }
+    source_cursor.storage.resize(
+        std::min(bytes, static_cast<size_t>(LUPINE_RPC_TRANSFER_CHUNK_BYTES)));
   } catch (...) {
     return -1;
   }
-  if (!producer.start()) {
+  if (lupine_set_current_context_on_route(source_route, source_context) !=
+      CUDA_SUCCESS) {
     return -1;
   }
 
-  rpc_write_cursor cursor(lupine_cross_route_device_source::refill_cursor,
-                          &producer);
+  rpc_write_cursor cursor(lupine_cross_route_source_cursor::refill_cursor,
+                          &source_cursor);
   if (rpc_write_start_response(destination_conn, request_id) < 0 ||
       rpc_write_cursors(destination_conn, &cursor, 1) < 0 ||
       rpc_write_end(destination_conn) < 0) {

--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -3,12 +3,14 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <map>
 #include <mutex>
+#include <thread>
 #ifndef _WIN32
 #include <fcntl.h>
 #include <sched.h>
@@ -2862,6 +2864,270 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
   return return_value;
 }
 
+// A destination server's ordinary HtoD callback treats its source address as
+// opaque. When that address belongs to another route, fill the unchanged
+// callback response with ordinary DtoH copies while the destination consumes
+// the other slot.
+struct lupine_cross_route_device_source {
+  enum slot_state { slot_free, slot_loading, slot_ready, slot_in_use };
+
+  struct slot {
+    std::vector<unsigned char> storage;
+    size_t logical_offset = 0;
+    size_t size = 0;
+    slot_state state = slot_free;
+  };
+
+  ~lupine_cross_route_device_source() {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      stopping = true;
+    }
+    condition.notify_all();
+    if (worker.joinable()) {
+      worker.join();
+    }
+  }
+
+  CUdeviceptr source = 0;
+  lupine_route source_route;
+  CUcontext source_context = nullptr;
+  size_t width = 0;
+  size_t rows = 0;
+  size_t row_stride = 0;
+  size_t slices = 0;
+  size_t slice_stride = 0;
+  size_t bytes = 0;
+  std::array<slot, 2> slots;
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::thread worker;
+  size_t next_offset = 0;
+  int consumer_slot = -1;
+  CUresult error = CUDA_SUCCESS;
+  bool finished = false;
+  bool stopping = false;
+
+  CUresult read(void *destination, size_t logical_offset,
+                size_t byte_count) const {
+    if (row_stride == width && slice_stride == width * rows) {
+      return cuMemcpyDtoH_v2(destination, source + logical_offset, byte_count);
+    }
+
+    auto *output = static_cast<unsigned char *>(destination);
+    size_t copied = 0;
+    while (copied < byte_count) {
+      size_t position = logical_offset + copied;
+      size_t row_index = position / width;
+      size_t x = position - row_index * width;
+      size_t slice = row_index / rows;
+      size_t row = row_index - slice * rows;
+      CUdeviceptr row_source =
+          source + slice * slice_stride + row * row_stride + x;
+      size_t remaining = byte_count - copied;
+      CUresult result = CUDA_SUCCESS;
+      if (x != 0 || remaining < width) {
+        size_t segment = std::min(remaining, width - x);
+        result = cuMemcpyDtoH_v2(output + copied, row_source, segment);
+        copied += segment;
+      } else {
+        size_t copied_rows = std::min(remaining / width, rows - row);
+        CUDA_MEMCPY2D copy = {};
+        copy.srcMemoryType = CU_MEMORYTYPE_DEVICE;
+        copy.srcDevice = row_source;
+        copy.srcPitch = row_stride;
+        copy.dstMemoryType = CU_MEMORYTYPE_HOST;
+        copy.dstHost = output + copied;
+        copy.dstPitch = width;
+        copy.WidthInBytes = width;
+        copy.Height = copied_rows;
+        result = cuMemcpy2D_v2(&copy);
+        copied += copied_rows * width;
+      }
+      if (result != CUDA_SUCCESS) {
+        return result;
+      }
+    }
+    return CUDA_SUCCESS;
+  }
+
+  void produce() {
+    CUresult context_result =
+        lupine_set_current_context_on_route(source_route, source_context);
+    if (context_result != CUDA_SUCCESS) {
+      std::lock_guard<std::mutex> lock(mutex);
+      error = context_result;
+      finished = true;
+      condition.notify_all();
+      return;
+    }
+    for (;;) {
+      size_t slot_index = 0;
+      size_t logical_offset = 0;
+      size_t chunk = 0;
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        condition.wait(lock, [&] {
+          return stopping || next_offset == bytes ||
+                 std::any_of(slots.begin(), slots.end(), [](const slot &entry) {
+                   return entry.state == slot_free;
+                 });
+        });
+        if (stopping) {
+          return;
+        }
+        if (next_offset == bytes) {
+          finished = true;
+          condition.notify_all();
+          return;
+        }
+        while (slots[slot_index].state != slot_free) {
+          ++slot_index;
+        }
+        slot &entry = slots[slot_index];
+        logical_offset = next_offset;
+        chunk = std::min(entry.storage.size(), bytes - next_offset);
+        next_offset += chunk;
+        entry.logical_offset = logical_offset;
+        entry.size = chunk;
+        entry.state = slot_loading;
+      }
+
+      CUresult result =
+          read(slots[slot_index].storage.data(), logical_offset, chunk);
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        slot &entry = slots[slot_index];
+        if (result != CUDA_SUCCESS) {
+          entry.state = slot_free;
+          error = result;
+          finished = true;
+          condition.notify_all();
+          return;
+        }
+        entry.state = slot_ready;
+      }
+      condition.notify_all();
+    }
+  }
+
+  bool start() {
+    try {
+      worker = std::thread(&lupine_cross_route_device_source::produce, this);
+    } catch (...) {
+      return false;
+    }
+    return true;
+  }
+
+  int refill(rpc_write_cursor *cursor) {
+    std::unique_lock<std::mutex> lock(mutex);
+    if (consumer_slot >= 0) {
+      slots[consumer_slot].state = slot_free;
+      consumer_slot = -1;
+      condition.notify_all();
+    }
+
+    condition.wait(lock, [&] {
+      return error != CUDA_SUCCESS || finished ||
+             std::any_of(slots.begin(), slots.end(), [](const slot &entry) {
+               return entry.state == slot_ready;
+             });
+    });
+    int ready_slot = -1;
+    for (size_t index = 0; index < slots.size(); ++index) {
+      if (slots[index].state == slot_ready &&
+          (ready_slot < 0 ||
+           slots[index].logical_offset < slots[ready_slot].logical_offset)) {
+        ready_slot = static_cast<int>(index);
+      }
+    }
+    if (ready_slot >= 0) {
+      slot &entry = slots[ready_slot];
+      entry.state = slot_in_use;
+      consumer_slot = ready_slot;
+      cursor->data = entry.storage.data();
+      cursor->size = entry.size;
+      return 1;
+    }
+    if (error != CUDA_SUCCESS) {
+      LUPINE_LOG_ERROR("Cross-route DtoD source read failed: " << error);
+      return -1;
+    }
+    return 0;
+  }
+};
+
+static int lupine_refill_cross_route_device_source(void *opaque,
+                                                   rpc_write_cursor *cursor) {
+  auto *source = static_cast<lupine_cross_route_device_source *>(opaque);
+  if (source == nullptr || cursor == nullptr) {
+    return -1;
+  }
+  return source->refill(cursor);
+}
+
+// Returns 1 when the address is not a cross-route device source, 0 after
+// writing its complete response, and -1 on a transport or source-copy error.
+extern "C" int lupine_write_cross_route_device_source(
+    conn_t *destination_conn, int request_id, CUdeviceptr source, size_t width,
+    size_t rows, size_t row_stride, size_t slices, size_t slice_stride) {
+  if (destination_conn == nullptr || source == 0 ||
+      !lupine_deviceptr_is_tracked(source) ||
+      lupine_copy_pointer_is_host(source)) {
+    return 1;
+  }
+  lupine_route source_route = lupine_route_for_deviceptr(source);
+  lupine_route destination_route =
+      lupine_remote_route_for_conn(destination_conn);
+  if (lupine_route_is_local(source_route) ||
+      lupine_routes_share_server(source_route, destination_route)) {
+    return 1;
+  }
+  if (width == 0 || rows == 0 || slices == 0 || width > SIZE_MAX / rows ||
+      width * rows > SIZE_MAX / slices) {
+    return -1;
+  }
+  CUcontext source_context = lupine_context_for_deviceptr(source);
+  if (source_context == nullptr) {
+    return -1;
+  }
+
+  lupine_cross_route_device_source producer;
+  producer.source = source;
+  producer.source_route = source_route;
+  producer.source_context = source_context;
+  producer.width = width;
+  producer.rows = rows;
+  producer.row_stride = row_stride;
+  producer.slices = slices;
+  producer.slice_stride = slice_stride;
+  producer.bytes = width * rows * slices;
+  try {
+    // The ordinary source DtoH path pipelines transfers at this size while
+    // keeping client memory independent of the complete copy size.
+    constexpr size_t source_chunk_bytes = 8 * LUPINE_RPC_TRANSFER_CHUNK_BYTES;
+    size_t remaining = producer.bytes;
+    for (auto &slot : producer.slots) {
+      size_t capacity = std::min(remaining, source_chunk_bytes);
+      slot.storage.resize(capacity);
+      remaining -= capacity;
+    }
+  } catch (...) {
+    return -1;
+  }
+  if (!producer.start()) {
+    return -1;
+  }
+
+  rpc_write_cursor cursor(lupine_refill_cross_route_device_source, &producer);
+  if (rpc_write_response_cursors(destination_conn, request_id, &cursor, 1) <
+      0) {
+    return -1;
+  }
+  return 0;
+}
+
 // The chunks are staged in a bounded pool on the server, so a copy of any size
 // costs the same fixed staging there.
 extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
@@ -3014,6 +3280,33 @@ extern "C" CUresult cuMemcpyHtoDAsync(CUdeviceptr dstDevice,
   return cuMemcpyHtoDAsync_v2(dstDevice, srcHost, ByteCount, hStream);
 }
 
+static bool lupine_device_copy_uses_remote_callback(CUdeviceptr destination,
+                                                    CUdeviceptr source) {
+  if (!lupine_deviceptr_is_tracked(source) ||
+      lupine_copy_pointer_is_host(source)) {
+    return false;
+  }
+  lupine_route destination_route = lupine_route_for_deviceptr(destination);
+  lupine_route source_route = lupine_route_for_deviceptr(source);
+  return !lupine_route_is_local(destination_route) &&
+         !lupine_route_is_local(source_route) &&
+         !lupine_routes_share_server(destination_route, source_route);
+}
+
+static CUDA_MEMCPY2D lupine_device_source_as_host(const CUDA_MEMCPY2D &copy) {
+  CUDA_MEMCPY2D staged = copy;
+  staged.srcMemoryType = CU_MEMORYTYPE_HOST;
+  staged.srcHost = reinterpret_cast<const void *>(copy.srcDevice);
+  return staged;
+}
+
+static CUDA_MEMCPY3D lupine_device_source_as_host(const CUDA_MEMCPY3D &copy) {
+  CUDA_MEMCPY3D staged = copy;
+  staged.srcMemoryType = CU_MEMORYTYPE_HOST;
+  staged.srcHost = reinterpret_cast<const void *>(copy.srcDevice);
+  return staged;
+}
+
 extern "C" CUresult
 lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                                size_t ByteCount, CUstream hStream, bool async) {
@@ -3024,6 +3317,12 @@ lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                    << " stream=" << hStream);
   if (ByteCount == 0) {
     return CUDA_SUCCESS;
+  }
+
+  if (lupine_device_copy_uses_remote_callback(dstDevice, srcDevice)) {
+    const void *source = reinterpret_cast<const void *>(srcDevice);
+    return async ? cuMemcpyHtoDAsync_v2(dstDevice, source, ByteCount, hStream)
+                 : cuMemcpyHtoD_v2(dstDevice, source, ByteCount);
   }
 
   constexpr size_t chunk_size = 16 * 1024 * 1024;
@@ -3285,7 +3584,11 @@ extern "C" CUresult cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy) {
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      // Different devices: the rows route through the client.
+      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
+                                                  copy.srcDevice)) {
+        CUDA_MEMCPY2D staged = lupine_device_source_as_host(copy);
+        return cuMemcpy2D_v2(&staged);
+      }
       for (size_t row = 0; row < copy.Height; ++row) {
         return_value = lupine_cuMemcpyDtoD_via_client(
             copy.dstDevice + (copy.dstY + row) * copy.dstPitch +
@@ -3428,7 +3731,11 @@ extern "C" CUresult cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy) {
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      // Different devices: the rows route through the client.
+      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
+                                                  copy.srcDevice)) {
+        CUDA_MEMCPY2D staged = lupine_device_source_as_host(copy);
+        return cuMemcpy2DUnaligned_v2(&staged);
+      }
       for (size_t row = 0; row < copy.Height; ++row) {
         return_value = lupine_cuMemcpyDtoD_via_client(
             copy.dstDevice + (copy.dstY + row) * copy.dstPitch +
@@ -3574,7 +3881,11 @@ extern "C" CUresult cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy,
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      // Different devices: the rows route through the client.
+      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
+                                                  copy.srcDevice)) {
+        CUDA_MEMCPY2D staged = lupine_device_source_as_host(copy);
+        return cuMemcpy2DAsync_v2(&staged, hStream);
+      }
       for (size_t row = 0; row < copy.Height; ++row) {
         return_value = lupine_cuMemcpyDtoD_via_client(
             copy.dstDevice + (copy.dstY + row) * copy.dstPitch +
@@ -3736,7 +4047,11 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      // Different devices: the rows route through the client.
+      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
+                                                  copy.srcDevice)) {
+        CUDA_MEMCPY3D staged = lupine_device_source_as_host(copy);
+        return cuMemcpy3D_v2(&staged);
+      }
       for (size_t z = 0; z < copy.Depth; ++z) {
         for (size_t row = 0; row < copy.Height; ++row) {
           return_value = lupine_cuMemcpyDtoD_via_client(
@@ -3886,7 +4201,11 @@ extern "C" CUresult cuMemcpy3DAsync_v2(const CUDA_MEMCPY3D *pCopy,
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      // Different devices: the rows route through the client.
+      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
+                                                  copy.srcDevice)) {
+        CUDA_MEMCPY3D staged = lupine_device_source_as_host(copy);
+        return cuMemcpy3DAsync_v2(&staged, hStream);
+      }
       for (size_t z = 0; z < copy.Depth; ++z) {
         for (size_t row = 0; row < copy.Height; ++row) {
           return_value = lupine_cuMemcpyDtoD_via_client(

--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -745,8 +745,9 @@ static std::vector<lupine_mapped_host_snapshot> lupine_mapped_host_snapshots() {
   return snapshots;
 }
 
-extern "C" void lupine_mark_mapped_host_kernel_params(
-    void *const *kernel_params, const size_t *sizes, uint32_t count) {
+extern "C" void
+lupine_mark_mapped_host_kernel_params(void *const *kernel_params,
+                                      const size_t *sizes, uint32_t count) {
   if (kernel_params == nullptr || sizes == nullptr || count == 0) {
     return;
   }
@@ -769,11 +770,9 @@ extern "C" void lupine_mark_mapped_host_kernel_params(
         continue;
       }
       uintptr_t host = reinterpret_cast<uintptr_t>(entry.first);
-      bool matches_host =
-          argument >= host && argument < host + allocation.size;
-      bool matches_device =
-          argument >= allocation.device_ptr &&
-          argument < allocation.device_ptr + allocation.size;
+      bool matches_host = argument >= host && argument < host + allocation.size;
+      bool matches_device = argument >= allocation.device_ptr &&
+                            argument < allocation.device_ptr + allocation.size;
       bool matches_server =
           allocation.server_host_ptr != 0 &&
           argument >= allocation.server_host_ptr &&
@@ -2965,13 +2964,10 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
 // callback response with ordinary DtoH copies while the destination consumes
 // the other slot.
 struct lupine_cross_route_device_source {
-  enum slot_state { slot_free, slot_loading, slot_ready, slot_in_use };
-
   struct slot {
     std::vector<unsigned char> storage;
-    size_t logical_offset = 0;
     size_t size = 0;
-    slot_state state = slot_free;
+    bool ready = false;
   };
 
   ~lupine_cross_route_device_source() {
@@ -2988,64 +2984,15 @@ struct lupine_cross_route_device_source {
   CUdeviceptr source = 0;
   lupine_route source_route;
   CUcontext source_context = nullptr;
-  size_t width = 0;
-  size_t rows = 0;
-  size_t row_stride = 0;
-  size_t slices = 0;
-  size_t slice_stride = 0;
   size_t bytes = 0;
   std::array<slot, 2> slots;
   std::mutex mutex;
   std::condition_variable condition;
   std::thread worker;
-  size_t next_offset = 0;
-  int consumer_slot = -1;
+  size_t consumed_slots = 0;
   CUresult error = CUDA_SUCCESS;
   bool finished = false;
   bool stopping = false;
-
-  CUresult read(void *destination, size_t logical_offset,
-                size_t byte_count) const {
-    if (row_stride == width && slice_stride == width * rows) {
-      return cuMemcpyDtoH_v2(destination, source + logical_offset, byte_count);
-    }
-
-    auto *output = static_cast<unsigned char *>(destination);
-    size_t copied = 0;
-    while (copied < byte_count) {
-      size_t position = logical_offset + copied;
-      size_t row_index = position / width;
-      size_t x = position - row_index * width;
-      size_t slice = row_index / rows;
-      size_t row = row_index - slice * rows;
-      CUdeviceptr row_source =
-          source + slice * slice_stride + row * row_stride + x;
-      size_t remaining = byte_count - copied;
-      CUresult result = CUDA_SUCCESS;
-      if (x != 0 || remaining < width) {
-        size_t segment = std::min(remaining, width - x);
-        result = cuMemcpyDtoH_v2(output + copied, row_source, segment);
-        copied += segment;
-      } else {
-        size_t copied_rows = std::min(remaining / width, rows - row);
-        CUDA_MEMCPY2D copy = {};
-        copy.srcMemoryType = CU_MEMORYTYPE_DEVICE;
-        copy.srcDevice = row_source;
-        copy.srcPitch = row_stride;
-        copy.dstMemoryType = CU_MEMORYTYPE_HOST;
-        copy.dstHost = output + copied;
-        copy.dstPitch = width;
-        copy.WidthInBytes = width;
-        copy.Height = copied_rows;
-        result = cuMemcpy2D_v2(&copy);
-        copied += copied_rows * width;
-      }
-      if (result != CUDA_SUCCESS) {
-        return result;
-      }
-    }
-    return CUDA_SUCCESS;
-  }
 
   void produce() {
     CUresult context_result =
@@ -3057,54 +3004,38 @@ struct lupine_cross_route_device_source {
       condition.notify_all();
       return;
     }
-    for (;;) {
-      size_t slot_index = 0;
-      size_t logical_offset = 0;
-      size_t chunk = 0;
+    size_t offset = 0;
+    for (size_t slot_index = 0; offset < bytes; ++slot_index) {
+      slot &entry = slots[slot_index % slots.size()];
       {
         std::unique_lock<std::mutex> lock(mutex);
-        condition.wait(lock, [&] {
-          return stopping || next_offset == bytes ||
-                 std::any_of(slots.begin(), slots.end(), [](const slot &entry) {
-                   return entry.state == slot_free;
-                 });
-        });
+        condition.wait(lock, [&] { return stopping || !entry.ready; });
         if (stopping) {
           return;
         }
-        if (next_offset == bytes) {
-          finished = true;
-          condition.notify_all();
-          return;
-        }
-        while (slots[slot_index].state != slot_free) {
-          ++slot_index;
-        }
-        slot &entry = slots[slot_index];
-        logical_offset = next_offset;
-        chunk = std::min(entry.storage.size(), bytes - next_offset);
-        next_offset += chunk;
-        entry.logical_offset = logical_offset;
-        entry.size = chunk;
-        entry.state = slot_loading;
+        entry.size = std::min(entry.storage.size(), bytes - offset);
       }
 
       CUresult result =
-          read(slots[slot_index].storage.data(), logical_offset, chunk);
+          cuMemcpyDtoH_v2(entry.storage.data(), source + offset, entry.size);
       {
         std::lock_guard<std::mutex> lock(mutex);
-        slot &entry = slots[slot_index];
         if (result != CUDA_SUCCESS) {
-          entry.state = slot_free;
           error = result;
           finished = true;
           condition.notify_all();
           return;
         }
-        entry.state = slot_ready;
+        entry.ready = true;
       }
+      offset += entry.size;
       condition.notify_all();
     }
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      finished = true;
+    }
+    condition.notify_all();
   }
 
   bool start() {
@@ -3118,32 +3049,18 @@ struct lupine_cross_route_device_source {
 
   int refill(rpc_write_cursor *cursor) {
     std::unique_lock<std::mutex> lock(mutex);
-    if (consumer_slot >= 0) {
-      slots[consumer_slot].state = slot_free;
-      consumer_slot = -1;
+    if (consumed_slots != 0) {
+      slots[(consumed_slots - 1) % slots.size()].ready = false;
       condition.notify_all();
     }
 
-    condition.wait(lock, [&] {
-      return error != CUDA_SUCCESS || finished ||
-             std::any_of(slots.begin(), slots.end(), [](const slot &entry) {
-               return entry.state == slot_ready;
-             });
-    });
-    int ready_slot = -1;
-    for (size_t index = 0; index < slots.size(); ++index) {
-      if (slots[index].state == slot_ready &&
-          (ready_slot < 0 ||
-           slots[index].logical_offset < slots[ready_slot].logical_offset)) {
-        ready_slot = static_cast<int>(index);
-      }
-    }
-    if (ready_slot >= 0) {
-      slot &entry = slots[ready_slot];
-      entry.state = slot_in_use;
-      consumer_slot = ready_slot;
+    slot &entry = slots[consumed_slots % slots.size()];
+    condition.wait(
+        lock, [&] { return error != CUDA_SUCCESS || entry.ready || finished; });
+    if (entry.ready) {
       cursor->data = entry.storage.data();
       cursor->size = entry.size;
+      ++consumed_slots;
       return 1;
     }
     if (error != CUDA_SUCCESS) {
@@ -3165,9 +3082,10 @@ static int lupine_refill_cross_route_device_source(void *opaque,
 
 // Returns 1 when the address is not a cross-route device source, 0 after
 // writing its complete response, and -1 on a transport or source-copy error.
-extern "C" int lupine_write_cross_route_device_source(
-    conn_t *destination_conn, int request_id, CUdeviceptr source, size_t width,
-    size_t rows, size_t row_stride, size_t slices, size_t slice_stride) {
+extern "C" int lupine_write_cross_route_device_source(conn_t *destination_conn,
+                                                      int request_id,
+                                                      CUdeviceptr source,
+                                                      size_t bytes) {
   if (destination_conn == nullptr || source == 0 ||
       !lupine_deviceptr_is_tracked(source) ||
       lupine_copy_pointer_is_host(source)) {
@@ -3180,10 +3098,6 @@ extern "C" int lupine_write_cross_route_device_source(
       lupine_routes_share_server(source_route, destination_route)) {
     return 1;
   }
-  if (width == 0 || rows == 0 || slices == 0 || width > SIZE_MAX / rows ||
-      width * rows > SIZE_MAX / slices) {
-    return -1;
-  }
   CUcontext source_context = lupine_context_for_deviceptr(source);
   if (source_context == nullptr) {
     return -1;
@@ -3193,16 +3107,9 @@ extern "C" int lupine_write_cross_route_device_source(
   producer.source = source;
   producer.source_route = source_route;
   producer.source_context = source_context;
-  producer.width = width;
-  producer.rows = rows;
-  producer.row_stride = row_stride;
-  producer.slices = slices;
-  producer.slice_stride = slice_stride;
-  producer.bytes = width * rows * slices;
+  producer.bytes = bytes;
   try {
-    // The ordinary source DtoH path pipelines transfers at this size while
-    // keeping client memory independent of the complete copy size.
-    constexpr size_t source_chunk_bytes = 8 * LUPINE_RPC_TRANSFER_CHUNK_BYTES;
+    constexpr size_t source_chunk_bytes = LUPINE_RPC_TRANSFER_CHUNK_BYTES;
     size_t remaining = producer.bytes;
     for (auto &slot : producer.slots) {
       size_t capacity = std::min(remaining, source_chunk_bytes);
@@ -3387,20 +3294,6 @@ static bool lupine_device_copy_uses_remote_callback(CUdeviceptr destination,
   return !lupine_route_is_local(destination_route) &&
          !lupine_route_is_local(source_route) &&
          !lupine_routes_share_server(destination_route, source_route);
-}
-
-static CUDA_MEMCPY2D lupine_device_source_as_host(const CUDA_MEMCPY2D &copy) {
-  CUDA_MEMCPY2D staged = copy;
-  staged.srcMemoryType = CU_MEMORYTYPE_HOST;
-  staged.srcHost = reinterpret_cast<const void *>(copy.srcDevice);
-  return staged;
-}
-
-static CUDA_MEMCPY3D lupine_device_source_as_host(const CUDA_MEMCPY3D &copy) {
-  CUDA_MEMCPY3D staged = copy;
-  staged.srcMemoryType = CU_MEMORYTYPE_HOST;
-  staged.srcHost = reinterpret_cast<const void *>(copy.srcDevice);
-  return staged;
 }
 
 extern "C" CUresult
@@ -3680,11 +3573,6 @@ extern "C" CUresult cuMemcpy2D_v2(const CUDA_MEMCPY2D *pCopy) {
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
-                                                  copy.srcDevice)) {
-        CUDA_MEMCPY2D staged = lupine_device_source_as_host(copy);
-        return cuMemcpy2D_v2(&staged);
-      }
       for (size_t row = 0; row < copy.Height; ++row) {
         return_value = lupine_cuMemcpyDtoD_via_client(
             copy.dstDevice + (copy.dstY + row) * copy.dstPitch +
@@ -3827,11 +3715,6 @@ extern "C" CUresult cuMemcpy2DUnaligned_v2(const CUDA_MEMCPY2D *pCopy) {
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
-                                                  copy.srcDevice)) {
-        CUDA_MEMCPY2D staged = lupine_device_source_as_host(copy);
-        return cuMemcpy2DUnaligned_v2(&staged);
-      }
       for (size_t row = 0; row < copy.Height; ++row) {
         return_value = lupine_cuMemcpyDtoD_via_client(
             copy.dstDevice + (copy.dstY + row) * copy.dstPitch +
@@ -3977,11 +3860,6 @@ extern "C" CUresult cuMemcpy2DAsync_v2(const CUDA_MEMCPY2D *pCopy,
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
-                                                  copy.srcDevice)) {
-        CUDA_MEMCPY2D staged = lupine_device_source_as_host(copy);
-        return cuMemcpy2DAsync_v2(&staged, hStream);
-      }
       for (size_t row = 0; row < copy.Height; ++row) {
         return_value = lupine_cuMemcpyDtoD_via_client(
             copy.dstDevice + (copy.dstY + row) * copy.dstPitch +
@@ -4143,11 +4021,6 @@ extern "C" CUresult cuMemcpy3D_v2(const CUDA_MEMCPY3D *pCopy) {
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
-                                                  copy.srcDevice)) {
-        CUDA_MEMCPY3D staged = lupine_device_source_as_host(copy);
-        return cuMemcpy3D_v2(&staged);
-      }
       for (size_t z = 0; z < copy.Depth; ++z) {
         for (size_t row = 0; row < copy.Height; ++row) {
           return_value = lupine_cuMemcpyDtoD_via_client(
@@ -4297,11 +4170,6 @@ extern "C" CUresult cuMemcpy3DAsync_v2(const CUDA_MEMCPY3D *pCopy,
     if (copy.srcMemoryType != CU_MEMORYTYPE_ARRAY &&
         copy.dstMemoryType != CU_MEMORYTYPE_ARRAY &&
         !lupine_deviceptrs_share_route(copy.dstDevice, copy.srcDevice)) {
-      if (lupine_device_copy_uses_remote_callback(copy.dstDevice,
-                                                  copy.srcDevice)) {
-        CUDA_MEMCPY3D staged = lupine_device_source_as_host(copy);
-        return cuMemcpy3DAsync_v2(&staged, hStream);
-      }
       for (size_t z = 0; z < copy.Depth; ++z) {
         for (size_t row = 0; row < copy.Height; ++row) {
           return_value = lupine_cuMemcpyDtoD_via_client(

--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -2958,38 +2958,6 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
   return return_value;
 }
 
-// A destination server's ordinary HtoD callback treats its source address as
-// opaque. When that address belongs to another route, fill the unchanged
-// callback response with ordinary DtoH copies.
-struct lupine_cross_route_source_cursor {
-  CUdeviceptr address = 0;
-  size_t remaining = 0;
-  std::vector<unsigned char> storage;
-
-  int refill(rpc_write_cursor *cursor) {
-    if (remaining == 0) {
-      return 0;
-    }
-
-    size_t chunk = std::min(remaining, storage.size());
-    CUresult result = cuMemcpyDtoH_v2(storage.data(), address, chunk);
-    if (result != CUDA_SUCCESS) {
-      LUPINE_LOG_ERROR("Cross-route DtoD source read failed: " << result);
-      return -1;
-    }
-    cursor->data = storage.data();
-    cursor->size = chunk;
-    address += chunk;
-    remaining -= chunk;
-    return 1;
-  }
-
-  static int refill_cursor(void *opaque, rpc_write_cursor *cursor) {
-    auto *source = static_cast<lupine_cross_route_source_cursor *>(opaque);
-    return source == nullptr || cursor == nullptr ? -1 : source->refill(cursor);
-  }
-};
-
 // Returns 1 when the address is not a cross-route device source, 0 after
 // writing its complete response, and -1 on a transport or source-copy error.
 extern "C" int lupine_write_cross_route_device_source(conn_t *destination_conn,
@@ -3013,7 +2981,11 @@ extern "C" int lupine_write_cross_route_device_source(conn_t *destination_conn,
     return -1;
   }
 
-  lupine_cross_route_source_cursor source_cursor;
+  struct source_cursor_state {
+    CUdeviceptr address = 0;
+    size_t remaining = 0;
+    std::vector<unsigned char> storage;
+  } source_cursor;
   source_cursor.address = source;
   source_cursor.remaining = bytes;
   try {
@@ -3027,8 +2999,29 @@ extern "C" int lupine_write_cross_route_device_source(conn_t *destination_conn,
     return -1;
   }
 
-  rpc_write_cursor cursor(lupine_cross_route_source_cursor::refill_cursor,
-                          &source_cursor);
+  auto refill_source = [](void *opaque, rpc_write_cursor *cursor) -> int {
+    auto *source = static_cast<source_cursor_state *>(opaque);
+    if (source == nullptr || cursor == nullptr) {
+      return -1;
+    }
+    if (source->remaining == 0) {
+      return 0;
+    }
+
+    size_t chunk = std::min(source->remaining, source->storage.size());
+    CUresult result =
+        cuMemcpyDtoH_v2(source->storage.data(), source->address, chunk);
+    if (result != CUDA_SUCCESS) {
+      LUPINE_LOG_ERROR("Cross-route DtoD source read failed: " << result);
+      return -1;
+    }
+    cursor->data = source->storage.data();
+    cursor->size = chunk;
+    source->address += chunk;
+    source->remaining -= chunk;
+    return 1;
+  };
+  rpc_write_cursor cursor(refill_source, &source_cursor);
   if (rpc_write_start_response(destination_conn, request_id) < 0 ||
       rpc_write_cursors(destination_conn, &cursor, 1) < 0 ||
       rpc_write_end(destination_conn) < 0) {

--- a/cuda_client_memcpy.h
+++ b/cuda_client_memcpy.h
@@ -4,10 +4,15 @@
 #include "cuda_compat.h"
 #undef LUPINE_CUDA_COMPAT_TYPES_ONLY
 
+typedef struct conn_t conn_t;
+
 extern "C" bool lupine_copy_pointer_is_host(CUdeviceptr ptr);
 extern "C" bool lupine_host_ptr_is_page_locked(const void *host);
 extern "C" bool lupine_is_managed_host_alias(CUdeviceptr ptr);
 extern "C" const void *lupine_mapped_host_read_source(const void *host,
                                                       size_t size);
+extern "C" int lupine_write_cross_route_device_source(
+    conn_t *destination_conn, int request_id, CUdeviceptr source, size_t width,
+    size_t rows, size_t row_stride, size_t slices, size_t slice_stride);
 extern "C" CUresult lupine_sync_mapped_device_to_host();
 extern "C" void lupine_materialize_host_allocations();

--- a/cuda_client_memcpy.h
+++ b/cuda_client_memcpy.h
@@ -11,9 +11,10 @@ extern "C" bool lupine_host_ptr_is_page_locked(const void *host);
 extern "C" bool lupine_is_managed_host_alias(CUdeviceptr ptr);
 extern "C" const void *lupine_mapped_host_read_source(const void *host,
                                                       size_t size);
-extern "C" int lupine_write_cross_route_device_source(
-    conn_t *destination_conn, int request_id, CUdeviceptr source, size_t width,
-    size_t rows, size_t row_stride, size_t slices, size_t slice_stride);
+extern "C" int lupine_write_cross_route_device_source(conn_t *destination_conn,
+                                                      int request_id,
+                                                      CUdeviceptr source,
+                                                      size_t bytes);
 extern "C" void
 lupine_mark_mapped_host_kernel_params(void *const *kernel_params,
                                       const size_t *sizes, uint32_t count);

--- a/h2.cpp
+++ b/h2.cpp
@@ -135,6 +135,7 @@ void h2_release_codecs(h2_stream &stream) {
 
 struct h2_write_source {
   std::vector<rpc_write_cursor> *cursors = nullptr;
+  rpc_write_cursor *refill_cursor = nullptr;
   size_t index = 0;
   uint64_t progress = 0;
   std::vector<unsigned char> pending;
@@ -348,12 +349,17 @@ ssize_t h2_data_source_read_callback(nghttp2_session *, int32_t stream_id,
     rpc_write_cursor *cursor = nullptr;
     if (write_source->cursors != nullptr) {
       auto &cursors = *write_source->cursors;
-      while (write_source->index < cursors.size() &&
-             cursors[write_source->index].remaining() == 0) {
+      while (write_source->index < cursors.size()) {
+        auto &candidate = cursors[write_source->index];
+        if (candidate.remaining() != 0) {
+          cursor = &candidate;
+          break;
+        }
+        if (candidate.refill != nullptr && !candidate.exhausted) {
+          write_source->refill_cursor = &candidate;
+          return NGHTTP2_ERR_DEFERRED;
+        }
         ++write_source->index;
-      }
-      if (write_source->index < cursors.size()) {
-        cursor = &cursors[write_source->index];
       }
     }
 
@@ -408,7 +414,7 @@ ssize_t h2_data_source_read_callback(nghttp2_session *, int32_t stream_id,
     cursor->size -= input;
     input_budget -= input;
     write_source->progress += input;
-    if (cursor->size == 0) {
+    if (cursor->size == 0 && cursor->refill == nullptr) {
       ++write_source->index;
     }
   }
@@ -871,6 +877,28 @@ int h2_send_source_locked(h2_transport *transport, int32_t stream_id,
       result = -1;
       break;
     }
+    if (source->refill_cursor != nullptr) {
+      rpc_write_cursor *cursor = source->refill_cursor;
+      pthread_mutex_unlock(&transport->session_mutex);
+      int refill = cursor->refill(cursor->refill_context, cursor);
+      pthread_mutex_lock(&transport->session_mutex);
+      source->refill_cursor = nullptr;
+      if (transport->transport_failed || refill < 0 ||
+          (refill == 0 && cursor->remaining() != 0) ||
+          (refill > 0 &&
+           (cursor->data == nullptr || cursor->remaining() == 0))) {
+        result = -1;
+        break;
+      }
+      if (refill == 0) {
+        cursor->exhausted = true;
+      }
+      if (nghttp2_session_resume_data(transport->session, stream_id) != 0) {
+        result = -1;
+        break;
+      }
+      continue;
+    }
     if (source->progress == progress &&
         pthread_cond_wait(&transport->session_progress,
                           &transport->session_mutex) != 0) {
@@ -1163,10 +1191,9 @@ int rpc_http2_read(conn_t *conn, void *data, size_t size) {
 int rpc_http2_write_stream(conn_t *conn, int32_t stream_id,
                            std::vector<rpc_write_cursor> &cursors) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
-  if (std::all_of(cursors.begin(), cursors.end(),
-                  [](const rpc_write_cursor &cursor) {
-                    return cursor.remaining() == 0;
-                  })) {
+  if (std::all_of(
+          cursors.begin(), cursors.end(),
+          [](const rpc_write_cursor &cursor) { return !cursor.pending(); })) {
     return 0;
   }
 

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1192,6 +1192,89 @@ void test_lz4_content_encoding_round_trip() {
   require(received_suffix == suffix, "LZ4 suffix mismatch");
 }
 
+struct refill_chunks {
+  std::vector<std::string> chunks;
+  size_t index = 0;
+  size_t calls = 0;
+};
+
+int refill_next_chunk(void *opaque, rpc_write_cursor *cursor) {
+  auto *source = static_cast<refill_chunks *>(opaque);
+  ++source->calls;
+  if (source->index == source->chunks.size()) {
+    return 0;
+  }
+  const std::string &chunk = source->chunks[source->index++];
+  cursor->data = reinterpret_cast<const unsigned char *>(chunk.data());
+  cursor->size = chunk.size();
+  return 1;
+}
+
+void test_refillable_cursor_round_trip() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+
+  refill_chunks source;
+  source.chunks = {
+      "first", std::string(LUPINE_RPC_TRANSFER_CHUNK_BYTES + 17, 'x'), "last"};
+  std::string expected = "prefix";
+  for (const auto &chunk : source.chunks) {
+    expected += chunk;
+  }
+  expected += "suffix";
+
+  std::string received;
+  std::thread reader(
+      [&] { received = read_string(&pair.server, expected.size()); });
+  std::string prefix = "prefix";
+  std::string suffix = "suffix";
+  std::vector<rpc_write_cursor> cursors = {
+      rpc_write_cursor(prefix.data(), prefix.size()),
+      rpc_write_cursor(refill_next_chunk, &source),
+      rpc_write_cursor(suffix.data(), suffix.size())};
+  require(rpc_http2_write(&pair.client, cursors) == 0,
+          "refillable cursor write failed");
+  reader.join();
+
+  require(received == expected, "refillable cursor payload mismatch");
+  require(source.calls == source.chunks.size() + 1,
+          "refillable cursor did not reach EOF exactly once");
+}
+
+void test_refillable_cursor_across_flow_control_window() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+
+  refill_chunks source;
+  constexpr size_t chunk_size = LUPINE_FF_STAGING_WINDOW_BYTES / 2;
+  source.chunks.resize(3, std::string(chunk_size, '\0'));
+  uint32_t seed = 91;
+  for (auto &chunk : source.chunks) {
+    for (char &byte : chunk) {
+      seed = seed * 1664525u + 1013904223u;
+      byte = static_cast<char>(seed >> 24);
+    }
+  }
+
+  std::string received;
+  std::thread reader([&] {
+    received = read_string(&pair.server, chunk_size * source.chunks.size());
+  });
+  rpc_write_cursor cursor(refill_next_chunk, &source);
+  std::vector<rpc_write_cursor> cursors = {cursor};
+  require(rpc_http2_write(&pair.client, cursors) == 0,
+          "flow-controlled refillable cursor write failed");
+  reader.join();
+
+  for (size_t index = 0; index < source.chunks.size(); ++index) {
+    require(received.compare(index * chunk_size, chunk_size,
+                             source.chunks[index]) == 0,
+            "flow-controlled refillable cursor payload mismatch");
+  }
+  require(source.calls == source.chunks.size() + 1,
+          "flow-controlled refillable cursor did not reach EOF exactly once");
+}
+
 void test_rpc_write_queue_grows() {
   conn_t zero_length = {};
   require(rpc_write(&zero_length, nullptr, 0) == 0,
@@ -1563,7 +1646,9 @@ int main() {
   RUN_CASE(test_socket_reader_hands_off_between_streams());
   RUN_CASE(test_large_payload());
   RUN_CASE(test_lz4_content_encoding_round_trip());
+  RUN_CASE(test_refillable_cursor_round_trip());
 #ifndef _WIN32
+  RUN_CASE(test_refillable_cursor_across_flow_control_window());
   RUN_CASE(test_payload_larger_than_flow_control_window());
 #endif
   RUN_CASE(test_server_window_hold_caps_and_releases());

--- a/routing.cpp
+++ b/routing.cpp
@@ -20,6 +20,7 @@ struct lupine_deviceptr_allocation_record {
   CUdeviceptr base = 0;
   size_t size = 0;
   int route_id = -2;
+  CUcontext context = nullptr;
 };
 
 struct lupine_device_entry {
@@ -32,6 +33,7 @@ struct lupine_device_entry {
 struct lupine_owner_record {
   int route_id = -2;
   bool is_green_context = false;
+  CUcontext pointer_context = nullptr;
 };
 
 static std::mutex &lupine_routing_mutex() {
@@ -395,7 +397,11 @@ static void lupine_note_owner(Handle handle, conn_t *conn) {
     return;
   }
   std::lock_guard<std::mutex> lock(lupine_routing_mutex());
-  lupine_owners<Handle>()[handle].route_id = index;
+  auto &owner = lupine_owners<Handle>()[handle];
+  owner.route_id = index;
+  if constexpr (std::is_same_v<Handle, CUdeviceptr>) {
+    owner.pointer_context = lupine_current_context_hint();
+  }
 }
 
 extern "C" void lupine_note_context_owner(CUcontext ctx, conn_t *conn) {
@@ -444,14 +450,17 @@ extern "C" void lupine_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn) {
 
 static void lupine_note_deviceptr_allocation_owner_locked(CUdeviceptr ptr,
                                                           size_t size,
-                                                          int route_id) {
-  lupine_owners<CUdeviceptr>()[ptr].route_id = route_id;
+                                                          int route_id,
+                                                          CUcontext context) {
+  auto &owner = lupine_owners<CUdeviceptr>()[ptr];
+  owner.route_id = route_id;
+  owner.pointer_context = context;
   if (size == 0) {
     lupine_deviceptr_allocations().erase(ptr);
     return;
   }
   lupine_deviceptr_allocations()[ptr] =
-      lupine_deviceptr_allocation_record{ptr, size, route_id};
+      lupine_deviceptr_allocation_record{ptr, size, route_id, context};
 }
 
 extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size,
@@ -461,7 +470,8 @@ extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size,
     return;
   }
   std::lock_guard<std::mutex> lock(lupine_routing_mutex());
-  lupine_note_deviceptr_allocation_owner_locked(ptr, size, index);
+  lupine_note_deviceptr_allocation_owner_locked(ptr, size, index,
+                                                lupine_current_context_hint());
 }
 
 template <typename Handle>
@@ -471,7 +481,11 @@ static void lupine_note_owner_route(Handle handle, lupine_route route) {
     return;
   }
   std::lock_guard<std::mutex> lock(lupine_routing_mutex());
-  lupine_owners<Handle>()[handle].route_id = route_id;
+  auto &owner = lupine_owners<Handle>()[handle];
+  owner.route_id = route_id;
+  if constexpr (std::is_same_v<Handle, CUdeviceptr>) {
+    owner.pointer_context = lupine_current_context_hint();
+  }
 }
 
 extern "C" void lupine_note_context_owner_route(CUcontext ctx,
@@ -540,7 +554,8 @@ extern "C" void lupine_note_deviceptr_allocation_route(CUdeviceptr ptr,
     return;
   }
   std::lock_guard<std::mutex> lock(lupine_routing_mutex());
-  lupine_note_deviceptr_allocation_owner_locked(ptr, size, -1);
+  lupine_note_deviceptr_allocation_owner_locked(ptr, size, -1,
+                                                lupine_current_context_hint());
 }
 
 extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr) {
@@ -689,6 +704,24 @@ extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr) {
     }
   }
   return lupine_route_for_default();
+}
+
+extern "C" CUcontext lupine_context_for_deviceptr(CUdeviceptr ptr) {
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  auto owner = lupine_owners<CUdeviceptr>().find(ptr);
+  if (owner != lupine_owners<CUdeviceptr>().end() &&
+      owner->second.pointer_context != nullptr) {
+    return owner->second.pointer_context;
+  }
+  for (const auto &entry : lupine_deviceptr_allocations()) {
+    const auto &allocation = entry.second;
+    if (allocation.base != 0 && allocation.size != 0 &&
+        ptr >= allocation.base &&
+        static_cast<uint64_t>(ptr - allocation.base) < allocation.size) {
+      return allocation.context;
+    }
+  }
+  return nullptr;
 }
 
 CUresult lupine_set_current_context_on_route(lupine_route route,

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -869,6 +869,33 @@ int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
   return 0;
 }
 
+int rpc_write_response_cursors(conn_t *conn, int read_id,
+                               const rpc_write_cursor *cursors, size_t count) {
+  if (conn == nullptr || conn->closed || read_id < 0 ||
+      (count != 0 && cursors == nullptr) ||
+      count > static_cast<size_t>(INT_MAX) - 2) {
+    return -1;
+  }
+  int32_t stream_id = rpc_current_http2_stream(conn);
+  if (stream_id < 0) {
+    return -1;
+  }
+
+  int response_op = -1;
+  std::vector<rpc_write_cursor> response;
+  try {
+    response.reserve(count + 2);
+    response.emplace_back(&read_id, sizeof(read_id));
+    response.emplace_back(&response_op, sizeof(response_op));
+    if (count != 0) {
+      response.insert(response.end(), cursors, cursors + count);
+    }
+  } catch (const std::bad_alloc &) {
+    return -1;
+  }
+  return rpc_http2_write_stream(conn, stream_id, response);
+}
+
 // rpc_write_end finalizes the current request builder on the given connection
 // index and sends the request to the server.
 //

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -869,33 +869,6 @@ int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
   return 0;
 }
 
-int rpc_write_response_cursors(conn_t *conn, int read_id,
-                               const rpc_write_cursor *cursors, size_t count) {
-  if (conn == nullptr || conn->closed || read_id < 0 ||
-      (count != 0 && cursors == nullptr) ||
-      count > static_cast<size_t>(INT_MAX) - 2) {
-    return -1;
-  }
-  int32_t stream_id = rpc_current_http2_stream(conn);
-  if (stream_id < 0) {
-    return -1;
-  }
-
-  int response_op = -1;
-  std::vector<rpc_write_cursor> response;
-  try {
-    response.reserve(count + 2);
-    response.emplace_back(&read_id, sizeof(read_id));
-    response.emplace_back(&response_op, sizeof(response_op));
-    if (count != 0) {
-      response.insert(response.end(), cursors, cursors + count);
-    }
-  } catch (const std::bad_alloc &) {
-    return -1;
-  }
-  return rpc_http2_write_stream(conn, stream_id, response);
-}
-
 // rpc_write_end finalizes the current request builder on the given connection
 // index and sends the request to the server.
 //

--- a/rpc.h
+++ b/rpc.h
@@ -206,12 +206,6 @@ extern int rpc_copy_alloc(conn_t *conn, const size_t size);
 extern void *rpc_write_buffer(conn_t *conn, size_t size, size_t alignment);
 extern int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
                              size_t count);
-// Writes a response from caller-owned cursors without occupying the
-// connection's request builder. Refillable response bodies can therefore
-// issue requests on other connections while they are being produced.
-extern int rpc_write_response_cursors(conn_t *conn, int read_id,
-                                      const rpc_write_cursor *cursors,
-                                      size_t count);
 extern int rpc_write_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
 // Signals transport readers to stop without releasing connection resources.

--- a/rpc.h
+++ b/rpc.h
@@ -24,16 +24,31 @@ static constexpr uint8_t LUPINE_COPY_DIRECTION_DTOD = 3;
 
 // References caller-owned bytes while an RPC is being serialized. Cursors are
 // consumed directly by the HTTP/2 transport.
+struct rpc_write_cursor;
+// A refill supplies a non-empty cursor and returns positive, returns zero at
+// end of input, or returns negative on failure.
+using rpc_write_cursor_refill = int (*)(void *context,
+                                        rpc_write_cursor *cursor);
+
 struct rpc_write_cursor {
   const unsigned char *data = nullptr;
   size_t size = 0;
+  rpc_write_cursor_refill refill = nullptr;
+  void *refill_context = nullptr;
+  bool exhausted = false;
 
   rpc_write_cursor() = default;
 
   rpc_write_cursor(const void *bytes, size_t byte_count)
       : data(static_cast<const unsigned char *>(bytes)), size(byte_count) {}
 
+  rpc_write_cursor(rpc_write_cursor_refill refill_fn, void *context)
+      : refill(refill_fn), refill_context(context) {}
+
   size_t remaining() const { return size; }
+  bool pending() const {
+    return size != 0 || (refill != nullptr && !exhausted);
+  }
 };
 
 struct rpc_http2_read_stats {
@@ -194,6 +209,12 @@ extern int rpc_copy_alloc(conn_t *conn, const size_t size);
 extern void *rpc_write_buffer(conn_t *conn, size_t size, size_t alignment);
 extern int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
                              size_t count);
+// Writes a response from caller-owned cursors without occupying the
+// connection's request builder. Refillable response bodies can therefore
+// issue requests on other connections while they are being produced.
+extern int rpc_write_response_cursors(conn_t *conn, int read_id,
+                                      const rpc_write_cursor *cursors,
+                                      size_t count);
 extern int rpc_write_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
 // Signals transport readers to stop without releasing connection resources.


### PR DESCRIPTION
## Summary

Cross-server device copies are composed entirely on the client:

- same-server DtoD remains a native server operation
- the source server sees only ordinary linear DtoH operations
- the destination server uses the existing HtoD host-read callback
- no copy-specific wire operation or server CUDA memcpy handler is added
- pitched 2D and 3D copies use the existing per-row client routing path, so the relay never repacks or interprets layouts

For a cross-route device source, each destination callback requests exactly the contiguous range it needs. The client relays that range through one reusable 4 MiB buffer. Each HTTP/2 cursor refill performs an ordinary `cuMemcpyDtoH_v2` and hands the resulting chunk to the existing RPC response builder; HTTP/2 consumes the chunk before requesting the next refill.

This uses the transport's existing reader threads and kernel buffering for progress and backpressure. It creates no per-copy worker thread and needs no transfer-local locks, atomics, slot ownership protocol, or copy-specific response path. Refills also run without holding the destination HTTP/2 session mutex.

Client allocation ownership retains the source context so the dispatch thread selects the correct remote CUDA context before relaying the data.

## Validation

- merged with current `main`
- CUDA client Release build
- 8/8 local CTest tests passed, including refill behavior beyond the HTTP/2 flow-control window
- PR diff formatting check passed
- full GPU and platform CI pending
