### PR TITLE
Generate the module-image loaders and cuModuleLoadDataEx from annotations

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2354,28 +2354,27 @@ CUresult cuCtxDetach(CUcontext ctx);
  */
 CUresult cuModuleLoad(CUmodule *module, const char *fname);
 /**
- * @disabled
- * @param module RECV_ONLY
- * @param image SEND_ONLY
- * @server CUDA
+ * @routingkey CURRENT_CONTEXT
+ * @recordowner MODULE module
+ * @param module SEND_RECV
+ * @moduleimage image module
  */
 CUresult cuModuleLoadData(CUmodule *module, const void *image);
 /**
- * @disabled
- * @param module RECV_ONLY
- * @param image SEND_ONLY NULL_TERMINATED
- * @param numOptions SEND_ONLY
- * @param options SEND_ONLY LENGTH:numOptions
- * @param optionValues SEND_RECV
- * @server CUDA
+ * @routingkey CURRENT_CONTEXT
+ * @recordowner MODULE module
+ * @param module SEND_RECV
+ * @moduleimage image module
+ * @jitoptions numOptions options optionValues
  */
 CUresult cuModuleLoadDataEx(CUmodule *module, const void *image,
                             unsigned int numOptions, CUjit_option *options,
                             void **optionValues);
 /**
- * @disabled
+ * @routingkey CURRENT_CONTEXT
+ * @recordowner MODULE module
  * @param module SEND_RECV
- * @param fatCubin SEND_RECV
+ * @moduleimage fatCubin module
  */
 CUresult cuModuleLoadFatBinary(CUmodule *module, const void *fatCubin);
 /**

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -18,6 +18,8 @@ import zlib
 from ops import (
     NullableOperation,
     ArrayOperation,
+    ModuleImageOperation,
+    JitOptionsOperation,
     InOutCountOperation,
     NullableArrayOperation,
     DeepStructOperation,
@@ -594,6 +596,44 @@ def parse_annotation(
                 node=annotation_param(params, parts[2]),
             )
             continue
+        if line.startswith("@moduleimage"):
+            # @moduleimage <image_param> <module_param>
+            parts = line.split()
+            if len(parts) != 3:
+                raise RuntimeError(
+                    "@moduleimage requires an image and a module parameter"
+                )
+            operations.append(
+                ModuleImageOperation(
+                    parameter=annotation_param(params, parts[1]),
+                    module=annotation_param(params, parts[2]),
+                )
+            )
+            continue
+        if line.startswith("@jitoptions"):
+            # @jitoptions <count_param> <options_param> <values_param>
+            parts = line.split()
+            if len(parts) != 4:
+                raise RuntimeError(
+                    "@jitoptions requires count, options, and values parameters"
+                )
+            count, options_name, values = parts[1], parts[2], parts[3]
+            for role, name in (
+                ("count", count),
+                ("options", options_name),
+                ("values", values),
+            ):
+                operations.append(
+                    JitOptionsOperation(
+                        parameter=annotation_param(params, name),
+                        role=role,
+                        state=f"{values}_jit",
+                        count=count,
+                        options=options_name,
+                        values=values,
+                    )
+                )
+            continue
         if line.startswith("@deeparray"):
             # @deeparray <param> <array_member> <count_member>
             parts = line.split()
@@ -1041,6 +1081,11 @@ def client_record_owner_stmt(owner: OwnerAnnotation) -> str:
 
 
 def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMetadata):
+    for operation in metadata.operations:
+        post_call = getattr(operation, "client_post_call", None)
+        if post_call is not None:
+            post_call(f)
+
     if function.name.format() == "cuDriverGetVersion":
         f.write("    if (driverVersion != nullptr) {\n")
         f.write("        const char *override_version = getenv(\"LUPINE_DRIVER_VERSION_OVERRIDE\");\n")
@@ -1893,6 +1938,20 @@ def main():
             'extern "C" const char *lupine_retain_returned_string(const void *handle, const char *data, size_t size);\n\n'
             'extern "C" void lupine_release_module_retained_strings(CUmodule module);\n'
             'extern "C" void lupine_release_library_retained_strings(CUlibrary library);\n\n'
+            # Module image packing and JIT option write-back live in
+            # cuda_client.cpp; see ModuleImageOperation and JitOptionsOperation.
+            "bool lupine_pack_module_image(const void *image, uint32_t *kind,\n"
+            "                              std::vector<unsigned char> *bytes);\n"
+            "int lupine_read_jit_outputs(conn_t *conn, unsigned int numOptions,\n"
+            "                            const CUjit_option *options,\n"
+            "                            void **optionValues);\n"
+            'extern "C" void lupine_remember_loaded_module(CUmodule module);\n'
+            'extern "C" void lupine_record_module_image(CUmodule module,\n'
+            "                                           lupine_route route,\n"
+            "                                           uint32_t kind,\n"
+            "                                           const unsigned char *image,\n"
+            "                                           size_t image_size,\n"
+            "                                           const void *image_ptr);\n\n"
             'extern "C" void lupine_record_library_module(CUmodule module, CUlibrary library);\n\n'
             'extern "C" CUresult lupine_record_library_kernel(CUkernel kernel, CUlibrary library, const char *name, lupine_route route);\n\n'
             'extern "C" CUresult lupine_record_module_function(CUfunction function, CUmodule module, const char *name, lupine_route route);\n\n'
@@ -1997,6 +2056,12 @@ def main():
                             )
                         )
                     )
+            # The image is packed before the routing branch: the local path
+            # records the same bytes the remote one ships.
+            for operation in operations:
+                if isinstance(operation, ModuleImageOperation):
+                    operation.client_pack(f)
+
             if metadata.cross_server_copy is not None:
                 copy = metadata.cross_server_copy
                 stream_arg = (
@@ -2285,7 +2350,12 @@ def main():
             '#include <vector>\n\n'
             '#include <cstdio>\n\n'
             '#include "cuda_server_memcpy.h"\n'
+            '#include "lupine_jit.h"\n'
             '#include "rpc.h"\n\n'
+        )
+        f.write(
+            "void lupine_note_device_stdout_image(const unsigned char *image,\n"
+            "                                     size_t image_size);\n\n"
         )
         annotation_only_functions = (
             legacy_abi_functions + annotation_only_server_functions
@@ -2394,6 +2464,11 @@ def main():
                 if metadata.guard is not None:
                     f.write("#endif\n\n")
                 continue
+
+            for operation in operations:
+                post_call = getattr(operation, "server_post_call", None)
+                if post_call is not None:
+                    post_call(f)
 
             f.write("    if (rpc_write_start_response(conn, request_id) < 0 ||\n")
 

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -59,6 +59,17 @@ extern "C" const char *lupine_retain_returned_string(const void *handle,
 extern "C" void lupine_release_module_retained_strings(CUmodule module);
 extern "C" void lupine_release_library_retained_strings(CUlibrary library);
 
+bool lupine_pack_module_image(const void *image, uint32_t *kind,
+                              std::vector<unsigned char> *bytes);
+int lupine_read_jit_outputs(conn_t *conn, unsigned int numOptions,
+                            const CUjit_option *options, void **optionValues);
+extern "C" void lupine_remember_loaded_module(CUmodule module);
+extern "C" void lupine_record_module_image(CUmodule module, lupine_route route,
+                                           uint32_t kind,
+                                           const unsigned char *image,
+                                           size_t image_size,
+                                           const void *image_ptr);
+
 extern "C" void lupine_record_library_module(CUmodule module,
                                              CUlibrary library);
 
@@ -671,6 +682,145 @@ CUresult cuCtxSetSharedMemConfig(CUsharedconfig config) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+CUresult cuModuleLoadData(CUmodule *module, const void *image) {
+  lupine_route route = lupine_route_for_current_context();
+  uint32_t image_kind = 0;
+  std::vector<unsigned char> image_bytes;
+  if (!lupine_pack_module_image(image, &image_kind, &image_bytes))
+    return CUDA_ERROR_INVALID_IMAGE;
+  size_t image_size = image_bytes.size();
+  CUresult return_value;
+  if (lupine_route_is_local(route)) {
+    return_value = lupine_call_real_cuda_fn("cuModuleLoadData", module, image);
+    if (return_value == CUDA_SUCCESS && module != nullptr) {
+      lupine_remember_loaded_module(*module);
+      lupine_record_module_image(*module, route, image_kind, image_bytes.data(),
+                                 image_bytes.size(), image);
+    }
+    if (return_value == CUDA_SUCCESS && module != nullptr) {
+      lupine_note_module_owner_route(*module, route);
+    }
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
+      rpc_write(conn, module, sizeof(CUmodule)) < 0 ||
+      rpc_write(conn, &image_kind, sizeof(image_kind)) < 0 ||
+      rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
+      rpc_write(conn, image_bytes.data(), image_size) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && module != nullptr) {
+    lupine_remember_loaded_module(*module);
+    lupine_record_module_image(*module, route, image_kind, image_bytes.data(),
+                               image_bytes.size(), image);
+  }
+  if (return_value == CUDA_SUCCESS && module != nullptr) {
+    lupine_note_module_owner_route(*module, route);
+  }
+  return return_value;
+}
+
+CUresult cuModuleLoadDataEx(CUmodule *module, const void *image,
+                            unsigned int numOptions, CUjit_option *options,
+                            void **optionValues) {
+  lupine_route route = lupine_route_for_current_context();
+  uint32_t image_kind = 0;
+  std::vector<unsigned char> image_bytes;
+  if (!lupine_pack_module_image(image, &image_kind, &image_bytes))
+    return CUDA_ERROR_INVALID_IMAGE;
+  size_t image_size = image_bytes.size();
+  CUresult return_value;
+  if (lupine_route_is_local(route)) {
+    return_value = lupine_call_real_cuda_fn("cuModuleLoadDataEx", module, image,
+                                            numOptions, options, optionValues);
+    if (return_value == CUDA_SUCCESS && module != nullptr) {
+      lupine_remember_loaded_module(*module);
+      lupine_record_module_image(*module, route, image_kind, image_bytes.data(),
+                                 image_bytes.size(), image);
+    }
+    if (return_value == CUDA_SUCCESS && module != nullptr) {
+      lupine_note_module_owner_route(*module, route);
+    }
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleLoadDataEx) < 0 ||
+      rpc_write(conn, module, sizeof(CUmodule)) < 0 ||
+      rpc_write(conn, &image_kind, sizeof(image_kind)) < 0 ||
+      rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
+      rpc_write(conn, image_bytes.data(), image_size) < 0 ||
+      rpc_write(conn, &numOptions, sizeof(numOptions)) < 0 ||
+      rpc_write(conn, options, numOptions * sizeof(*options)) < 0 ||
+      rpc_write(conn, optionValues, numOptions * sizeof(*optionValues)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
+      lupine_read_jit_outputs(conn, numOptions, options, optionValues) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && module != nullptr) {
+    lupine_remember_loaded_module(*module);
+    lupine_record_module_image(*module, route, image_kind, image_bytes.data(),
+                               image_bytes.size(), image);
+  }
+  if (return_value == CUDA_SUCCESS && module != nullptr) {
+    lupine_note_module_owner_route(*module, route);
+  }
+  return return_value;
+}
+
+CUresult cuModuleLoadFatBinary(CUmodule *module, const void *fatCubin) {
+  lupine_route route = lupine_route_for_current_context();
+  uint32_t fatCubin_kind = 0;
+  std::vector<unsigned char> fatCubin_bytes;
+  if (!lupine_pack_module_image(fatCubin, &fatCubin_kind, &fatCubin_bytes))
+    return CUDA_ERROR_INVALID_IMAGE;
+  size_t fatCubin_size = fatCubin_bytes.size();
+  CUresult return_value;
+  if (lupine_route_is_local(route)) {
+    return_value =
+        lupine_call_real_cuda_fn("cuModuleLoadFatBinary", module, fatCubin);
+    if (return_value == CUDA_SUCCESS && module != nullptr) {
+      lupine_remember_loaded_module(*module);
+      lupine_record_module_image(*module, route, fatCubin_kind,
+                                 fatCubin_bytes.data(), fatCubin_bytes.size(),
+                                 fatCubin);
+    }
+    if (return_value == CUDA_SUCCESS && module != nullptr) {
+      lupine_note_module_owner_route(*module, route);
+    }
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuModuleLoadFatBinary) < 0 ||
+      rpc_write(conn, module, sizeof(CUmodule)) < 0 ||
+      rpc_write(conn, &fatCubin_kind, sizeof(fatCubin_kind)) < 0 ||
+      rpc_write(conn, &fatCubin_size, sizeof(fatCubin_size)) < 0 ||
+      rpc_write(conn, fatCubin_bytes.data(), fatCubin_size) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && module != nullptr) {
+    lupine_remember_loaded_module(*module);
+    lupine_record_module_image(*module, route, fatCubin_kind,
+                               fatCubin_bytes.data(), fatCubin_bytes.size(),
+                               fatCubin);
+  }
+  if (return_value == CUDA_SUCCESS && module != nullptr) {
+    lupine_note_module_owner_route(*module, route);
+  }
   return return_value;
 }
 
@@ -7254,6 +7404,9 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuCtxDetach", (void *)cuCtxDetach},
     {"cuCtxGetSharedMemConfig", (void *)cuCtxGetSharedMemConfig},
     {"cuCtxSetSharedMemConfig", (void *)cuCtxSetSharedMemConfig},
+    {"cuModuleLoadData", (void *)cuModuleLoadData},
+    {"cuModuleLoadDataEx", (void *)cuModuleLoadDataEx},
+    {"cuModuleLoadFatBinary", (void *)cuModuleLoadFatBinary},
     {"cuModuleUnload", (void *)cuModuleUnload},
     {"cuModuleGetLoadingMode", (void *)cuModuleGetLoadingMode},
     {"cuModuleGetFunction", (void *)cuModuleGetFunction},

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -11,7 +11,11 @@
 #include <cstdio>
 
 #include "cuda_server_memcpy.h"
+#include "lupine_jit.h"
 #include "rpc.h"
+
+void lupine_note_device_stdout_image(const unsigned char *image,
+                                     size_t image_size);
 
 #ifdef cuGraphInstantiate_v2
 #undef cuGraphInstantiate_v2
@@ -988,6 +992,110 @@ int handle_cuCtxSetSharedMemConfig(conn_t *conn) {
   lupine_intercept_result = cuCtxSetSharedMemConfig(config);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+int handle_cuModuleLoadData(conn_t *conn) {
+  CUmodule module;
+  uint32_t image_kind;
+  size_t image_size;
+  std::vector<unsigned char> image;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &module, sizeof(CUmodule)) < 0 ||
+      rpc_read(conn, &image_kind, sizeof(image_kind)) < 0 ||
+      rpc_read(conn, &image_size, sizeof(image_size)) < 0 ||
+      ((image.resize(image_size), false)) ||
+      (image_size != 0 && rpc_read(conn, image.data(), image_size) < 0) ||
+      false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuModuleLoadData(&module, image.data());
+
+  if (lupine_intercept_result == CUDA_SUCCESS)
+    lupine_note_device_stdout_image(image.data(), image.size());
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &module, sizeof(CUmodule)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+int handle_cuModuleLoadDataEx(conn_t *conn) {
+  CUmodule module;
+  uint32_t image_kind;
+  size_t image_size;
+  std::vector<unsigned char> image;
+  lupine_jit_options optionValues_jit;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &module, sizeof(CUmodule)) < 0 ||
+      rpc_read(conn, &image_kind, sizeof(image_kind)) < 0 ||
+      rpc_read(conn, &image_size, sizeof(image_size)) < 0 ||
+      ((image.resize(image_size), false)) ||
+      (image_size != 0 && rpc_read(conn, image.data(), image_size) < 0) ||
+      lupine_read_jit_options(conn, &optionValues_jit.state) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuModuleLoadDataEx(
+      &module, image.data(), optionValues_jit.state.num_options,
+      optionValues_jit.state.options, optionValues_jit.state.option_values);
+
+  if (lupine_intercept_result == CUDA_SUCCESS)
+    lupine_note_device_stdout_image(image.data(), image.size());
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &module, sizeof(CUmodule)) < 0 ||
+      lupine_write_jit_outputs(conn, &optionValues_jit.state) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+int handle_cuModuleLoadFatBinary(conn_t *conn) {
+  CUmodule module;
+  uint32_t fatCubin_kind;
+  size_t fatCubin_size;
+  std::vector<unsigned char> fatCubin;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &module, sizeof(CUmodule)) < 0 ||
+      rpc_read(conn, &fatCubin_kind, sizeof(fatCubin_kind)) < 0 ||
+      rpc_read(conn, &fatCubin_size, sizeof(fatCubin_size)) < 0 ||
+      ((fatCubin.resize(fatCubin_size), false)) ||
+      (fatCubin_size != 0 &&
+       rpc_read(conn, fatCubin.data(), fatCubin_size) < 0) ||
+      false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuModuleLoadFatBinary(&module, fatCubin.data());
+
+  if (lupine_intercept_result == CUDA_SUCCESS)
+    lupine_note_device_stdout_image(fatCubin.data(), fatCubin.size());
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &module, sizeof(CUmodule)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -1134,8 +1134,205 @@ class DereferenceOperation:
         )
 
 
+@dataclass
+class ModuleImageOperation:
+    """
+    A module image parameter, declared in the function doxygen with:
+
+        @moduleimage <image_param> <module_param>
+
+    The image argument carries no length: a fat binary container hides its
+    payload behind a pointer, an ELF cubin is sized by its headers, and PTX is
+    text. lupine_pack_module_image() resolves all three into a tagged byte
+    range on the client, which is what crosses the wire; the server hands that
+    range to the driver. The packed bytes are also what the client keeps for
+    the module, so a later reload onto another server can replay the image.
+    """
+
+    parameter: Parameter
+    module: Parameter
+
+    @property
+    def kind_name(self) -> str:
+        return f"{self.parameter.name}_kind"
+
+    @property
+    def bytes_name(self) -> str:
+        return f"{self.parameter.name}_bytes"
+
+    @property
+    def size_name(self) -> str:
+        return f"{self.parameter.name}_size"
+
+    def client_pack(self, f):
+        # Packing precedes the routing branch: the local path records the same
+        # bytes as the remote one.
+        f.write(f"    uint32_t {self.kind_name} = 0;\n")
+        f.write(f"    std::vector<unsigned char> {self.bytes_name};\n")
+        f.write(
+            f"    if (!lupine_pack_module_image({self.parameter.name}, "
+            f"&{self.kind_name}, &{self.bytes_name}))\n"
+            f"        return CUDA_ERROR_INVALID_IMAGE;\n"
+        )
+        f.write(
+            f"    size_t {self.size_name} = {self.bytes_name}.size();\n"
+        )
+
+    def client_rpc_write(self, f):
+        f.write(
+            f"        rpc_write(conn, &{self.kind_name}, "
+            f"sizeof({self.kind_name})) < 0 ||\n"
+        )
+        f.write(
+            f"        rpc_write(conn, &{self.size_name}, "
+            f"sizeof({self.size_name})) < 0 ||\n"
+        )
+        f.write(
+            f"        rpc_write(conn, {self.bytes_name}.data(), "
+            f"{self.size_name}) < 0 ||\n"
+        )
+
+    def client_rpc_read(self, f):
+        return
+
+    def client_post_call(self, f):
+        module = self.module.name
+        f.write(
+            f"    if (return_value == CUDA_SUCCESS && {module} != nullptr) {{\n"
+            f"        lupine_remember_loaded_module(*{module});\n"
+            f"        lupine_record_module_image(*{module}, route, "
+            f"{self.kind_name}, {self.bytes_name}.data(), "
+            f"{self.bytes_name}.size(), {self.parameter.name});\n"
+            "    }\n"
+        )
+
+    @property
+    def server_declaration(self) -> str:
+        return (
+            f"    uint32_t {self.kind_name};\n"
+            f"    size_t {self.size_name};\n"
+            f"    std::vector<unsigned char> {self.parameter.name};\n"
+        )
+
+    def server_rpc_read(self, f) -> Optional[str]:
+        name = self.parameter.name
+        f.write(
+            f"        rpc_read(conn, &{self.kind_name}, "
+            f"sizeof({self.kind_name})) < 0 ||\n"
+        )
+        f.write(
+            f"        rpc_read(conn, &{self.size_name}, "
+            f"sizeof({self.size_name})) < 0 ||\n"
+        )
+        f.write(f"        (({name}.resize({self.size_name}), false)) ||\n")
+        f.write(
+            f"        ({self.size_name} != 0 && "
+            f"rpc_read(conn, {name}.data(), {self.size_name}) < 0) ||\n"
+        )
+        return None
+
+    @property
+    def server_reference(self) -> str:
+        return f"{self.parameter.name}.data()"
+
+    def server_post_call(self, f):
+        name = self.parameter.name
+        f.write(
+            "    if (lupine_intercept_result == CUDA_SUCCESS)\n"
+            f"        lupine_note_device_stdout_image({name}.data(), "
+            f"{name}.size());\n"
+        )
+
+    def server_rpc_write(self, f):
+        return
+
+
+@dataclass
+class JitOptionsOperation:
+    """
+    The JIT option table three CUDA loaders take, declared in the function
+    doxygen with:
+
+        @jitoptions <count_param> <options_param> <values_param>
+
+    One object is built per parameter; the one holding the values array does
+    the marshalling and the other two only name their slice of the server-side
+    state. The values array cannot be copied as a flat array of words: an entry
+    tagged CU_JIT_INFO_LOG_BUFFER is a pointer to caller memory the driver
+    writes into, while the rest are values the driver rewrites in place, and
+    the log buffer sizes live in other entries of the same array.
+    """
+
+    parameter: Parameter
+    role: str  # "count", "options", or "values"
+    state: str
+    count: str
+    options: str
+    values: str
+
+    @property
+    def is_primary(self) -> bool:
+        return self.role == "values"
+
+    def client_rpc_write(self, f):
+        if not self.is_primary:
+            return
+        f.write(
+            f"        rpc_write(conn, &{self.count}, "
+            f"sizeof({self.count})) < 0 ||\n"
+        )
+        f.write(
+            f"        rpc_write(conn, {self.options}, "
+            f"{self.count} * sizeof(*{self.options})) < 0 ||\n"
+        )
+        f.write(
+            f"        rpc_write(conn, {self.values}, "
+            f"{self.count} * sizeof(*{self.values})) < 0 ||\n"
+        )
+
+    def client_rpc_read(self, f):
+        if not self.is_primary:
+            return
+        f.write(
+            f"        lupine_read_jit_outputs(conn, {self.count}, "
+            f"{self.options}, {self.values}) < 0 ||\n"
+        )
+
+    @property
+    def server_declaration(self) -> str:
+        if not self.is_primary:
+            return ""
+        return f"    lupine_jit_options {self.state};\n"
+
+    def server_rpc_read(self, f) -> Optional[str]:
+        if not self.is_primary:
+            return None
+        f.write(
+            f"        lupine_read_jit_options(conn, &{self.state}.state) < 0 ||\n"
+        )
+        return None
+
+    @property
+    def server_reference(self) -> str:
+        member = {
+            "count": "num_options",
+            "options": "options",
+            "values": "option_values",
+        }[self.role]
+        return f"{self.state}.state.{member}"
+
+    def server_rpc_write(self, f):
+        if not self.is_primary:
+            return
+        f.write(
+            f"        lupine_write_jit_outputs(conn, &{self.state}.state) < 0 ||\n"
+        )
+
+
 Operation = Union[
     NullableOperation,
+    ModuleImageOperation,
+    JitOptionsOperation,
     ArrayOperation,
     NullTerminatedOperation,
     OpaqueTypeOperation,

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -18,8 +18,6 @@
   HANDLER(RPC_cuCtxAttach, handle_cuCtxAttach, rpc_backend::cuda) \
   HANDLER(RPC_cuCtxDetach, handle_cuCtxDetach, rpc_backend::cuda) \
   HANDLER(RPC_cuModuleLoad, handle_cuModuleLoad, rpc_backend::cuda) \
-  HANDLER(RPC_cuModuleLoadData, handle_cuModuleLoadData, rpc_backend::cuda) \
-  HANDLER(RPC_cuModuleLoadDataEx, handle_cuModuleLoadDataEx, rpc_backend::cuda) \
   HANDLER(RPC_cuModuleGetGlobal_v2, handle_cuModuleGetGlobal_v2, rpc_backend::cuda) \
   HANDLER(RPC_cuLinkCreate_v2, handle_cuLinkCreate_v2, rpc_backend::cuda) \
   HANDLER(RPC_cuLinkAddData_v2, handle_cuLinkAddData_v2, rpc_backend::cuda) \
@@ -141,6 +139,9 @@
   HANDLER(RPC_cuCtxGetExecAffinity, handle_cuCtxGetExecAffinity, rpc_backend::cuda) \
   HANDLER(RPC_cuCtxGetSharedMemConfig, handle_cuCtxGetSharedMemConfig, rpc_backend::cuda) \
   HANDLER(RPC_cuCtxSetSharedMemConfig, handle_cuCtxSetSharedMemConfig, rpc_backend::cuda) \
+  HANDLER(RPC_cuModuleLoadData, handle_cuModuleLoadData, rpc_backend::cuda) \
+  HANDLER(RPC_cuModuleLoadDataEx, handle_cuModuleLoadDataEx, rpc_backend::cuda) \
+  HANDLER(RPC_cuModuleLoadFatBinary, handle_cuModuleLoadFatBinary, rpc_backend::cuda) \
   HANDLER(RPC_cuModuleUnload, handle_cuModuleUnload, rpc_backend::cuda) \
   HANDLER(RPC_cuModuleGetLoadingMode, handle_cuModuleGetLoadingMode, rpc_backend::cuda) \
   HANDLER(RPC_cuModuleGetFunction, handle_cuModuleGetFunction, rpc_backend::cuda) \

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -740,7 +740,7 @@ lupine_graph_kernel_node_params_cache() {
   return *cache;
 }
 
-static void lupine_remember_loaded_module(CUmodule module) {
+extern "C" void lupine_remember_loaded_module(CUmodule module) {
   if (module == nullptr) {
     return;
   }
@@ -4067,9 +4067,8 @@ lupine_jit_client_states() {
 // value is rewritten in place by the driver (CU_JIT_WALL_TIME and the log
 // sizes report through the option array itself), so its word replaces the one
 // that was sent.
-static int lupine_read_jit_outputs(conn_t *conn, unsigned int numOptions,
-                                   const CUjit_option *options,
-                                   void **optionValues) {
+int lupine_read_jit_outputs(conn_t *conn, unsigned int numOptions,
+                            const CUjit_option *options, void **optionValues) {
   size_t log_sizes[2] = {0, 0};
   for (unsigned int i = 0; i < numOptions; ++i) {
     if (options[i] == CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES) {
@@ -4661,8 +4660,8 @@ static bool lupine_image_looks_like_text(const char *image) {
   return true;
 }
 
-static bool lupine_pack_module_image(const void *image, uint32_t *kind,
-                                     std::vector<unsigned char> *bytes) {
+bool lupine_pack_module_image(const void *image, uint32_t *kind,
+                              std::vector<unsigned char> *bytes) {
   if (image == nullptr || kind == nullptr || bytes == nullptr) {
     return false;
   }
@@ -4735,107 +4734,6 @@ static bool lupine_pack_module_image(const void *image, uint32_t *kind,
   const auto *raw = static_cast<const unsigned char *>(fatbin);
   bytes->assign(raw, raw + image_size);
   return true;
-}
-
-extern "C" CUresult cuModuleLoadData(CUmodule *module, const void *image) {
-  if (module == nullptr || image == nullptr) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  uint32_t kind = 0;
-  std::vector<unsigned char> image_bytes;
-  if (!lupine_pack_module_image(image, &kind, &image_bytes)) {
-    return CUDA_ERROR_INVALID_IMAGE;
-  }
-
-  lupine_route route = lupine_route_for_current_context();
-  if (lupine_route_is_local(route)) {
-    CUresult result =
-        lupine_call_real_cuda_fn("cuModuleLoadData", module, image);
-    if (result == CUDA_SUCCESS) {
-      lupine_remember_loaded_module(*module);
-      lupine_note_module_owner_route(*module, route);
-      lupine_record_module_image(*module, route, kind, image_bytes.data(),
-                                 image_bytes.size(), image);
-    }
-    return result;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  size_t image_size = image_bytes.size();
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
-      rpc_write(conn, &kind, sizeof(kind)) < 0 ||
-      rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
-      rpc_write(conn, image_bytes.data(), image_size) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (return_value == CUDA_SUCCESS) {
-    lupine_remember_loaded_module(*module);
-    lupine_note_module_owner(*module, conn);
-    lupine_record_module_image(*module, lupine_remote_route_for_conn(conn),
-                               kind, image_bytes.data(), image_bytes.size(),
-                               image);
-  }
-  return return_value;
-}
-
-extern "C" CUresult cuModuleLoadDataEx(CUmodule *module, const void *image,
-                                       unsigned int numOptions,
-                                       CUjit_option *options,
-                                       void **optionValues) {
-  if (module == nullptr || image == nullptr) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  uint32_t kind = 0;
-  std::vector<unsigned char> image_bytes;
-  if (!lupine_pack_module_image(image, &kind, &image_bytes)) {
-    return CUDA_ERROR_INVALID_IMAGE;
-  }
-
-  lupine_route route = lupine_route_for_current_context();
-  if (lupine_route_is_local(route)) {
-    CUresult result = lupine_call_real_cuda_fn(
-        "cuModuleLoadDataEx", module, image, numOptions, options, optionValues);
-    if (result == CUDA_SUCCESS) {
-      lupine_remember_loaded_module(*module);
-      lupine_note_module_owner_route(*module, route);
-      lupine_record_module_image(*module, route, kind, image_bytes.data(),
-                                 image_bytes.size(), image);
-    }
-    return result;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  size_t image_size = image_bytes.size();
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuModuleLoadDataEx) < 0 ||
-      rpc_write(conn, &kind, sizeof(kind)) < 0 ||
-      rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
-      rpc_write(conn, image_bytes.data(), image_size) < 0 ||
-      rpc_write(conn, &numOptions, sizeof(numOptions)) < 0 ||
-      rpc_write(conn, options, numOptions * sizeof(*options)) < 0 ||
-      rpc_write(conn, optionValues, numOptions * sizeof(*optionValues)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      lupine_read_jit_outputs(conn, numOptions, options, optionValues) < 0 ||
-      rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (return_value == CUDA_SUCCESS) {
-    lupine_remember_loaded_module(*module);
-    lupine_note_module_owner(*module, conn);
-    lupine_record_module_image(*module, lupine_remote_route_for_conn(conn),
-                               kind, image_bytes.data(), image_bytes.size(),
-                               image);
-  }
-  return return_value;
 }
 
 struct lupine_wire_library_kernel_record {
@@ -7878,7 +7776,6 @@ static void *lupine_make_missing_stub(const char *symbol) {
 
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuCtxCreate)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuModuleLoadData)
-LUPINE_DEFINE_UNSUPPORTED_STUB(cuModuleLoadFatBinary)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuLibraryLoadData)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuLibraryGetKernelCount)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuLibraryEnumerateKernels)
@@ -7982,7 +7879,6 @@ static void *lupine_get_unsupported_stub(const char *symbol) {
   { #name, (void *)&lupine_unsupported_##name }
       LUPINE_STUB_ENTRY(cuCtxCreate),
       LUPINE_STUB_ENTRY(cuModuleLoadData),
-      LUPINE_STUB_ENTRY(cuModuleLoadFatBinary),
       LUPINE_STUB_ENTRY(cuLibraryLoadData),
       LUPINE_STUB_ENTRY(cuLibraryGetKernelCount),
       LUPINE_STUB_ENTRY(cuLibraryEnumerateKernels),

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -44,6 +44,7 @@
 #include "ipc.h"
 #include "lupine_attr_sizes.h"
 #include "lupine_fatbin.h"
+#include "lupine_jit.h"
 #include "lupine_log.h"
 #include "rpc.h"
 
@@ -132,17 +133,7 @@ static int lupine_write_attribute_snapshot(conn_t *conn, Query query) {
   return 0;
 }
 
-struct lupine_jit_state {
-  unsigned int num_options = 0;
-  CUjit_option *options = nullptr;
-  void **option_values = nullptr;
-  size_t info_log_size = 0;
-  char *info_log = nullptr;
-  size_t error_log_size = 0;
-  char *error_log = nullptr;
-};
-
-static int lupine_read_jit_options(conn_t *conn, lupine_jit_state *jit) {
+int lupine_read_jit_options(conn_t *conn, lupine_jit_state *jit) {
   if (rpc_read(conn, &jit->num_options, sizeof(jit->num_options)) < 0) {
     return -1;
   }
@@ -192,7 +183,7 @@ static int lupine_read_jit_options(conn_t *conn, lupine_jit_state *jit) {
 // buffers as the bytes written into them, everything else as the option value
 // word the driver left in the server's array (CU_JIT_WALL_TIME and the log
 // sizes are rewritten there by value, not through the caller's pointer).
-static int lupine_write_jit_outputs(conn_t *conn, lupine_jit_state *jit) {
+int lupine_write_jit_outputs(conn_t *conn, lupine_jit_state *jit) {
   if (rpc_copy_alloc(conn, jit->num_options * sizeof(size_t)) < 0) {
     return -1;
   }
@@ -376,8 +367,8 @@ static bool lupine_image_may_use_device_stdout(const unsigned char *image,
                                 sizeof(ptx_version) - 1);
 }
 
-static void lupine_note_device_stdout_image(const unsigned char *image,
-                                            size_t image_size) {
+void lupine_note_device_stdout_image(const unsigned char *image,
+                                     size_t image_size) {
   if (lupine_image_may_use_device_stdout(image, image_size)) {
     lupine_stdout_capture_required.store(true, std::memory_order_release);
   }
@@ -962,94 +953,6 @@ int handle_cuModuleLoad(conn_t *conn) {
   return 0;
 }
 
-int handle_cuModuleLoadData(conn_t *conn) {
-  uint32_t kind = 0;
-  size_t image_size = 0;
-  int request_id;
-  CUmodule module = nullptr;
-  CUresult result = CUDA_ERROR_INVALID_VALUE;
-
-  if (rpc_read(conn, &kind, sizeof(kind)) < 0 ||
-      rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
-    return -1;
-  }
-
-  std::vector<unsigned char> image(image_size);
-  if (image_size == 0 || rpc_read(conn, image.data(), image_size) < 0) {
-    return -1;
-  }
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0) {
-    return -1;
-  }
-
-  if (kind == LUPINE_MODULE_IMAGE_FATBINC_V1 ||
-      kind == LUPINE_MODULE_IMAGE_FATBINC_V2) {
-    result = cuModuleLoadFatBinary(&module, image.data());
-  } else if (kind == LUPINE_MODULE_IMAGE_FATBIN_RAW) {
-    result = cuModuleLoadData(&module, image.data());
-  } else {
-    result = CUDA_ERROR_NOT_SUPPORTED;
-  }
-  if (result == CUDA_SUCCESS) {
-    lupine_note_device_stdout_image(image.data(), image.size());
-  }
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &module, sizeof(module)) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    return -1;
-  }
-  return 0;
-}
-
-int handle_cuModuleLoadDataEx(conn_t *conn) {
-  uint32_t kind = 0;
-  size_t image_size = 0;
-  int request_id;
-  lupine_jit_state jit;
-  CUmodule module = nullptr;
-
-  if (rpc_read(conn, &kind, sizeof(kind)) < 0 ||
-      rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
-    return -1;
-  }
-
-  std::vector<unsigned char> image(image_size);
-  if (image_size == 0 || rpc_read(conn, image.data(), image_size) < 0 ||
-      lupine_read_jit_options(conn, &jit) < 0) {
-    return -1;
-  }
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0) {
-    return -1;
-  }
-
-  // The client always unwraps fat binary containers, and cuModuleLoadDataEx
-  // takes a cubin, fatbin, or PTX image, so the kind tag the request carries
-  // for the options-free entry point makes no difference here.
-  CUresult result = cuModuleLoadDataEx(&module, image.data(), jit.num_options,
-                                       jit.options, jit.option_values);
-  if (result == CUDA_SUCCESS) {
-    lupine_note_device_stdout_image(image.data(), image.size());
-  }
-
-  int status = 0;
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      lupine_write_jit_outputs(conn, &jit) < 0 ||
-      rpc_write(conn, &module, sizeof(module)) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    status = -1;
-  }
-  std::free(jit.options);
-  std::free(jit.option_values);
-  std::free(jit.info_log);
-  std::free(jit.error_log);
-  return status;
-}
-
 int handle_lupineFunctionParamLayoutSnapshot(conn_t *conn) {
   CUfunction function = nullptr;
   if (rpc_read(conn, &function, sizeof(function)) < 0) {
@@ -1109,7 +1012,7 @@ int handle_cuLibraryLoadData(conn_t *conn) {
   int request_id;
   CUlibrary library = nullptr;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
-  lupine_jit_state jit_state;
+  lupine_jit_options jit;
 
   if (rpc_read(conn, &kind, sizeof(kind)) < 0 ||
       rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
@@ -1120,7 +1023,7 @@ int handle_cuLibraryLoadData(conn_t *conn) {
   if (image_size == 0 || rpc_read(conn, image.data(), image_size) < 0) {
     return -1;
   }
-  if (lupine_read_jit_options(conn, &jit_state) < 0) {
+  if (lupine_read_jit_options(conn, &jit.state) < 0) {
     return -1;
   }
   unsigned int num_library_options = 0;
@@ -1166,14 +1069,14 @@ int handle_cuLibraryLoadData(conn_t *conn) {
         nullptr,
     };
     result = cuLibraryLoadData(
-        &library, &wrapper, jit_state.options, jit_state.option_values,
-        jit_state.num_options, library_options.data(),
+        &library, &wrapper, jit.state.options, jit.state.option_values,
+        jit.state.num_options, library_options.data(),
         has_library_option_values ? library_option_values.data() : nullptr,
         num_library_options);
   } else if (kind == LUPINE_MODULE_IMAGE_FATBIN_RAW) {
     result = cuLibraryLoadData(
-        &library, image.data(), jit_state.options, jit_state.option_values,
-        jit_state.num_options, library_options.data(),
+        &library, image.data(), jit.state.options, jit.state.option_values,
+        jit.state.num_options, library_options.data(),
         has_library_option_values ? library_option_values.data() : nullptr,
         num_library_options);
   } else {
@@ -1185,18 +1088,10 @@ int handle_cuLibraryLoadData(conn_t *conn) {
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &library, sizeof(library)) < 0 ||
-      lupine_write_jit_outputs(conn, &jit_state) < 0 ||
+      lupine_write_jit_outputs(conn, &jit.state) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    std::free(jit_state.options);
-    std::free(jit_state.option_values);
-    std::free(jit_state.info_log);
-    std::free(jit_state.error_log);
     return -1;
   }
-  std::free(jit_state.options);
-  std::free(jit_state.option_values);
-  std::free(jit_state.info_log);
-  std::free(jit_state.error_log);
   return 0;
 }
 
@@ -1831,7 +1726,7 @@ int handle_cuLinkAddData_v2(conn_t *conn) {
   CUjitInputType type = CU_JIT_INPUT_PTX;
   size_t size = 0;
   size_t name_len = 0;
-  lupine_jit_state jit_state;
+  lupine_jit_options jit;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
   if (rpc_read(conn, &state, sizeof(state)) < 0 ||
       rpc_read(conn, &type, sizeof(type)) < 0 ||
@@ -1845,7 +1740,7 @@ int handle_cuLinkAddData_v2(conn_t *conn) {
   }
   std::vector<char> name(name_len == 0 ? 1 : name_len, '\0');
   if ((name_len != 0 && rpc_read(conn, name.data(), name_len) < 0) ||
-      lupine_read_jit_options(conn, &jit_state) < 0) {
+      lupine_read_jit_options(conn, &jit.state) < 0) {
     return -1;
   }
   int request_id = rpc_read_end(conn);
@@ -1856,22 +1751,14 @@ int handle_cuLinkAddData_v2(conn_t *conn) {
   if (link_state != nullptr) {
     result = cuLinkAddData_v2(
         link_state->cuda_state, type, data.data(), data.size(),
-        name_len == 0 ? nullptr : name.data(), jit_state.num_options,
-        jit_state.options, jit_state.option_values);
+        name_len == 0 ? nullptr : name.data(), jit.state.num_options,
+        jit.state.options, jit.state.option_values);
   }
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      lupine_write_jit_outputs(conn, &jit_state) < 0 ||
+      lupine_write_jit_outputs(conn, &jit.state) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    std::free(jit_state.options);
-    std::free(jit_state.option_values);
-    std::free(jit_state.info_log);
-    std::free(jit_state.error_log);
     return -1;
   }
-  std::free(jit_state.options);
-  std::free(jit_state.option_values);
-  std::free(jit_state.info_log);
-  std::free(jit_state.error_log);
   return 0;
 }
 
@@ -1881,7 +1768,7 @@ int handle_cuLinkAddFile_v2(conn_t *conn) {
   size_t path_len = 0;
   uint8_t has_file_data = 0;
   uint64_t file_size = 0;
-  lupine_jit_state jit_state;
+  lupine_jit_options jit;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
   if (rpc_read(conn, &state, sizeof(state)) < 0 ||
       rpc_read(conn, &type, sizeof(type)) < 0 ||
@@ -1903,7 +1790,7 @@ int handle_cuLinkAddFile_v2(conn_t *conn) {
       return -1;
     }
   }
-  if (lupine_read_jit_options(conn, &jit_state) < 0) {
+  if (lupine_read_jit_options(conn, &jit.state) < 0) {
     return -1;
   }
   int request_id = rpc_read_end(conn);
@@ -1916,26 +1803,18 @@ int handle_cuLinkAddFile_v2(conn_t *conn) {
   } else if (!file_data.empty()) {
     result = cuLinkAddData_v2(
         link_state->cuda_state, type, file_data.data(), file_data.size(),
-        path_len == 0 ? nullptr : path.data(), jit_state.num_options,
-        jit_state.options, jit_state.option_values);
+        path_len == 0 ? nullptr : path.data(), jit.state.num_options,
+        jit.state.options, jit.state.option_values);
   } else {
     result = cuLinkAddFile_v2(
         link_state->cuda_state, type, path_len == 0 ? nullptr : path.data(),
-        jit_state.num_options, jit_state.options, jit_state.option_values);
+        jit.state.num_options, jit.state.options, jit.state.option_values);
   }
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      lupine_write_jit_outputs(conn, &jit_state) < 0 ||
+      lupine_write_jit_outputs(conn, &jit.state) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
-    std::free(jit_state.options);
-    std::free(jit_state.option_values);
-    std::free(jit_state.info_log);
-    std::free(jit_state.error_log);
     return -1;
   }
-  std::free(jit_state.options);
-  std::free(jit_state.option_values);
-  std::free(jit_state.info_log);
-  std::free(jit_state.error_log);
   return 0;
 }
 

--- a/cuda_server.h
+++ b/cuda_server.h
@@ -10,8 +10,6 @@ int handle_cuGetErrorString(conn_t *conn);
 int handle_cuGetExportTableMetadata(conn_t *conn);
 int handle_cuPrivateGetModuleNode(conn_t *conn);
 int handle_cuModuleLoad(conn_t *conn);
-int handle_cuModuleLoadData(conn_t *conn);
-int handle_cuModuleLoadDataEx(conn_t *conn);
 int handle_lupineFunctionParamLayoutSnapshot(conn_t *conn);
 int handle_lupineFunctionAttributeSnapshot(conn_t *conn);
 int handle_cuLibraryLoadData(conn_t *conn);

--- a/lupine_jit.h
+++ b/lupine_jit.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdlib>
+
+#include <cuda.h>
+
+#include "rpc.h"
+
+// JIT option marshalling, shared by the hand-written loaders in
+// cuda_server.cpp and the generated handlers in gen_cuda_server.cpp. The
+// caller's log buffer pointers are client addresses, so they are replaced with
+// server-side storage before the driver sees them; every option value word the
+// driver rewrites in place is echoed back untouched.
+struct lupine_jit_state {
+  unsigned int num_options = 0;
+  CUjit_option *options = nullptr;
+  void **option_values = nullptr;
+  size_t info_log_size = 0;
+  char *info_log = nullptr;
+  size_t error_log_size = 0;
+  char *error_log = nullptr;
+};
+
+int lupine_read_jit_options(conn_t *conn, lupine_jit_state *jit);
+int lupine_write_jit_outputs(conn_t *conn, lupine_jit_state *jit);
+
+// Owns what lupine_read_jit_options allocates, so a handler can leave through
+// an error label without a cleanup list.
+struct lupine_jit_options {
+  lupine_jit_state state;
+
+  ~lupine_jit_options() {
+    std::free(state.options);
+    std::free(state.option_values);
+    std::free(state.info_log);
+    std::free(state.error_log);
+  }
+};


### PR DESCRIPTION
Stacked on #676 — review that one first.

#676 hand-wrote both halves of `cuModuleLoadDataEx`, so its wire format is defined twice and kept in step by eye. This teaches the generator the two protocols that made it un-generatable and applies them to every entry point that speaks them.

## The directives

    @moduleimage <image_param> <module_param>

The image argument carries no length: a fat binary container hides its payload behind a pointer, an ELF cubin is sized by its headers, PTX is text. `lupine_pack_module_image()` resolves all three into a tagged byte range on the client — which is why `LENGTH:`/`SIZE:`/`NULL_TERMINATED` can't describe it (`SIZE:` is a compile-time constant; `NULL_TERMINATED` truncates a fatbin at its first zero byte). Emits the pack before the routing branch, ships kind/size/bytes, records the image for module replay, notes the device-stdout image server-side.

    @jitoptions <count_param> <options_param> <values_param>

`optionValues` is a tagged union, not an array: an entry tagged `CU_JIT_INFO_LOG_BUFFER` is a pointer into caller memory, the rest are words the driver rewrites in place, and the log sizes live in other entries of the same array. A generated `SEND_RECV LENGTH:` array would hand the driver client addresses to write the JIT log into, inside the server process.

## What they cover

| entry point | before | after |
| --- | --- | --- |
| `cuModuleLoadData` | hand-written both halves (89 lines) | generated |
| `cuModuleLoadDataEx` | hand-written both halves (100 lines, added in #676) | generated |
| `cuModuleLoadFatBinary` | `CUDA_ERROR_NOT_SUPPORTED` stub | generated — **now works** |

`lupine_jit_options` (new `lupine_jit.h`) owns what `lupine_read_jit_options` allocates, so a handler can leave through an error label with no cleanup list; the three hand-written loaders that freed those four pointers at two exits apiece now don't.

## The accounting, and why it is what it is

Hand-maintained lines: **+350 / −268**, so **~82 net added** (generated files excluded). The additions are almost entirely generator: `ops.py` +197, `codegen.py` +75, plus the new header.

I pushed this as far as it goes and it does not reach net-negative. Measured, the rest of the JIT family:

| entry point | hand-written lines | convertible? |
| --- | --- | --- |
| `cuLinkAddData_v2` | 76 | yes, with a link-state-handle directive and nullable send strings (~50 generator lines) |
| `cuLibraryLoadData` | 172 | yes, with a library-options protocol and a server-side container re-wrap (~130 generator lines) |
| `cuLinkCreate_v2` | 62 | no — the jit buffers outlive the call inside the link state |
| `cuLinkComplete` | 84 | no — driver-owned cubin lifetime and the client-side state map |
| `cuLinkAddFile_v2` | 124 | no — the client mmaps the file and stages the payload |

Converting both convertible ones lands somewhere around break-even. That is the real shape of it: the generator pays off for *families* — 500-odd functions share `ArrayOperation` — not for protocols with two or three users, where the emitter costs about what the hand-written code costs.

So this is a judgment call, not a win to merge on autopilot. What it buys: one definition of these wire formats instead of two, and a `cuModuleLoadFatBinary` that returns something other than `NOT_SUPPORTED`. What it costs: ~82 lines, CUDA-specific vocabulary in a type-driven generator, and six helpers that lost `static` to reach the generated translation units. #676 stands on its own if this is dropped.

One behavior note: the generated clients drop the `module == nullptr || image == nullptr` guards, matching every other generated entry point (`cuStreamCreate` has the same shape) and the house rule against validating client input.

## Testing

- All 35 `test/run_custom_tests.sh` tests pass against inferable-node-006 on the final build.
- matrixMulDynlinkJIT through Lupine still prints the empty JIT log that matches the native run.
- `cuModuleLoadFatBinary` through Lupine returns `CUDA_SUCCESS` for both a raw fatbin and a container, where it returned `CUDA_ERROR_NOT_SUPPORTED` (801) before.
- With the server's JIT cache disabled, a PTX-only fatbin loaded through the generated path reports the same 329-byte verbose info log and ~7ms wall time as native.
- `test/run_unit_tests.sh`: only `hip_smemcpy_test` fails, which needs an AMD GPU this host does not have.