### PR TITLE
Allow manual GPU integration cache warming

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -17,6 +17,7 @@ concurrency:
 
 on:
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Add a `workflow_dispatch` trigger to the GPU integration workflow.

This restores a trusted, opt-in cache producer without running the GPU matrix on every push to `main`. Pull-request runs remain unable to upload cache entries.