### PR TITLE
Stop printing host-callback transfer diagnostics to stdout

### DIFF
--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -7988,8 +7988,6 @@ void *rpc_client_dispatch_thread(void *arg) {
     op = rpc_dispatch(conn, 1);
 
     if (op == LUPINE_SIDE_EFFECT_HOST_FUNCTION) {
-      std::cout << "Transferring memory..." << std::endl;
-
       int found = 0;
 
       if (rpc_read(conn, &found, sizeof(found)) < 0) {


### PR DESCRIPTION
Fixes #670.

`rpc_client_dispatch_thread` printed `Transferring memory...` to `std::cout` on every `LUPINE_SIDE_EFFECT_HOST_FUNCTION` dispatch, so any application using graph host callbacks (e.g. the `simpleCudaGraphs` sample, 12 callbacks) got internal transport chatter interleaved with its own stdout.

Removed the print. It carried no information the error paths below it don't already log, so nothing is moved to the trace path.