### PR TITLE
Forward cuModuleLoadDataEx JIT options and write back their outputs

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2367,6 +2367,7 @@ CUresult cuModuleLoadData(CUmodule *module, const void *image);
  * @param numOptions SEND_ONLY
  * @param options SEND_ONLY LENGTH:numOptions
  * @param optionValues SEND_RECV
+ * @server CUDA
  */
 CUresult cuModuleLoadDataEx(CUmodule *module, const void *image,
                             unsigned int numOptions, CUjit_option *options,

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -19,6 +19,7 @@
   HANDLER(RPC_cuCtxDetach, handle_cuCtxDetach, rpc_backend::cuda) \
   HANDLER(RPC_cuModuleLoad, handle_cuModuleLoad, rpc_backend::cuda) \
   HANDLER(RPC_cuModuleLoadData, handle_cuModuleLoadData, rpc_backend::cuda) \
+  HANDLER(RPC_cuModuleLoadDataEx, handle_cuModuleLoadDataEx, rpc_backend::cuda) \
   HANDLER(RPC_cuModuleGetGlobal_v2, handle_cuModuleGetGlobal_v2, rpc_backend::cuda) \
   HANDLER(RPC_cuLinkCreate_v2, handle_cuLinkCreate_v2, rpc_backend::cuda) \
   HANDLER(RPC_cuLinkAddData_v2, handle_cuLinkAddData_v2, rpc_backend::cuda) \

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -4040,8 +4040,13 @@ extern "C" CUresult cuCtxGetStreamPriorityRange(int *leastPriority,
   return return_value;
 }
 
+// The CUDA linker requires the caller's option arrays to stay valid for the
+// lifetime of the CUlinkState, so cuLinkComplete writes its outputs straight
+// back into the arrays cuLinkCreate was given.
 struct lupine_jit_client_state {
-  std::vector<void *> option_values;
+  unsigned int num_options = 0;
+  CUjit_option *options = nullptr;
+  void **option_values = nullptr;
   std::vector<unsigned char> cubin;
 };
 
@@ -4054,6 +4059,43 @@ static std::unordered_map<CUlinkState, lupine_jit_client_state> &
 lupine_jit_client_states() {
   static std::unordered_map<CUlinkState, lupine_jit_client_state> states;
   return states;
+}
+
+// JIT option write-back. Log buffers arrive as the bytes the driver wrote and
+// need their terminator restored here, because the caller's buffer is
+// uninitialized on entry and is read back as a C string. Every other option
+// value is rewritten in place by the driver (CU_JIT_WALL_TIME and the log
+// sizes report through the option array itself), so its word replaces the one
+// that was sent.
+static int lupine_read_jit_outputs(conn_t *conn, unsigned int numOptions,
+                                   const CUjit_option *options,
+                                   void **optionValues) {
+  size_t log_sizes[2] = {0, 0};
+  for (unsigned int i = 0; i < numOptions; ++i) {
+    if (options[i] == CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES) {
+      log_sizes[0] = reinterpret_cast<uintptr_t>(optionValues[i]);
+    } else if (options[i] == CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES) {
+      log_sizes[1] = reinterpret_cast<uintptr_t>(optionValues[i]);
+    }
+  }
+  for (unsigned int i = 0; i < numOptions; ++i) {
+    const bool is_info_log = options[i] == CU_JIT_INFO_LOG_BUFFER;
+    const bool is_log = is_info_log || options[i] == CU_JIT_ERROR_LOG_BUFFER;
+    size_t length = 0;
+    if (rpc_read(conn, &length, sizeof(length)) < 0 ||
+        rpc_read(conn, is_log ? optionValues[i] : &optionValues[i], length) <
+            0) {
+      return -1;
+    }
+    if (is_log) {
+      size_t log_size = log_sizes[is_info_log ? 0 : 1];
+      if (log_size != 0) {
+        auto *log = static_cast<char *>(optionValues[i]);
+        log[length < log_size ? length : log_size - 1] = '\0';
+      }
+    }
+  }
+  return 0;
 }
 
 extern "C" CUresult cuLinkCreate_v2(unsigned int numOptions,
@@ -4083,9 +4125,9 @@ extern "C" CUresult cuLinkCreate_v2(unsigned int numOptions,
   if (return_value == CUDA_SUCCESS) {
     std::lock_guard<std::mutex> lock(lupine_jit_client_mutex());
     auto &jit_state = lupine_jit_client_states()[*stateOut];
-    if (numOptions != 0) {
-      jit_state.option_values.assign(optionValues, optionValues + numOptions);
-    }
+    jit_state.num_options = numOptions;
+    jit_state.options = options;
+    jit_state.option_values = optionValues;
   }
   return return_value;
 }
@@ -4103,7 +4145,6 @@ extern "C" CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t name_len = name == nullptr ? 0 : strlen(name) + 1;
-  size_t jit_output_length = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuLinkAddData_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
@@ -4118,11 +4159,8 @@ extern "C" CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type,
       rpc_wait_for_response(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  for (unsigned int i = 0; i < numOptions; ++i) {
-    if (rpc_read(conn, &jit_output_length, sizeof(jit_output_length)) < 0 ||
-        rpc_read(conn, optionValues[i], jit_output_length) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
+  if (lupine_read_jit_outputs(conn, numOptions, options, optionValues) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
@@ -4148,7 +4186,6 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
   size_t mapped_file_size = 0;
   uint64_t file_size = 0;
   uint8_t has_file_data = 0;
-  size_t jit_output_length = 0;
   int file_fd = open(path, O_RDONLY | O_BINARY);
   if (file_fd < 0) {
     return CUDA_ERROR_FILE_NOT_FOUND;
@@ -4189,12 +4226,9 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
     munmap(file_mapping, mapped_file_size);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  for (unsigned int i = 0; i < numOptions; ++i) {
-    if (rpc_read(conn, &jit_output_length, sizeof(jit_output_length)) < 0 ||
-        rpc_read(conn, optionValues[i], jit_output_length) < 0) {
-      munmap(file_mapping, mapped_file_size);
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
+  if (lupine_read_jit_outputs(conn, numOptions, options, optionValues) < 0) {
+    munmap(file_mapping, mapped_file_size);
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
@@ -4217,8 +4251,9 @@ extern "C" CUresult cuLinkComplete(CUlinkState state, void **cubinOut,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t cubin_size = 0;
-  std::vector<void *> option_values;
-  size_t jit_output_length = 0;
+  unsigned int num_options = 0;
+  CUjit_option *options = nullptr;
+  void **option_values = nullptr;
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuLinkComplete) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
@@ -4238,16 +4273,15 @@ extern "C" CUresult cuLinkComplete(CUlinkState state, void **cubinOut,
         rpc_read(conn, jit_state.cubin.data(), cubin_size) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
+    num_options = jit_state.num_options;
+    options = jit_state.options;
     option_values = jit_state.option_values;
     *cubinOut = jit_state.cubin.empty() ? nullptr : jit_state.cubin.data();
     *sizeOut = jit_state.cubin.size();
   }
 
-  for (size_t i = 0; i < option_values.size(); ++i) {
-    if (rpc_read(conn, &jit_output_length, sizeof(jit_output_length)) < 0 ||
-        rpc_read(conn, option_values[i], jit_output_length) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
+  if (lupine_read_jit_outputs(conn, num_options, options, option_values) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
@@ -4754,10 +4788,54 @@ extern "C" CUresult cuModuleLoadDataEx(CUmodule *module, const void *image,
                                        unsigned int numOptions,
                                        CUjit_option *options,
                                        void **optionValues) {
-  (void)options;
-  (void)optionValues;
-  (void)numOptions;
-  return cuModuleLoadData(module, image);
+  if (module == nullptr || image == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  uint32_t kind = 0;
+  std::vector<unsigned char> image_bytes;
+  if (!lupine_pack_module_image(image, &kind, &image_bytes)) {
+    return CUDA_ERROR_INVALID_IMAGE;
+  }
+
+  lupine_route route = lupine_route_for_current_context();
+  if (lupine_route_is_local(route)) {
+    CUresult result = lupine_call_real_cuda_fn(
+        "cuModuleLoadDataEx", module, image, numOptions, options, optionValues);
+    if (result == CUDA_SUCCESS) {
+      lupine_remember_loaded_module(*module);
+      lupine_note_module_owner_route(*module, route);
+      lupine_record_module_image(*module, route, kind, image_bytes.data(),
+                                 image_bytes.size(), image);
+    }
+    return result;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult return_value;
+  size_t image_size = image_bytes.size();
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleLoadDataEx) < 0 ||
+      rpc_write(conn, &kind, sizeof(kind)) < 0 ||
+      rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
+      rpc_write(conn, image_bytes.data(), image_size) < 0 ||
+      rpc_write(conn, &numOptions, sizeof(numOptions)) < 0 ||
+      rpc_write(conn, options, numOptions * sizeof(*options)) < 0 ||
+      rpc_write(conn, optionValues, numOptions * sizeof(*optionValues)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      lupine_read_jit_outputs(conn, numOptions, options, optionValues) < 0 ||
+      rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_remember_loaded_module(*module);
+    lupine_note_module_owner(*module, conn);
+    lupine_record_module_image(*module, lupine_remote_route_for_conn(conn),
+                               kind, image_bytes.data(), image_bytes.size(),
+                               image);
+  }
+  return return_value;
 }
 
 struct lupine_wire_library_kernel_record {
@@ -4959,7 +5037,6 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t image_size = image_bytes.size();
-  size_t jit_output_length = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
       rpc_copy_alloc(conn, libraryOptionValues == nullptr
@@ -4993,11 +5070,9 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
       rpc_read(conn, library, sizeof(CUlibrary)) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  for (unsigned int i = 0; i < numJitOptions; ++i) {
-    if (rpc_read(conn, &jit_output_length, sizeof(jit_output_length)) < 0 ||
-        rpc_read(conn, jitOptionsValues[i], jit_output_length) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
+  if (lupine_read_jit_outputs(conn, numJitOptions, jitOptions,
+                              jitOptionsValues) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -136,7 +136,6 @@ struct lupine_jit_state {
   unsigned int num_options = 0;
   CUjit_option *options = nullptr;
   void **option_values = nullptr;
-  float wall_time = 0.0f;
   size_t info_log_size = 0;
   char *info_log = nullptr;
   size_t error_log_size = 0;
@@ -160,11 +159,8 @@ static int lupine_read_jit_options(conn_t *conn, lupine_jit_state *jit) {
   void **info_log_output = nullptr;
   void **error_log_output = nullptr;
   for (unsigned int i = 0; i < jit->num_options; ++i) {
-    if (jit->options[i] == CU_JIT_WALL_TIME &&
+    if (jit->options[i] == CU_JIT_INFO_LOG_BUFFER &&
         jit->option_values[i] != nullptr) {
-      jit->option_values[i] = &jit->wall_time;
-    } else if (jit->options[i] == CU_JIT_INFO_LOG_BUFFER &&
-               jit->option_values[i] != nullptr) {
       info_log_output = &jit->option_values[i];
     } else if (jit->options[i] == CU_JIT_ERROR_LOG_BUFFER &&
                jit->option_values[i] != nullptr) {
@@ -192,26 +188,27 @@ static int lupine_read_jit_options(conn_t *conn, lupine_jit_state *jit) {
   return 0;
 }
 
+// Every JIT option value the driver may rewrite is echoed back: the log
+// buffers as the bytes written into them, everything else as the option value
+// word the driver left in the server's array (CU_JIT_WALL_TIME and the log
+// sizes are rewritten there by value, not through the caller's pointer).
 static int lupine_write_jit_outputs(conn_t *conn, lupine_jit_state *jit) {
   if (rpc_copy_alloc(conn, jit->num_options * sizeof(size_t)) < 0) {
     return -1;
   }
   for (unsigned int i = 0; i < jit->num_options; ++i) {
-    const void *output = nullptr;
-    size_t output_length = 0;
-    if (jit->options[i] == CU_JIT_WALL_TIME &&
-        jit->option_values[i] != nullptr) {
-      output = &jit->wall_time;
-      output_length = sizeof(jit->wall_time);
-    } else if (jit->options[i] == CU_JIT_INFO_LOG_BUFFER) {
+    const bool is_log = jit->options[i] == CU_JIT_INFO_LOG_BUFFER ||
+                        jit->options[i] == CU_JIT_ERROR_LOG_BUFFER;
+    const void *output = &jit->option_values[i];
+    size_t output_length = sizeof(jit->option_values[i]);
+    if (jit->options[i] == CU_JIT_INFO_LOG_BUFFER) {
       output = jit->info_log;
       output_length = jit->info_log_size;
     } else if (jit->options[i] == CU_JIT_ERROR_LOG_BUFFER) {
       output = jit->error_log;
       output_length = jit->error_log_size;
     }
-    if (output != nullptr && output_length != 0 &&
-        jit->options[i] != CU_JIT_WALL_TIME) {
+    if (is_log && output != nullptr && output_length != 0) {
       const auto *end =
           static_cast<const char *>(std::memchr(output, '\0', output_length));
       if (end != nullptr) {
@@ -1005,6 +1002,52 @@ int handle_cuModuleLoadData(conn_t *conn) {
     return -1;
   }
   return 0;
+}
+
+int handle_cuModuleLoadDataEx(conn_t *conn) {
+  uint32_t kind = 0;
+  size_t image_size = 0;
+  int request_id;
+  lupine_jit_state jit;
+  CUmodule module = nullptr;
+
+  if (rpc_read(conn, &kind, sizeof(kind)) < 0 ||
+      rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
+    return -1;
+  }
+
+  std::vector<unsigned char> image(image_size);
+  if (image_size == 0 || rpc_read(conn, image.data(), image_size) < 0 ||
+      lupine_read_jit_options(conn, &jit) < 0) {
+    return -1;
+  }
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  // The client always unwraps fat binary containers, and cuModuleLoadDataEx
+  // takes a cubin, fatbin, or PTX image, so the kind tag the request carries
+  // for the options-free entry point makes no difference here.
+  CUresult result = cuModuleLoadDataEx(&module, image.data(), jit.num_options,
+                                       jit.options, jit.option_values);
+  if (result == CUDA_SUCCESS) {
+    lupine_note_device_stdout_image(image.data(), image.size());
+  }
+
+  int status = 0;
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      lupine_write_jit_outputs(conn, &jit) < 0 ||
+      rpc_write(conn, &module, sizeof(module)) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    status = -1;
+  }
+  std::free(jit.options);
+  std::free(jit.option_values);
+  std::free(jit.info_log);
+  std::free(jit.error_log);
+  return status;
 }
 
 int handle_lupineFunctionParamLayoutSnapshot(conn_t *conn) {

--- a/cuda_server.h
+++ b/cuda_server.h
@@ -11,6 +11,7 @@ int handle_cuGetExportTableMetadata(conn_t *conn);
 int handle_cuPrivateGetModuleNode(conn_t *conn);
 int handle_cuModuleLoad(conn_t *conn);
 int handle_cuModuleLoadData(conn_t *conn);
+int handle_cuModuleLoadDataEx(conn_t *conn);
 int handle_lupineFunctionParamLayoutSnapshot(conn_t *conn);
 int handle_lupineFunctionAttributeSnapshot(conn_t *conn);
 int handle_cuLibraryLoadData(conn_t *conn);

--- a/test/test_cuLibraryLoadData_options.cu
+++ b/test/test_cuLibraryLoadData_options.cu
@@ -6,7 +6,9 @@
 // loads PTX text (so the server must JIT it) with a mix of option kinds and
 // verifies:
 //   * the call returns CUDA_SUCCESS (options forwarded, not rejected);
-//   * CU_JIT_WALL_TIME is populated (output options are written back);
+//   * CU_JIT_WALL_TIME is populated (output options are written back), which
+//     the driver reports in the option value word rather than through the
+//     pointer stored there;
 //   * the loaded library is usable (launch the kernel, check the result).
 // Auto-discovered by test/run_custom_tests.sh via the test_*.cu glob.
 #include <cuda.h>
@@ -62,7 +64,8 @@ int main() {
   opts[2] = CU_JIT_INFO_LOG_BUFFER;
   vals[2] = (void *)info_log;
   opts[3] = CU_JIT_WALL_TIME;
-  vals[3] = &wall_time_ms;
+  vals[3] = nullptr;
+  memcpy(&vals[3], &wall_time_ms, sizeof(wall_time_ms));
   CUlibraryOption lopts[1] = {CU_LIBRARY_BINARY_IS_PRESERVED};
   void *lvals[1] = {(void *)1};
 
@@ -85,6 +88,7 @@ int main() {
 
   // Output option must be written back. The info log may legitimately be empty
   // on some drivers, so use wall time as the stable writeback signal.
+  memcpy(&wall_time_ms, &vals[3], sizeof(wall_time_ms));
   size_t log_len = strlen(info_log);
 
   // The loaded library must be usable: resolve the kernel and run it.

--- a/test/test_module_load_data_ex_options.cu
+++ b/test/test_module_load_data_ex_options.cu
@@ -1,0 +1,181 @@
+// Integration test for cuModuleLoadDataEx JIT option forwarding.
+//
+// The lupine client used to drop numOptions/options/optionValues and delegate
+// to cuModuleLoadData, so the caller's CU_JIT_INFO_LOG_BUFFER was never
+// touched and applications printed whatever garbage the allocation held (see
+// matrixMulDynlinkJIT, issue #671). This test pre-fills the log buffers with
+// non-zero bytes and checks the option write-back the driver performs:
+//   * a rejected PTX image fills the error log, NUL-terminated inside the
+//     declared size, and reports its length in the size option;
+//   * a valid PTX image loads, runs, and leaves a clean info log;
+//   * CU_JIT_WALL_TIME lands in the option value word, not through the
+//     pointer the caller happened to store there.
+// Auto-discovered by test/run_custom_tests.sh via the test_*.cu glob.
+#include <cuda.h>
+#include <stdio.h>
+#include <string.h>
+
+// cuGetErrorName hands back a per-thread buffer that the next lookup reuses,
+// so each name has to be copied before the next call.
+static char *cn(CUresult r, char *out, size_t size) {
+  const char *s = nullptr;
+  cuGetErrorName(r, &s);
+  snprintf(out, size, "%s", s ? s : "?");
+  return out;
+}
+
+static const char kSetvalPtx[] =
+    ".version 6.4\n"
+    ".target sm_52\n"
+    ".address_size 64\n"
+    "\n"
+    ".visible .entry setval(.param .u64 p0)\n"
+    "{\n"
+    "  .reg .b64 %rd<2>;\n"
+    "  .reg .b32 %r<2>;\n"
+    "  ld.param.u64 %rd1, [p0];\n"
+    "  mov.u32 %r1, 0x42280000;\n"
+    "  st.global.u32 [%rd1], %r1;\n"
+    "  ret;\n"
+    "}\n";
+
+static const char kBrokenPtx[] = ".version 6.4\n"
+                                 ".target sm_52\n"
+                                 ".address_size 64\n"
+                                 ".visible .entry bad(.param .u64 p0)\n"
+                                 "{\n"
+                                 "  not_an_instruction %r1, %r2;\n"
+                                 "  ret;\n"
+                                 "}\n";
+
+static char info_log[1024];
+static char error_log[1024];
+
+enum {
+  kInfoSize = 0,
+  kInfoBuffer = 1,
+  kErrorSize = 2,
+  kErrorBuffer = 3,
+  kMaxRegisters = 4,
+  kWallTime = 5,
+  kNumOptions = 6
+};
+
+static void reset_options(CUjit_option *opts, void **vals) {
+  memset(info_log, 0xAA, sizeof(info_log));
+  memset(error_log, 0xAA, sizeof(error_log));
+  opts[kInfoSize] = CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES;
+  vals[kInfoSize] = (void *)(size_t)sizeof(info_log);
+  opts[kInfoBuffer] = CU_JIT_INFO_LOG_BUFFER;
+  vals[kInfoBuffer] = info_log;
+  opts[kErrorSize] = CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES;
+  vals[kErrorSize] = (void *)(size_t)sizeof(error_log);
+  opts[kErrorBuffer] = CU_JIT_ERROR_LOG_BUFFER;
+  vals[kErrorBuffer] = error_log;
+  opts[kMaxRegisters] = CU_JIT_MAX_REGISTERS;
+  vals[kMaxRegisters] = (void *)(size_t)32;
+  // Sentinel so an untouched wall time reads back as a negative float.
+  float sentinel = -1.0f;
+  opts[kWallTime] = CU_JIT_WALL_TIME;
+  vals[kWallTime] = nullptr;
+  memcpy(&vals[kWallTime], &sentinel, sizeof(sentinel));
+}
+
+static float wall_time_of(void *const *vals) {
+  float wall_time = 0.0f;
+  memcpy(&wall_time, &vals[kWallTime], sizeof(wall_time));
+  return wall_time;
+}
+
+// A log buffer the driver never wrote to still has to be a valid C string:
+// find the terminator inside the declared size and reject binary garbage.
+static bool log_is_clean(const char *log, size_t size, size_t *length) {
+  *length = strnlen(log, size);
+  if (*length == size) {
+    return false;
+  }
+  for (size_t i = 0; i < *length; ++i) {
+    if (log[i] != '\n' && log[i] != '\t' && (log[i] < 0x20 || log[i] > 0x7e)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+int main() {
+  cuInit(0);
+  CUcontext ctx = nullptr;
+  CUdevice dev = 0;
+  if (cuDevicePrimaryCtxRetain(&ctx, dev) != CUDA_SUCCESS ||
+      cuCtxSetCurrent(ctx) != CUDA_SUCCESS) {
+    printf("RESULT: ERROR context\n");
+    return 2;
+  }
+
+  CUjit_option opts[kNumOptions];
+  void *vals[kNumOptions];
+
+  // The driver only reports the JIT error log for the first failed
+  // compilation in a process, so the broken image has to go first.
+  reset_options(opts, vals);
+  CUmodule broken = nullptr;
+  CUresult broken_result =
+      cuModuleLoadDataEx(&broken, kBrokenPtx, kNumOptions, opts, vals);
+  size_t error_len = 0;
+  bool error_clean = log_is_clean(error_log, sizeof(error_log), &error_len);
+  size_t error_size_out = (size_t)vals[kErrorSize];
+
+  reset_options(opts, vals);
+  CUmodule mod = nullptr;
+  CUresult r = cuModuleLoadDataEx(&mod, kSetvalPtx, kNumOptions, opts, vals);
+  size_t info_len = 0;
+  bool info_clean = log_is_clean(info_log, sizeof(info_log), &info_len);
+  size_t info_size_out = (size_t)vals[kInfoSize];
+  float wall_time_ms = wall_time_of(vals);
+  if (r != CUDA_SUCCESS) {
+    char name[64];
+    printf("RESULT: FAIL cuModuleLoadDataEx=%s(%d)\n",
+           cn(r, name, sizeof(name)), (int)r);
+    return 1;
+  }
+
+  CUfunction func = nullptr;
+  CUdeviceptr dev_x = 0;
+  float host_x = 0.0f;
+  r = cuModuleGetFunction(&func, mod, "setval");
+  if (r == CUDA_SUCCESS) {
+    r = cuMemAlloc_v2(&dev_x, sizeof(float));
+  }
+  if (r == CUDA_SUCCESS) {
+    void *params[1] = {&dev_x};
+    r = cuLaunchKernel(func, 1, 1, 1, 1, 1, 1, 0, nullptr, params, nullptr);
+  }
+  if (r == CUDA_SUCCESS) {
+    r = cuMemcpyDtoH_v2(&host_x, dev_x, sizeof(float));
+  }
+  if (r == CUDA_SUCCESS) {
+    r = cuCtxSynchronize();
+  }
+
+  bool ok = (r == CUDA_SUCCESS) && (host_x == 42.0f) &&
+            (broken_result == CUDA_ERROR_INVALID_PTX) && error_clean &&
+            (error_len != 0) && (error_size_out == error_len) && info_clean &&
+            (info_size_out == info_len) && (wall_time_ms >= 0.0f);
+  char launch_name[64];
+  char broken_name[64];
+  cn(r, launch_name, sizeof(launch_name));
+  cn(broken_result, broken_name, sizeof(broken_name));
+  printf("RESULT: %s launch=%s host_x=%.1f broken=%s error_len=%zu/%zu "
+         "error_clean=%d info_len=%zu/%zu info_clean=%d wall_time_ms=%.3f\n",
+         ok ? "PASS" : "FAIL", launch_name, host_x, broken_name, error_len,
+         error_size_out, (int)error_clean, info_len, info_size_out,
+         (int)info_clean, wall_time_ms);
+  if (!ok) {
+    printf("  error_log=\"%.*s\"\n", (int)(error_len > 200 ? 200 : error_len),
+           error_log);
+    printf("  info_log=\"%.*s\"\n", (int)(info_len > 200 ? 200 : info_len),
+           info_log);
+  }
+  cuModuleUnload(mod);
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #671.

`cuModuleLoadDataEx` discarded `numOptions`/`options`/`optionValues` and delegated to `cuModuleLoadData`, so the caller's `CU_JIT_INFO_LOG_BUFFER` was never written and matrixMulDynlinkJIT printed whatever bytes the fresh allocation held.

The options now ship with the image over a `cuModuleLoadDataEx` RPC, and the server hands them to the driver. The write-back also had to be corrected everywhere it already existed (`cuLinkAddData`, `cuLinkAddFile`, `cuLinkComplete`, `cuLibraryLoadData`): the server trimmed log buffers to their written length but the client never restored the terminator, and `CU_JIT_WALL_TIME` was routed through the pointer the caller stored in the option array. Probing the driver on an RTX 4090 (590.48.01, CUDA 13.3) shows it rewrites those option value words in place instead — wall time and both log sizes come back in `optionValues[i]`, the pointer target is untouched. One client-side helper now handles all of it: log bytes into the caller's buffer with a terminator, every other option value as the word the driver left behind.

`test/test_cuLibraryLoadData_options.cu` asserted the old pointer behavior (it fails against the native driver), so it now reads wall time from the option value word.

## Reproduction

matrixMulDynlinkJIT through a client built from `main`, against a server on an RTX 4090, three runs:

    > PTX JIT log:
    0?M-^@M-KM-^Bw
    > PTX JIT log:
    0?M-`M-gM-=|
    > PTX JIT log:
    0? M-5wz

Same sample and server with this branch, matching the native run byte for byte:

    > PTX JIT log:

## Testing

- New `test/test_module_load_data_ex_options.cu`: pre-fills both log buffers with `0xAA`, checks a rejected PTX image fills a terminated error log whose length is reported back in the size option, a valid image loads and runs with a clean info log, and wall time lands in the option value word. Passes natively and through Lupine with identical output.
- Fat binary images: the client unwraps containers before sending, and `cuModuleLoadDataEx` takes a raw fatbin, so the handler needs no separate `cuModuleLoadFatBinary` path and the options reach the driver for every image kind. With the server's JIT cache disabled, loading a PTX-only fatbin through Lupine reports the same 329-byte verbose info log and ~7ms wall time as the native run.
- All 35 `test/run_custom_tests.sh` tests pass against inferable-node-006.
- `test/run_unit_tests.sh`: only `hip_smemcpy_test` fails, which needs an AMD GPU this host does not have.