### PR TITLE
Deliver graph device-to-host node copies once per launch

### DIFF
--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -4118,7 +4118,7 @@ int handle_cuStreamSynchronize(conn_t *conn) {
   lupine_finish_stdout_capture(&capture);
   uint32_t copy_count = 0;
   std::vector<lupine_graph_host_copy> graph_copies =
-      lupine_stream_dtoh_copy_snapshot(stream);
+      lupine_take_stream_dtoh_copies(stream);
   uint32_t graph_copy_count = static_cast<uint32_t>(graph_copies.size());
   bool all_pending_streams = stream == nullptr;
   auto pending =

--- a/cuda_server_memcpy.cpp
+++ b/cuda_server_memcpy.cpp
@@ -166,6 +166,12 @@ struct lupine_graph_resources {
     }
   }
 
+  // A launch marks its host copies undelivered; the next stream sync that
+  // reports them clears the mark. Without it every later sync on that stream
+  // would replay the same staging buffers over host memory a plain
+  // cuMemcpyDtoH has since overwritten.
+  std::atomic<bool> dtoh_undelivered{false};
+
   std::vector<lupine_graph_host_copy> dtoh_copy_snapshot() const {
     std::vector<lupine_graph_host_copy> copies;
     for (auto *node = dtoh_copies.load(std::memory_order_acquire);
@@ -402,6 +408,7 @@ void lupine_note_graph_launch(CUgraphExec exec, CUstream stream,
   lupine_graph_resources *resources = nullptr;
   (void)lupine_graph_exec_resource_map().find(exec, resources);
   if (result == CUDA_SUCCESS && resources != nullptr) {
+    resources->dtoh_undelivered.store(true, std::memory_order_release);
     lupine_stream_capture_resource_map().insert_or_assign(stream, resources);
   }
 }
@@ -423,10 +430,14 @@ lupine_graph_dtoh_copy_snapshot(lupine_graph_resources *resources) {
 }
 
 std::vector<lupine_graph_host_copy>
-lupine_stream_dtoh_copy_snapshot(CUstream stream) {
+lupine_take_stream_dtoh_copies(CUstream stream) {
   lupine_graph_resources *resources = nullptr;
   (void)lupine_stream_capture_resource_map().find(stream, resources);
-  return lupine_graph_dtoh_copy_snapshot(resources);
+  if (resources == nullptr ||
+      !resources->dtoh_undelivered.exchange(false, std::memory_order_acq_rel)) {
+    return {};
+  }
+  return resources->dtoh_copy_snapshot();
 }
 
 void *lupine_alloc_capture_scratch(lupine_graph_resources *resources,

--- a/cuda_server_memcpy.h
+++ b/cuda_server_memcpy.h
@@ -54,8 +54,10 @@ bool lupine_graph_install_capture_scratch(lupine_graph_resources *resources,
                                           void *scratch, size_t size);
 std::vector<lupine_graph_host_copy>
 lupine_graph_dtoh_copy_snapshot(lupine_graph_resources *resources);
+// Reports the host copies a graph launched on this stream still owes the
+// client, exactly once per launch.
 std::vector<lupine_graph_host_copy>
-lupine_stream_dtoh_copy_snapshot(CUstream stream);
+lupine_take_stream_dtoh_copies(CUstream stream);
 struct lupine_htod_graph_binding {
   CUgraph original = nullptr;
   CUgraph prepared = nullptr;

--- a/test/test_graph_dtoh_node_replay.cu
+++ b/test/test_graph_dtoh_node_replay.cu
@@ -1,0 +1,113 @@
+// A graph device-to-host memcpy node stages its bytes in a server-side buffer
+// that lupine ships to the client when the launch stream synchronizes. That
+// staging buffer outlives the launch, so the delivery has to happen once:
+// jacobiCudaGraphs reads its convergence sum through such a node every
+// iteration, then overwrites the same host variable with a plain
+// cuMemcpyDtoHAsync before one last synchronize. Replaying the node's stale
+// bytes at that synchronize silently reverts the final result (issue #672).
+//
+// Pure driver API, no kernels (so it is arch-independent). Exits non-zero on
+// the first failed assertion.
+#include <cstdio>
+#include <cstdlib>
+#include <cuda.h>
+
+static int g_failures = 0;
+#define CHECK(cond, msg)                                                       \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      fprintf(stderr, "FAIL: %s (line %d)\n", msg, __LINE__);                  \
+      g_failures++;                                                            \
+    } else {                                                                   \
+      fprintf(stderr, "ok:   %s\n", msg);                                      \
+    }                                                                          \
+  } while (0)
+
+static const char *errstr(CUresult r) {
+  const char *s = nullptr;
+  cuGetErrorName(r, &s);
+  return s ? s : "?";
+}
+#define DRV(call)                                                              \
+  do {                                                                         \
+    CUresult _r = (call);                                                      \
+    if (_r != CUDA_SUCCESS) {                                                  \
+      fprintf(stderr, "FATAL: %s -> %s (line %d)\n", #call, errstr(_r),        \
+              __LINE__);                                                       \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+static const unsigned int kGraphValue = 0x11112222u;
+static const unsigned int kDirectValue = 0x33334444u;
+
+int main() {
+  DRV(cuInit(0));
+  CUdevice dev;
+  DRV(cuDeviceGet(&dev, 0));
+  CUcontext ctx;
+  DRV(cuDevicePrimaryCtxRetain(&ctx, dev));
+  DRV(cuCtxSetCurrent(ctx));
+
+  CUstream stream;
+  DRV(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+  CUdeviceptr value;
+  DRV(cuMemAlloc(&value, sizeof(unsigned int)));
+
+  // The host destination is a pageable stack variable, exactly as the sample
+  // reads its sum: cuMemcpyDtoHAsync to pageable memory completes inline.
+  unsigned int host = 0;
+
+  CUgraph graph;
+  DRV(cuGraphCreate(&graph, 0));
+
+  CUDA_MEMSET_NODE_PARAMS memset_params = {};
+  memset_params.dst = value;
+  memset_params.pitch = 0;
+  memset_params.value = kGraphValue;
+  memset_params.elementSize = sizeof(unsigned int);
+  memset_params.width = 1;
+  memset_params.height = 1;
+  CUgraphNode memset_node;
+  DRV(cuGraphAddMemsetNode(&memset_node, graph, nullptr, 0, &memset_params,
+                           ctx));
+
+  CUDA_MEMCPY3D copy_params = {};
+  copy_params.srcMemoryType = CU_MEMORYTYPE_DEVICE;
+  copy_params.srcDevice = value;
+  copy_params.dstMemoryType = CU_MEMORYTYPE_HOST;
+  copy_params.dstHost = &host;
+  copy_params.WidthInBytes = sizeof(unsigned int);
+  copy_params.Height = 1;
+  copy_params.Depth = 1;
+  CUgraphNode copy_node;
+  DRV(cuGraphAddMemcpyNode(&copy_node, graph, &memset_node, 1, &copy_params,
+                           ctx));
+
+  CUgraphExec exec;
+  DRV(cuGraphInstantiateWithFlags(&exec, graph, 0));
+  DRV(cuGraphLaunch(exec, stream));
+  DRV(cuStreamSynchronize(stream));
+  CHECK(host == kGraphValue, "graph memcpy node delivers its bytes");
+
+  // No launch since, so this synchronize owes the client nothing.
+  host = 0;
+  DRV(cuStreamSynchronize(stream));
+  CHECK(host == 0, "idle synchronize does not replay the node's bytes");
+
+  // What the sample does after it converges: overwrite the same host variable
+  // from outside the graph, then synchronize one last time.
+  DRV(cuMemsetD32Async(value, kDirectValue, 1, stream));
+  DRV(cuMemcpyDtoHAsync(&host, value, sizeof(host), stream));
+  DRV(cuStreamSynchronize(stream));
+  CHECK(host == kDirectValue, "direct copy survives the following synchronize");
+
+  DRV(cuGraphExecDestroy(exec));
+  DRV(cuGraphDestroy(graph));
+  DRV(cuMemFree(value));
+  DRV(cuStreamDestroy(stream));
+  DRV(cuDevicePrimaryCtxRelease(dev));
+
+  printf("%s\n", g_failures == 0 ? "PASSED" : "FAILED");
+  return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #672.

## Root cause

A graph memcpy node with a host destination stages its bytes in a server-side
buffer that lives as long as the graph, and `handle_cuStreamSynchronize` ships
those buffers to the client through the stream -> graph-resources association
`lupine_note_graph_launch` installs. Nothing ever consumed that association, so
*every* subsequent synchronize on the stream replayed the same staging buffers
over the client's host memory.

jacobiCudaGraphs hits this exactly. Its graph reads the convergence sum into a
host stack variable through a memcpy node each iteration, and once it converges
it overwrites that same variable outside the graph:

    finalError<<<...>>>(x, d_sum);
    cudaMemcpyAsync(&sum, d_sum, sizeof(double), cudaMemcpyDeviceToHost, stream);
    cudaStreamSynchronize(stream);
    printf("GPU error : %.3e\n", sum);

The destination is pageable, so the copy completes inline and `sum` briefly
holds the correct final error. The following synchronize then replays the
graph node's stale bytes on top of it, and the sample prints the last
convergence sum instead. That is why the reported value was 9.995e-03: it is
the loop's exit sum, which by construction sits just under the 1.0e-2
threshold, and why the tolerance was wide enough to still report PASSED.

## Fix

Mark a graph's host copies undelivered at launch and clear the mark on the
synchronize that reports them, so each launch's copies reach the client exactly
once. Stale replay onto host memory the client has since rewritten is gone; a
graph that is launched again re-arms the mark.

## Test

`test/test_graph_dtoh_node_replay.cu` builds a memset + device-to-host memcpy
graph into a pageable host variable and asserts the three behaviors: the node's
bytes arrive, an idle synchronize delivers nothing, and a plain
`cuMemcpyDtoHAsync` survives the synchronize that follows it. It fails on main
(second and third assertions) and passes here.

## Validation

    SERVER_HOST=inferable-node-006 BUILD_SAMPLES=0 ./test/compare_cuda_samples_stdout.sh jacobiCudaGraphs

now reports `GPU error : 4.988e-03`, matching the native GPU and CPU results.
`test_cuda_graph_api`, `test_cuda_graph_kernel_node_params`,
`test_default_stream_event_dtoh`, `test_host_func_dtoh`,
`test_htod_side_effect_capture`, `test_htod_side_effect_pitched`,
`test_pageable_async_dtoh`, and `test_stream_callback_route` all pass on
inferable-node-008.