### PR TITLE
Fix CUDA 11 graph exec update ABI

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -4759,6 +4759,18 @@ CUresult cuGraphExecDestroy(CUgraphExec hGraphExec);
  * @server CUDA
  */
 CUresult cuGraphDestroy(CUgraph hGraph);
+#ifdef cuGraphExecUpdate
+#undef cuGraphExecUpdate
+#endif
+/**
+ * @param hGraphExec SEND_ONLY
+ * @param hGraph SEND_ONLY
+ * @param hErrorNode_out RECV_ONLY NULLABLE
+ * @param updateResult_out RECV_ONLY NULLABLE
+ */
+CUresult cuGraphExecUpdate(CUgraphExec hGraphExec, CUgraph hGraph,
+                           CUgraphNode *hErrorNode_out,
+                           CUgraphExecUpdateResult *updateResult_out);
 /**
  * @param hGraphExec SEND_ONLY
  * @param hGraph SEND_ONLY

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -39,6 +39,7 @@ from ops import (
 # CUDA headers omit some legacy ABI entry points from their public declarations.
 # Keep the small set that still needs RPC wrappers explicit here.
 LEGACY_ABI_FUNCTIONS = {
+    "cuGraphExecUpdate",
     "cuGraphInstantiate_v2",
 }
 
@@ -67,7 +68,6 @@ MANUAL_REMAPPINGS = [
     ("cuMemsetD2D32", "cuMemsetD2D32_v2"),
     ("cuIpcOpenMemHandle", "cuIpcOpenMemHandle_v2"),
     ("cuStreamBeginCapture", "cuStreamBeginCapture_v2"),
-    ("cuGraphExecUpdate", "cuGraphExecUpdate_v2"),
     ("cuMemcpy_ptds", "cuMemcpy"),
     ("cuMemcpyAsync_ptsz", "cuMemcpyAsync"),
     ("cuMemcpyPeer_ptds", "cuMemcpyPeer"),
@@ -135,10 +135,6 @@ FUNCTION_MAP_ALIASES = [
 KERNEL_PARAM_LAYOUT_INVALIDATORS = {
     "cuLibraryUnload",
     "cuModuleUnload",
-}
-
-MANUAL_REMAPPING_GUARDS = {
-    "cuGraphExecUpdate": "CUDA_VERSION >= 12000",
 }
 
 NVML_RPC_FUNCTIONS = [
@@ -2178,9 +2174,6 @@ def main():
             if alias in function_by_name or target not in function_by_name:
                 continue
             target_function = function_by_name[target]
-            guard = MANUAL_REMAPPING_GUARDS.get(alias)
-            if guard is not None:
-                f.write("#if {guard}\n".format(guard=guard))
             f.write("#ifdef {name}\n#undef {name}\n#endif\n".format(name=alias))
             f.write(
                 'extern "C" {return_type} {name}({params})\n'.format(
@@ -2200,9 +2193,6 @@ def main():
             else:
                 f.write("    return {call};\n".format(call=call))
                 f.write("}\n\n")
-            if guard is not None:
-                f.write("#endif\n\n")
-
         f.write("std::unordered_map<std::string, void *> functionMap = {\n")
         for function, _, _, metadata in functions_with_annotations:
             if metadata.disabled_client and metadata.disabled_server:

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -100,6 +100,13 @@ extern "C" CUresult CUDAAPI cuGraphInstantiate_v2(CUgraphExec *phGraphExec,
                                                   char *logBuffer,
                                                   size_t bufferSize);
 
+#ifdef cuGraphExecUpdate
+#undef cuGraphExecUpdate
+#endif
+extern "C" CUresult CUDAAPI cuGraphExecUpdate(
+    CUgraphExec hGraphExec, CUgraph hGraph, CUgraphNode *hErrorNode_out,
+    CUgraphExecUpdateResult *updateResult_out);
+
 CUresult cuDriverGetVersion(int *driverVersion) {
   lupine_route route = lupine_route_for_default();
   CUresult return_value;
@@ -6842,6 +6849,38 @@ CUresult cuGraphInstantiate_v2(CUgraphExec *phGraphExec, CUgraph hGraph,
   return return_value;
 }
 
+CUresult cuGraphExecUpdate(CUgraphExec hGraphExec, CUgraph hGraph,
+                           CUgraphNode *hErrorNode_out,
+                           CUgraphExecUpdateResult *updateResult_out) {
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
+  CUresult return_value;
+  if (lupine_route_is_local(route))
+    return lupine_call_real_cuda_fn("cuGraphExecUpdate", hGraphExec, hGraph,
+                                    hErrorNode_out, updateResult_out);
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUgraphNode *hErrorNode_out_null_check;
+  CUgraphExecUpdateResult *updateResult_out_null_check;
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuGraphExecUpdate) < 0 ||
+      rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
+      rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
+      rpc_write(conn, &hErrorNode_out, sizeof(CUgraphNode *)) < 0 ||
+      rpc_write(conn, &updateResult_out, sizeof(CUgraphExecUpdateResult *)) <
+          0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &hErrorNode_out_null_check, sizeof(CUgraphNode *)) < 0 ||
+      (hErrorNode_out_null_check &&
+       rpc_read(conn, hErrorNode_out, sizeof(CUgraphNode)) < 0) ||
+      rpc_read(conn, &updateResult_out_null_check,
+               sizeof(CUgraphExecUpdateResult *)) < 0 ||
+      (updateResult_out_null_check &&
+       rpc_read(conn, updateResult_out, sizeof(CUgraphExecUpdateResult)) < 0) ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
 #ifdef cuCtxDestroy
 #undef cuCtxDestroy
 #endif
@@ -6932,17 +6971,6 @@ extern "C" CUresult cuIpcOpenMemHandle(CUdeviceptr *pdptr,
                                        unsigned int Flags) {
   return cuIpcOpenMemHandle_v2(pdptr, handle, Flags);
 }
-
-#if CUDA_VERSION >= 12000
-#ifdef cuGraphExecUpdate
-#undef cuGraphExecUpdate
-#endif
-extern "C" CUresult cuGraphExecUpdate(CUgraphExec hGraphExec, CUgraph hGraph,
-                                      CUgraphExecUpdateResultInfo *resultInfo) {
-  return cuGraphExecUpdate_v2(hGraphExec, hGraph, resultInfo);
-}
-
-#endif
 
 #ifdef cuMemcpyPeer_ptds
 #undef cuMemcpyPeer_ptds
@@ -7630,6 +7658,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuStreamGetDevResource", (void *)cuStreamGetDevResource},
 #endif
     {"cuGraphInstantiate_v2", (void *)cuGraphInstantiate_v2},
+    {"cuGraphExecUpdate", (void *)cuGraphExecUpdate},
     {"cuCtxDestroy", (void *)cuCtxDestroy_v2},
     {"cuModuleGetGlobal", (void *)cuModuleGetGlobal_v2},
     {"cuMemAlloc", (void *)cuMemAlloc_v2},
@@ -7641,7 +7670,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemsetD2D16", (void *)cuMemsetD2D16_v2},
     {"cuMemsetD2D32", (void *)cuMemsetD2D32_v2},
     {"cuIpcOpenMemHandle", (void *)cuIpcOpenMemHandle_v2},
-    {"cuGraphExecUpdate", (void *)cuGraphExecUpdate_v2},
     {"cuMemcpyPeer_ptds", (void *)cuMemcpyPeer},
     {"cuMemcpyPeerAsync_ptsz", (void *)cuMemcpyPeerAsync},
     {"cuMemsetD8Async_ptsz", (void *)cuMemsetD8Async},

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -22,6 +22,13 @@ extern "C" CUresult CUDAAPI cuGraphInstantiate_v2(CUgraphExec *phGraphExec,
                                                   char *logBuffer,
                                                   size_t bufferSize);
 
+#ifdef cuGraphExecUpdate
+#undef cuGraphExecUpdate
+#endif
+extern "C" CUresult CUDAAPI cuGraphExecUpdate(
+    CUgraphExec hGraphExec, CUgraph hGraph, CUgraphNode *hErrorNode_out,
+    CUgraphExecUpdateResult *updateResult_out);
+
 #ifdef cuMemPrefetchAsync
 #undef cuMemPrefetchAsync
 #endif
@@ -8995,6 +9002,48 @@ int handle_cuMemAdvise(conn_t *conn) {
   lupine_intercept_result = cuMemAdvise(devPtr, count, advice, device);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+int handle_cuGraphExecUpdate(conn_t *conn) {
+  CUgraphExec hGraphExec;
+  CUgraph hGraph;
+  CUgraphNode *hErrorNode_out_null_check;
+  CUgraphNode hErrorNode_out;
+  CUgraphExecUpdateResult *updateResult_out_null_check;
+  CUgraphExecUpdateResult updateResult_out;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
+      rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
+      rpc_read(conn, &hErrorNode_out_null_check, sizeof(CUgraphNode *)) < 0 ||
+      rpc_read(conn, &updateResult_out_null_check,
+               sizeof(CUgraphExecUpdateResult *)) < 0 ||
+      false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuGraphExecUpdate(
+      hGraphExec, hGraph, hErrorNode_out_null_check ? &hErrorNode_out : nullptr,
+      updateResult_out_null_check ? &updateResult_out : nullptr);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &hErrorNode_out_null_check, sizeof(CUgraphNode *)) < 0 ||
+      (hErrorNode_out_null_check &&
+       rpc_write(conn, &hErrorNode_out, sizeof(CUgraphNode)) < 0) ||
+      rpc_write(conn, &updateResult_out_null_check,
+                sizeof(CUgraphExecUpdateResult *)) < 0 ||
+      (updateResult_out_null_check &&
+       rpc_write(conn, &updateResult_out, sizeof(CUgraphExecUpdateResult)) <
+           0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;

--- a/codegen/gen_rpc_ids.h
+++ b/codegen/gen_rpc_ids.h
@@ -393,6 +393,7 @@
 #define RPC_cuGreenCtxGetId 1724676806
 #define RPC_cuStreamGetDevResource 494275841
 #define RPC_cuGraphInstantiate_v2 1599532620
+#define RPC_cuGraphExecUpdate 882549126
 #define RPC_cuCtxCreate_v2 804269166
 #define RPC_cuCtxCreate_v3 1492589816
 #define RPC_cuDeviceGetGraphMemAttribute 622504442

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -381,7 +381,8 @@
   HANDLER(RPC_cuGraphicsMapResources, handle_cuGraphicsMapResources, rpc_backend::cuda) \
   HANDLER(RPC_cuGraphicsUnmapResources, handle_cuGraphicsUnmapResources, rpc_backend::cuda) \
   HANDLER(RPC_cuMemPrefetchAsync, handle_cuMemPrefetchAsync, rpc_backend::cuda) \
-  HANDLER(RPC_cuMemAdvise, handle_cuMemAdvise, rpc_backend::cuda)
+  HANDLER(RPC_cuMemAdvise, handle_cuMemAdvise, rpc_backend::cuda) \
+  HANDLER(RPC_cuGraphExecUpdate, handle_cuGraphExecUpdate, rpc_backend::cuda)
 #define LUPINE_NVML_RPC_HANDLERS(HANDLER) \
   HANDLER(RPC_nvmlDeviceGetComputeRunningProcesses, handle_nvmlDeviceGetComputeRunningProcesses, rpc_backend::nvml) \
   HANDLER(RPC_nvmlDeviceGetComputeRunningProcesses_v2, handle_nvmlDeviceGetComputeRunningProcesses_v2, rpc_backend::nvml) \

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -8357,6 +8357,15 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
     return CUDA_SUCCESS;
   }
 
+  if (symbol != nullptr && strcmp(symbol, "cuGraphExecUpdate") == 0) {
+    *pfn = get_function_pointer(cudaVersion < 12000 ? "cuGraphExecUpdate"
+                                                    : "cuGraphExecUpdate_v2");
+    if (symbolStatus != nullptr) {
+      *symbolStatus = CU_GET_PROC_ADDRESS_SUCCESS;
+    }
+    return CUDA_SUCCESS;
+  }
+
   if (strcmp(symbol, "cuFuncGetAttribute") == 0) {
     *pfn = reinterpret_cast<void *>(&lupine_cuFuncGetAttribute_safe);
     if (symbolStatus != nullptr) {

--- a/test/test_graph_exec_update.cu
+++ b/test/test_graph_exec_update.cu
@@ -1,0 +1,56 @@
+// Exercise the cudaGraphExecUpdate ABI selected by the active CUDA runtime.
+// CUDA 11 uses separate error-node and update-result outputs, while CUDA 12+
+// uses cudaGraphExecUpdateResultInfo.
+#include <cstdio>
+#include <cuda_runtime_api.h>
+
+static int check(cudaError_t result, const char *operation) {
+  if (result == cudaSuccess)
+    return 0;
+  fprintf(stderr, "FAIL: %s: %s\n", operation, cudaGetErrorString(result));
+  return 1;
+}
+
+int main() {
+  cudaGraph_t original = nullptr;
+  cudaGraph_t update = nullptr;
+  cudaGraphExec_t exec = nullptr;
+  cudaGraphNode_t original_node = nullptr;
+  cudaGraphNode_t update_node = nullptr;
+  int failed = 0;
+
+  failed |= check(cudaGraphCreate(&original, 0), "cudaGraphCreate(original)");
+  failed |= check(cudaGraphAddEmptyNode(&original_node, original, nullptr, 0),
+                  "cudaGraphAddEmptyNode(original)");
+  failed |= check(cudaGraphInstantiate(&exec, original, nullptr, nullptr, 0),
+                  "cudaGraphInstantiate");
+  failed |= check(cudaGraphCreate(&update, 0), "cudaGraphCreate(update)");
+  failed |= check(cudaGraphAddEmptyNode(&update_node, update, nullptr, 0),
+                  "cudaGraphAddEmptyNode(update)");
+  if (failed)
+    return 1;
+
+  cudaGraphExecUpdateResult update_result = cudaGraphExecUpdateError;
+#if CUDART_VERSION >= 12000
+  cudaGraphExecUpdateResultInfo result_info = {};
+  cudaError_t result = cudaGraphExecUpdate(exec, update, &result_info);
+  update_result = result_info.result;
+#else
+  cudaGraphNode_t error_node = nullptr;
+  cudaError_t result =
+      cudaGraphExecUpdate(exec, update, &error_node, &update_result);
+#endif
+  if (result != cudaSuccess || update_result != cudaGraphExecUpdateSuccess) {
+    fprintf(stderr, "FAIL: cudaGraphExecUpdate: %s, update result %d\n",
+            cudaGetErrorString(result), static_cast<int>(update_result));
+    failed = 1;
+  }
+
+  failed |= check(cudaGraphExecDestroy(exec), "cudaGraphExecDestroy");
+  failed |= check(cudaGraphDestroy(update), "cudaGraphDestroy(update)");
+  failed |= check(cudaGraphDestroy(original), "cudaGraphDestroy(original)");
+
+  if (!failed)
+    fprintf(stderr, "PASS: cudaGraphExecUpdate\n");
+  return failed ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- add direct runtime coverage for both `cudaGraphExecUpdate` ABIs
- generate a dedicated RPC wrapper for the CUDA 11 error-node/update-result form
- select the v1 or v2 wrapper from `cuGetProcAddress` using the requested API version

## Reproduction

On current `main`, the new probe failed on the CUDA 11.8/L4 integration lane with:

```
FAIL: cudaGraphExecUpdate: operation not supported, update result 1
```

CUDA 12.4 continued through the v2 path.

## Testing

- `./codegen/run.sh`
- CUDA 13.3 full CMake build
- `ctest --test-dir build --output-on-failure`
- CUDA 11.8 clean client build; verified `cuGraphExecUpdate` export
- CUDA 11.8 clean server build
- post-fix GPU integration on L4: CUDA 11.8, 12.4, and 13.3 passed
- CUDA 11.8 artifact confirms `custom.test_graph_exec_update` passed with `PASS: cudaGraphExecUpdate`

Closes #601