### PR TITLE
Drop the unused ITER array-operation codegen path

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -6638,7 +6638,7 @@ cudaError_t cudaGraphCreate(cudaGraph_t *pGraph, unsigned int flags);
  * @param numDependencies SEND_ONLY
  * @param pGraphNode RECV_ONLY
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param pNodeParams SEND_ONLY NULLABLE
  */
 cudaError_t
@@ -6690,7 +6690,7 @@ cudaGraphKernelNodeSetAttribute(cudaGraphNode_t hNode,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode RECV_ONLY
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param pCopyParams SEND_ONLY NULLABLE
  */
 cudaError_t cudaGraphAddMemcpyNode(cudaGraphNode_t *pGraphNode,
@@ -6702,7 +6702,7 @@ cudaError_t cudaGraphAddMemcpyNode(cudaGraphNode_t *pGraphNode,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param symbol SEND_RECV
  * @param src SEND_RECV
  * @param count SEND_ONLY
@@ -6720,7 +6720,7 @@ cudaError_t cudaGraphAddMemcpyNodeToSymbol(cudaGraphNode_t *pGraphNode,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param dst SEND_RECV
  * @param symbol SEND_RECV
  * @param count SEND_ONLY
@@ -6735,7 +6735,7 @@ cudaError_t cudaGraphAddMemcpyNodeFromSymbol(
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param dst SEND_RECV
  * @param src SEND_RECV
  * @param count SEND_ONLY
@@ -6801,7 +6801,7 @@ cudaError_t cudaGraphMemcpyNodeSetParams1D(cudaGraphNode_t node, void *dst,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode RECV_ONLY
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param pMemsetParams SEND_ONLY NULLABLE
  */
 cudaError_t
@@ -6827,7 +6827,7 @@ cudaGraphMemsetNodeSetParams(cudaGraphNode_t node,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_RECV ITER:numDependencies
+ * @param pDependencies SEND_RECV LENGTH:numDependencies
  * @param pNodeParams SEND_ONLY NULLABLE
  */
 cudaError_t cudaGraphAddHostNode(cudaGraphNode_t *pGraphNode, cudaGraph_t graph,
@@ -6851,7 +6851,7 @@ cudaGraphHostNodeSetParams(cudaGraphNode_t node,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param childGraph SEND_ONLY NULLABLE
  */
 cudaError_t cudaGraphAddChildGraphNode(cudaGraphNode_t *pGraphNode,
@@ -6869,7 +6869,7 @@ cudaError_t cudaGraphChildGraphNodeGetGraph(cudaGraphNode_t node,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  */
 cudaError_t cudaGraphAddEmptyNode(cudaGraphNode_t *pGraphNode,
                                   cudaGraph_t graph,
@@ -6879,7 +6879,7 @@ cudaError_t cudaGraphAddEmptyNode(cudaGraphNode_t *pGraphNode,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param event SEND_ONLY NULLABLE
  */
 cudaError_t cudaGraphAddEventRecordNode(cudaGraphNode_t *pGraphNode,
@@ -6903,7 +6903,7 @@ cudaError_t cudaGraphEventRecordNodeSetEvent(cudaGraphNode_t node,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param event SEND_ONLY NULLABLE
  */
 cudaError_t cudaGraphAddEventWaitNode(cudaGraphNode_t *pGraphNode,
@@ -6927,7 +6927,7 @@ cudaError_t cudaGraphEventWaitNodeSetEvent(cudaGraphNode_t node,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param nodeParams SEND_ONLY NULLABLE
  */
 cudaError_t cudaGraphAddExternalSemaphoresSignalNode(
@@ -6952,7 +6952,7 @@ cudaError_t cudaGraphExternalSemaphoresSignalNodeSetParams(
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param nodeParams SEND_ONLY NULLABLE
  */
 cudaError_t cudaGraphAddExternalSemaphoresWaitNode(
@@ -6978,7 +6978,7 @@ cudaError_t cudaGraphExternalSemaphoresWaitNodeSetParams(
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param nodeParams SEND_ONLY NULLABLE
  */
 cudaError_t cudaGraphAddMemAllocNode(cudaGraphNode_t *pGraphNode,
@@ -6998,7 +6998,7 @@ cudaGraphMemAllocNodeGetParams(cudaGraphNode_t node,
  * @param numDependencies SEND_ONLY
  * @param pGraphNode SEND_RECV
  * @param graph SEND_ONLY
- * @param pDependencies SEND_ONLY ITER:numDependencies
+ * @param pDependencies SEND_ONLY LENGTH:numDependencies
  * @param dptr SEND_ONLY
  */
 cudaError_t cudaGraphAddMemFreeNode(cudaGraphNode_t *pGraphNode,

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -619,7 +619,6 @@ def parse_annotation(
                     recv = False
 
                 size_arg = next((arg for arg in args if arg.startswith("SIZE:")), None)
-                iter_arg = next((arg for arg in args if arg.startswith("ITER:")), None)
                 null_terminated = "NULL_TERMINATED" in args
                 nullable = "NULLABLE" in args
                 deref = "DEREF" in args
@@ -680,7 +679,6 @@ def parse_annotation(
                                 parameter=param,
                                 ptr=param.type,
                                 length=length_param,
-                                iter=False,
                             )
                         )
                 elif size_arg:
@@ -692,22 +690,6 @@ def parse_annotation(
                             parameter=param,
                             ptr=param.type,
                             length=int(size_arg.split(":")[1]),
-                            iter=False
-                        )
-                    )
-                elif iter_arg:
-                    print(f"ITER FOUND!! {param}")
-                    length_param = next(
-                        p for p in params if p.name == iter_arg.split(":")[1]
-                    )
-                    operations.append(
-                        ArrayOperation(
-                            send=send,
-                            recv=recv,
-                            parameter=param,
-                            ptr=param.type,
-                            length=length_param,
-                            iter=True
                         )
                     )
                 elif null_terminated:

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -133,7 +133,6 @@ class ArrayOperation:
 
     send: bool
     recv: bool
-    iter: bool
     parameter: Parameter
     ptr: Pointer
     # if int, it's a constant length, if Parameter, it's a variable length.
@@ -191,8 +190,7 @@ class ArrayOperation:
         rpc_write_start_request().
         """
         if (
-            self.iter
-            or not self.send
+            not self.send
             or isinstance(self.length, int)
             or isinstance(self.ptr, Array)
         ):
@@ -206,26 +204,6 @@ class ArrayOperation:
             )
         )
     def client_rpc_write(self, f):
-        if self.iter:
-            loop_template = """
-                [=]() -> bool {{
-                    for (size_t i = 0; i < {length}; ++i) {{
-                        if (rpc_write(0, &{param_name}[i], sizeof({param_type})) < 0) {{
-                            printf("Failed to write Dependency[%zu]\\n", i);
-                            return false;
-                        }}
-                    }}
-                    return true;
-                }}() == false ||
-                """.strip()
-
-            f.write(loop_template.format(
-                length=self.length.name,
-                param_type=self.ptr.ptr_to.format(),
-                param_name=self.parameter.name,
-            ))
-            return
-
         if not self.send:
             return
         if isinstance(self.length, int):
@@ -321,11 +299,6 @@ class ArrayOperation:
             self.ptr.array_of.const = False
             s = f"    {self.ptr.array_of.format()}* {self.parameter.name} = nullptr;\n"
             self.ptr.array_of.const = c
-        elif self.iter:
-            c = self.ptr.ptr_to.const
-            self.ptr.ptr_to.const = False
-            s = f"    std::vector<{self.ptr.ptr_to.format()}> {self.parameter.name};\n"
-            self.ptr.ptr_to.const = c
         else:
             c = self.ptr.ptr_to.const
             self.ptr.ptr_to.const = False
@@ -336,26 +309,6 @@ class ArrayOperation:
         return s
 
     def server_rpc_read(self, f) -> Optional[str]:
-        if self.iter:
-            lambda_template = """
-            [=, &{param_name}]() -> bool {{
-                {param_name}.resize({length});  // Resize the dependencies vector
-                for (size_t i = 0; i < {length}; ++i) {{
-                    if (rpc_read(conn, &{param_name}[i], sizeof({param_type})) < 0) {{
-                        return false;
-                    }}
-                }}
-                return true;
-            }}() == false ||
-            """.strip()
-
-            f.write(lambda_template.format(
-                param_name=self.parameter.name,
-                length=self.length.name,
-                param_type=self.ptr.ptr_to.format(),
-            ))
-            return
-
         if not self.send:
             # if this parameter is recv only and it's a type pointer, it needs to be malloc'd.
             if isinstance(self.ptr, Pointer):
@@ -432,8 +385,6 @@ class ArrayOperation:
 
     @property
     def server_reference(self) -> str:
-        if self.iter:
-            return f"{self.parameter.name}.data()"
         if isinstance(self.length, int):
             return f"{self.parameter.name}"
         return (


### PR DESCRIPTION
`ArrayOperation(iter=True)` was never constructed: the only `ITER:` annotations sit on `cudaGraphAdd*Node` doc blocks, and codegen emits no cudart wrappers at all, so `codegen.py`'s `elif iter_arg` branch never ran (its `ITER FOUND!!` print fires 0 times over a full run).

The path was also strictly worse than the one it duplicated. Where `LENGTH:` writes the dependency array in a single `rpc_write`, `ITER:` emitted a per-element loop with a `printf("Failed to write Dependency[%zu]\n", i)` — an application-stdout write on an RPC error path, the same class of leak as #670.

Removed the parsing branch, the `iter` field, and its four branches in `ops.py`, and switched the 15 `ITER:numDependencies` annotations to the `LENGTH:numDependencies` their driver-API siblings (e.g. `cuGraphAddEmptyNode`) already use, so the annotations stay correct if cudart wrappers are ever generated.

Regenerating produces byte-identical `codegen/gen_*` output.