### PR TITLE
Order mapped-host flushes across client lanes

### DIFF
--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -163,11 +163,15 @@ struct lupine_dirty_host_range_queue {
 
 static lupine_dirty_host_range_queue
     lupine_dirty_host_range_queues[LUPINE_MAX_MANAGED_HOST_FLUSH_ROUTES];
-// Keep dirty state visible until a flush completes. A single exchanged boolean
-// would let another request start while the first request is still flushing.
+// Dirty publications receive globally ordered tickets, but only the publishing
+// thread waits for its latest ticket. Another thread may flush that ticket; the
+// acknowledged global watermark then satisfies the publisher without making
+// unrelated RPC callers join the flush.
 static uint64_t lupine_dirty_host_epoch = 0;
+static thread_local uint64_t lupine_required_host_epoch = 0;
 static volatile sig_atomic_t lupine_device_work_pending = 0;
 static std::atomic<uint64_t> lupine_flushed_host_epoch{0};
+static std::mutex lupine_host_flush_mutex;
 
 struct lupine_fault_entry {
   uintptr_t base = 0;
@@ -427,6 +431,13 @@ lupine_reserve_dirty_host_range(lupine_dirty_host_range_queue &queue,
   return true;
 }
 
+static void lupine_require_dirty_host_flush() {
+  uint64_t required_epoch =
+      __atomic_add_fetch(&lupine_dirty_host_epoch, 1, __ATOMIC_ACQ_REL);
+  __atomic_store_n(&lupine_required_host_epoch, required_epoch,
+                   __ATOMIC_RELEASE);
+}
+
 static void lupine_queue_dirty_host_range(lupine_host_allocation *allocation,
                                           uintptr_t start, uintptr_t end) {
   int route_id = allocation->route_id;
@@ -441,14 +452,14 @@ static void lupine_queue_dirty_host_range(lupine_host_allocation *allocation,
   if (lupine_reserve_dirty_host_range(queue, &slot)) {
     queue.ranges[slot] = {allocation, start, end};
     __atomic_store_n(&queue.ready[slot], 1, __ATOMIC_RELEASE);
-    __atomic_add_fetch(&lupine_dirty_host_epoch, 1, __ATOMIC_RELEASE);
+    lupine_require_dirty_host_flush();
     return;
   }
 
   __atomic_sub_fetch(&allocation->pending_dirty_ranges, 1, __ATOMIC_RELEASE);
   __atomic_store_n(&allocation->full_dirty, 1, __ATOMIC_RELEASE);
   __atomic_store_n(&queue.full_dirty_pending, 1, __ATOMIC_RELEASE);
-  __atomic_add_fetch(&lupine_dirty_host_epoch, 1, __ATOMIC_RELEASE);
+  lupine_require_dirty_host_flush();
 }
 
 static void lupine_sigsegv_handler(int sig, siginfo_t *info, void *uctx) {
@@ -769,7 +780,7 @@ extern "C" void lupine_mark_mapped_host_kernel_params(
         continue;
       }
       allocation.device_pointer_exposed = true;
-      __atomic_add_fetch(&lupine_dirty_host_epoch, 1, __ATOMIC_RELEASE);
+      lupine_require_dirty_host_flush();
       break;
     }
   }
@@ -843,8 +854,14 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
 
   uint32_t reserved = __atomic_load_n(&queue.next, __ATOMIC_ACQUIRE);
   uint32_t end = queue.start;
-  while (end < reserved &&
-         __atomic_load_n(&queue.ready[end], __ATOMIC_ACQUIRE) != 0) {
+  while (end < reserved) {
+    // A signal handler reserves its lock-free slot before publishing it. A
+    // later slot can therefore carry an epoch included in our completion
+    // watermark while this earlier producer is still filling its range. Do
+    // not advance the watermark past that hole.
+    while (__atomic_load_n(&queue.ready[end], __ATOMIC_ACQUIRE) == 0) {
+      sched_yield();
+    }
     ++end;
   }
   bool has_full_dirty =
@@ -968,11 +985,14 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
       return CUDA_SUCCESS;
     }
     // This is the flush performed by lupine_prepare_rpc(), so it must use
-    // the raw transport primitive.
+    // the raw transport primitives. Wait for the server acknowledgement:
+    // requests from different client threads use different HTTP/2 lanes, and
+    // publishing the flushed epoch before this lane is applied would let a
+    // server-authoritative HtoD on another lane observe stale host data.
     if (rpc_write_start_request(conn, LUPINE_RPC_lupineManagedHostFlush) < 0 ||
         rpc_write(conn, &count, sizeof(count)) < 0 ||
         rpc_write_cursors(conn, cursors.data(), count * 2) < 0 ||
-        rpc_write_end(conn) < 0) {
+        rpc_wait_for_response(conn) < 0 || rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
     return CUDA_SUCCESS;
@@ -1019,6 +1039,9 @@ static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
 }
 
 static CUresult lupine_flush_dirty_host_pages_to_server() {
+  std::lock_guard<std::mutex> flush_lock(lupine_host_flush_mutex);
+  uint64_t flush_epoch =
+      __atomic_load_n(&lupine_dirty_host_epoch, __ATOMIC_ACQUIRE);
   for (int route_id = 0; route_id < rpc_size(); ++route_id) {
     CUresult result =
         lupine_flush_dirty_host_pages_to_route(static_cast<size_t>(route_id));
@@ -1026,6 +1049,7 @@ static CUresult lupine_flush_dirty_host_pages_to_server() {
       return result;
     }
   }
+  lupine_flushed_host_epoch.store(flush_epoch, std::memory_order_release);
   return CUDA_SUCCESS;
 }
 
@@ -1040,14 +1064,27 @@ extern "C" int lupine_prepare_rpc(conn_t *conn) {
     return -1;
   }
 
-  uint64_t dirty_epoch =
-      __atomic_load_n(&lupine_dirty_host_epoch, __ATOMIC_ACQUIRE);
-  if (dirty_epoch !=
-      lupine_flushed_host_epoch.load(std::memory_order_acquire)) {
-    if (lupine_flush_dirty_host_pages_to_server() != CUDA_SUCCESS) {
-      return -1;
+  uint64_t required_epoch =
+      __atomic_load_n(&lupine_required_host_epoch, __ATOMIC_ACQUIRE);
+  if (lupine_flushed_host_epoch.load(std::memory_order_acquire) <
+      required_epoch) {
+    std::lock_guard<std::mutex> flush_lock(lupine_host_flush_mutex);
+    required_epoch =
+        __atomic_load_n(&lupine_required_host_epoch, __ATOMIC_ACQUIRE);
+    while (lupine_flushed_host_epoch.load(std::memory_order_acquire) <
+           required_epoch) {
+      uint64_t flush_epoch =
+          __atomic_load_n(&lupine_dirty_host_epoch, __ATOMIC_ACQUIRE);
+      for (int route_id = 0; route_id < rpc_size(); ++route_id) {
+        if (lupine_flush_dirty_host_pages_to_route(
+                static_cast<size_t>(route_id)) != CUDA_SUCCESS) {
+          return -1;
+        }
+      }
+      lupine_flushed_host_epoch.store(flush_epoch, std::memory_order_release);
+      required_epoch =
+          __atomic_load_n(&lupine_required_host_epoch, __ATOMIC_ACQUIRE);
     }
-    lupine_flushed_host_epoch.store(dirty_epoch, std::memory_order_release);
   }
   return 0;
 }
@@ -1061,6 +1098,7 @@ lupine_drain_retiring_dirty_ranges(lupine_host_allocation *allocation) {
   if (allocation->route_id >= 0 &&
       allocation->route_id <
           static_cast<int>(LUPINE_MAX_MANAGED_HOST_FLUSH_ROUTES)) {
+    std::lock_guard<std::mutex> flush_lock(lupine_host_flush_mutex);
     result = lupine_flush_dirty_host_pages_to_route(
         static_cast<size_t>(allocation->route_id));
     while (result == CUDA_SUCCESS &&
@@ -2081,7 +2119,7 @@ extern "C" CUresult cuMemHostGetDevicePointer_v2(CUdeviceptr *pdptr, void *p,
       if (it->second.device_ptr != 0) {
         if (!it->second.device_pointer_exposed) {
           it->second.device_pointer_exposed = true;
-          __atomic_add_fetch(&lupine_dirty_host_epoch, 1, __ATOMIC_RELEASE);
+          lupine_require_dirty_host_flush();
         }
         uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
         uintptr_t addr = reinterpret_cast<uintptr_t>(p);

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -3562,8 +3562,6 @@ int handle_cuGraphDestroy(conn_t *conn) {
   return 0;
 }
 
-// Fire-and-forget: connection ordering already guarantees the flush is
-// applied before any later request, so no response is sent.
 int handle_lupineManagedHostFlush(conn_t *conn) {
   uint32_t count = 0;
 
@@ -3576,7 +3574,7 @@ int handle_lupineManagedHostFlush(conn_t *conn) {
     size_t bytes = 0;
     // Host mappings and native identity-VA managed allocations are both CPU
     // accessible. Reading directly avoids a context-dependent pinned
-    // allocation on this fire-and-forget RPC path.
+    // allocation in the flush handler.
     if (rpc_read(conn, &server_host_ptr, sizeof(server_host_ptr)) < 0 ||
         rpc_read(conn, &bytes, sizeof(bytes)) < 0 ||
         rpc_read(conn, server_host_ptr, bytes) < 0) {
@@ -3584,7 +3582,12 @@ int handle_lupineManagedHostFlush(conn_t *conn) {
     }
   }
 
-  return rpc_read_end(conn) < 0 ? -1 : 0;
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0 || rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
 }
 // Serves LUPINE_RPC_lupineDeviceSnapshot: every immutable per-device value the
 // client caches, for every device, in one response. Mutable state (primary

--- a/test/test_cross_lane_host_flush.cu
+++ b/test/test_cross_lane_host_flush.cu
@@ -1,0 +1,140 @@
+// A dirty thread may flush ranges published by other client threads. The batch
+// must be server-visible before any publisher whose ticket it contains lets
+// another HTTP/2 lane use its mapped allocation as an HtoD source.
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <pthread.h>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr int kThreadCount = 8;
+constexpr int kRounds = 32;
+constexpr size_t kElements = 100000;
+constexpr size_t kBytes = kElements * sizeof(int);
+
+struct callback_state {
+  int *source = nullptr;
+  int expected = 0;
+  int thread_index = 0;
+  int round = 0;
+  std::atomic<int> *failures = nullptr;
+  std::atomic<bool> done{false};
+};
+
+__global__ void increment(int *values) {
+  size_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index < kElements) {
+    ++values[index];
+  }
+}
+
+void CUDART_CB validate(cudaStream_t, cudaError_t status, void *opaque) {
+  auto *state = static_cast<callback_state *>(opaque);
+  if (status != cudaSuccess) {
+    std::fprintf(stderr, "FAIL: callback: %s\n", cudaGetErrorString(status));
+    state->failures->fetch_add(1, std::memory_order_relaxed);
+  } else {
+    for (size_t i = 0; i < kElements; ++i) {
+      if (state->source[i] == state->expected) {
+        continue;
+      }
+      std::fprintf(stderr,
+                   "FAIL: lane %d round %d element %zu: got %d want %d\n",
+                   state->thread_index, state->round, i, state->source[i],
+                   state->expected);
+      state->failures->fetch_add(1, std::memory_order_relaxed);
+      break;
+    }
+  }
+  state->done.store(true, std::memory_order_release);
+}
+
+void check(cudaError_t result, const char *operation) {
+  if (result == cudaSuccess) {
+    return;
+  }
+  std::fprintf(stderr, "FAIL: %s: %s\n", operation, cudaGetErrorString(result));
+  std::exit(EXIT_FAILURE);
+}
+
+} // namespace
+
+int main() {
+  int device_count = 0;
+  check(cudaGetDeviceCount(&device_count), "cudaGetDeviceCount");
+  if (device_count == 0) {
+    std::printf("SKIP: no CUDA devices found\n");
+    return EXIT_SUCCESS;
+  }
+
+  pthread_barrier_t barrier;
+  if (pthread_barrier_init(&barrier, nullptr, kThreadCount) != 0) {
+    std::fprintf(stderr, "FAIL: pthread_barrier_init\n");
+    return EXIT_FAILURE;
+  }
+
+  std::atomic<int> failures{0};
+  std::vector<std::thread> threads;
+  threads.reserve(kThreadCount);
+  for (int thread_index = 0; thread_index < kThreadCount; ++thread_index) {
+    threads.emplace_back([thread_index, device_count, &barrier, &failures] {
+      check(cudaSetDevice(thread_index % device_count), "cudaSetDevice");
+
+      cudaStream_t stream = nullptr;
+      int *device = nullptr;
+      int *source = nullptr;
+      check(cudaStreamCreate(&stream), "cudaStreamCreate");
+      check(cudaMalloc(&device, kBytes), "cudaMalloc");
+      check(cudaHostAlloc(&source, kBytes, cudaHostAllocPortable),
+            "cudaHostAlloc");
+      for (int round = 0; round < kRounds; ++round) {
+        int expected = 1 + thread_index * kRounds + round;
+        std::fill(source, source + kElements, expected);
+
+        // Make every lane race to consume dirty mapped-host state. One lane
+        // drains the shared queue; the others wait only for their own tickets.
+        pthread_barrier_wait(&barrier);
+        check(cudaMemcpyAsync(device, source, kBytes, cudaMemcpyHostToDevice,
+                              stream),
+              "cudaMemcpyAsync HtoD");
+        increment<<<(kElements + 255) / 256, 256, 0, stream>>>(device);
+        check(cudaGetLastError(), "increment launch");
+        check(cudaMemcpyAsync(source, device, kBytes, cudaMemcpyDeviceToHost,
+                              stream),
+              "cudaMemcpyAsync DtoH");
+        callback_state state{source, expected + 1, thread_index, round,
+                             &failures};
+        check(cudaStreamAddCallback(stream, validate, &state, 0),
+              "cudaStreamAddCallback");
+        while (!state.done.load(std::memory_order_acquire)) {
+          std::this_thread::yield();
+        }
+        pthread_barrier_wait(&barrier);
+      }
+
+      check(cudaFreeHost(source), "cudaFreeHost");
+      check(cudaFree(device), "cudaFree");
+      check(cudaStreamDestroy(stream), "cudaStreamDestroy");
+    });
+  }
+
+  for (std::thread &thread : threads) {
+    thread.join();
+  }
+  pthread_barrier_destroy(&barrier);
+
+  int failure_count = failures.load(std::memory_order_relaxed);
+  if (failure_count != 0) {
+    std::fprintf(stderr, "FAIL: %d cross-lane host flush mismatches\n",
+                 failure_count);
+    return EXIT_FAILURE;
+  }
+  std::printf("PASS: mapped host flushes are ordered across client lanes\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- wait for mapped-host flushes to be acknowledged before publishing their completed epoch
- assign every dirty publication a globally ordered ticket while keeping each thread's required ticket in TLS, so unrelated RPC callers stay on the lock-free fast path
- serialize all flushing RPCs behind one global mutex and re-check the completed watermark after acquiring it, preventing reentrant or duplicate flushes
- add an eight-lane regression covering HtoD, kernel execution, pinned DtoH, and callback visibility

## Root cause

Client threads use independent HTTP/2 lanes. Dirty mapped-host ranges live in a shared queue, so thread A can drain a range published by thread B. Previously A immediately advanced a process-wide flushed epoch even though its flush RPC was fire-and-forget. Thread B could then issue a server-authoritative HtoD on another lane before the server had applied A's payload.

The server now acknowledges the flush only after synchronously copying the payload into its host mirror. Dirty writes receive global tickets, but a thread waits only for the latest ticket it published. If A flushes B's range, A's acknowledged completion watermark satisfies B; threads with no outstanding ticket never enter the flush mutex. Queue draining also waits for reserved-but-not-yet-published slots before advancing the completion watermark.

The request payload and RPC ID are unchanged.

## Validation

- regression against unmodified `main`: 67 stale-copy mismatches in 32 rounds
- strengthened regression with this fix: 32/32 rounds pass on both one- and two-route servers
- NVIDIA CUDA 11.8 `simpleCallback`: 400/400 final-tree runs pass at four-way concurrency; unmodified `main` failed 4/400 under the same stress
- focused CUDA 11.8 tests pass: host callback userdata, host-function DtoH, mapped-host free/sync, and HtoD side-effect capture
- repo unit suite: 11/11 selected targets pass (3 expected skips)
