### PR TITLE
Move generated CUDA client hooks into annotations

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -66,6 +66,25 @@ routes through the client-side cross-server copy helper.
 private graph clone associated with an executable before the generated server
 handler calls CUDA.
 
+Functions that need custom client-side code around the generated call may be
+written as definitions instead of declarations. The body must contain one
+explicitly typed generated-call placeholder and end by returning its result:
+
+```cpp
+CUresult cuExample(CUdeviceptr ptr) {
+  prepare(ptr);
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS)
+    update_bookkeeping(ptr);
+  return return_value;
+}
+```
+
+The generator emits code before the placeholder once before route dispatch and
+code after it on both the local and remote paths. It validates the result type,
+placeholder count, and final return. Functions without custom client code stay
+as ordinary declarations.
+
 `CUdeviceptr` values go on the wire unchanged: identity VA arenas place every
 client-visible alias at its server address, so no per-parameter translation is
 generated (connections that cannot reserve the identity arena fail at connect).

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2216,7 +2216,19 @@ CUresult cuCtxCreate_v3(CUcontext *pctx, CUexecAffinityParam *paramsArray,
  * @param ctx SEND_ONLY
  * @server CUDA
  */
-CUresult cuCtxDestroy_v2(CUcontext ctx);
+CUresult cuCtxDestroy_v2(CUcontext ctx) {
+  CUcontext lupine_current_before_destroy = nullptr;
+  if (cuCtxGetCurrent(&lupine_current_before_destroy) == CUDA_SUCCESS &&
+      lupine_current_before_destroy == ctx) {
+    cuCtxSetCurrent(nullptr);
+  }
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS)
+    lupine_forget_destroyed_context(ctx);
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_current_context_cache();
+  return return_value;
+}
 /**
  * @disabled client - manual client maintains the virtual context stack
  * @param ctx SEND_ONLY
@@ -2345,7 +2357,12 @@ CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags);
  * @param ctx SEND_ONLY
  * @server CUDA
  */
-CUresult cuCtxDetach(CUcontext ctx);
+CUresult cuCtxDetach(CUcontext ctx) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_current_context_cache();
+  return return_value;
+}
 /**
  * @disabled - manual client sends mapped file bytes to server
  * @param module RECV_ONLY
@@ -2383,7 +2400,12 @@ CUresult cuModuleLoadFatBinary(CUmodule *module, const void *fatCubin);
  * @release MODULE hmod
  * @param hmod SEND_ONLY
  */
-CUresult cuModuleUnload(CUmodule hmod);
+CUresult cuModuleUnload(CUmodule hmod) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_function_caches();
+  return return_value;
+}
 /**
  * @param mode SEND_RECV
  */
@@ -2408,7 +2430,12 @@ CUresult cuModuleGetFunction(CUfunction *hfunc, CUmodule hmod,
  * @server CUDA
  */
 CUresult cuModuleGetGlobal_v2(CUdeviceptr *dptr, size_t *bytes, CUmodule hmod,
-                              const char *name);
+                              const char *name) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS && dptr != nullptr && bytes != nullptr)
+    lupine_note_deviceptr_allocation_route(*dptr, *bytes, route);
+  return return_value;
+}
 /**
  * @disabled client - manual client handles JIT option values
  * @param numOptions SEND_ONLY
@@ -2519,7 +2546,12 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
  * @param library SEND_ONLY
  * @server CUDA
  */
-CUresult cuLibraryUnload(CUlibrary library);
+CUresult cuLibraryUnload(CUlibrary library) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_function_caches();
+  return return_value;
+}
 /**
  * @disabled client - manual client serves the library kernel table
  * @routingkey LIBRARY library
@@ -2579,7 +2611,12 @@ CUresult cuFuncGetParamInfo(CUfunction func, size_t paramIndex,
  * @param name SEND_ONLY NULL_TERMINATED
  */
 CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
-                            const char *name);
+                            const char *name) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS && dptr != nullptr && bytes != nullptr)
+    lupine_note_deviceptr_allocation_route(*dptr, *bytes, route);
+  return return_value;
+}
 /**
  * @routingkey LIBRARY library
  * @recordowner DEVICEPTR dptr
@@ -2589,7 +2626,12 @@ CUresult cuLibraryGetGlobal(CUdeviceptr *dptr, size_t *bytes, CUlibrary library,
  * @param name SEND_ONLY NULL_TERMINATED
  */
 CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
-                             CUlibrary library, const char *name);
+                             CUlibrary library, const char *name) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS && dptr != nullptr && bytes != nullptr)
+    lupine_note_deviceptr_allocation_route(*dptr, *bytes, route);
+  return return_value;
+}
 /**
  * @routingkey LIBRARY library
  * @param fptr RECV_ONLY
@@ -2615,7 +2657,13 @@ CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
  * @param dev SEND_ONLY
  */
 CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
-                              CUkernel kernel, CUdevice dev);
+                              CUkernel kernel, CUdevice dev) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS)
+    lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel,
+                                        (int)attrib, (int)dev);
+  return return_value;
+}
 /**
  * @param kernel SEND_ONLY
  * @param config SEND_ONLY
@@ -2643,7 +2691,12 @@ CUresult cuMemGetInfo_v2(size_t *free, size_t *total);
  * @param dptr SEND_RECV
  * @param bytesize SEND_ONLY
  */
-CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize);
+CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS && dptr != nullptr)
+    lupine_note_deviceptr_allocation_route(*dptr, bytesize, route);
+  return return_value;
+}
 /**
  * @routingkey CURRENT_CONTEXT
  * @recordowner DEVICEPTR dptr
@@ -2655,7 +2708,18 @@ CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize);
  */
 CUresult cuMemAllocPitch_v2(CUdeviceptr *dptr, size_t *pPitch,
                             size_t WidthInBytes, size_t Height,
-                            unsigned int ElementSizeBytes);
+                            unsigned int ElementSizeBytes) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS && dptr != nullptr) {
+    size_t allocation_size = 0;
+    if (pPitch != nullptr)
+      allocation_size = (*pPitch) * Height;
+    else
+      allocation_size = WidthInBytes * Height;
+    lupine_note_deviceptr_allocation_route(*dptr, allocation_size, route);
+  }
+  return return_value;
+}
 /**
  * @disabled client - manual client handles managed host alias
  * @disabled server - manual server releases identity-mapped allocations
@@ -3308,7 +3372,12 @@ CUresult cuMemRetainAllocationHandle(CUmemGenericAllocationHandle *handle,
  * @param dptr SEND_ONLY
  * @param hStream SEND_ONLY
  */
-CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream);
+CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS)
+    lupine_forget_deviceptr_owner(dptr);
+  return return_value;
+}
 /**
  * @routingkey STREAM hStream
  * @recordowner DEVICEPTR dptr
@@ -3316,7 +3385,12 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream);
  * @param bytesize SEND_ONLY
  * @param hStream SEND_ONLY
  */
-CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream);
+CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS && dptr != nullptr)
+    lupine_note_deviceptr_allocation_route(*dptr, bytesize, route);
+  return return_value;
+}
 /**
  * @param pool SEND_ONLY
  * @param minBytesToKeep SEND_ONLY
@@ -3371,7 +3445,12 @@ CUresult cuMemPoolDestroy(CUmemoryPool pool);
  * @param hStream SEND_ONLY
  */
 CUresult cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t bytesize,
-                                 CUmemoryPool pool, CUstream hStream);
+                                 CUmemoryPool pool, CUstream hStream) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS && dptr != nullptr)
+    lupine_note_deviceptr_allocation_route(*dptr, bytesize, route);
+  return return_value;
+}
 /**
  * @disabled both - POSIX fds cross the wire via the IPC fd broker
  * @server CUDA
@@ -3636,13 +3715,23 @@ CUresult cuGreenCtxCreate(CUgreenCtx *phCtx, CUdevResourceDesc desc,
  * @param pContext RECV_ONLY
  * @param hCtx SEND_ONLY
  */
-CUresult cuCtxFromGreenCtx(CUcontext *pContext, CUgreenCtx hCtx);
+CUresult cuCtxFromGreenCtx(CUcontext *pContext, CUgreenCtx hCtx) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS && pContext != nullptr)
+    lupine_mark_context_green(*pContext);
+  return return_value;
+}
 /**
  * @guard CUDA_VERSION >= 12040
  * @routingkey CURRENT_CONTEXT
  * @param hCtx SEND_ONLY
  */
-CUresult cuGreenCtxDestroy(CUgreenCtx hCtx);
+CUresult cuGreenCtxDestroy(CUgreenCtx hCtx) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS)
+    lupine_forget_destroyed_context(reinterpret_cast<CUcontext>(hCtx));
+  return return_value;
+}
 /**
  * @guard CUDA_VERSION >= 12050
  * @routingkey CURRENT_CONTEXT
@@ -3777,7 +3866,12 @@ CUresult cuStreamSynchronize(CUstream hStream);
  * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  */
-CUresult cuStreamDestroy_v2(CUstream hStream);
+CUresult cuStreamDestroy_v2(CUstream hStream) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS)
+    lupine_forget_stream_owner(hStream);
+  return return_value;
+}
 /**
  * @routingkey STREAM dst
  * @param dst SEND_ONLY
@@ -3972,7 +4066,14 @@ CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
  * @param value SEND_ONLY
  */
 CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
-                            int value);
+                            int value) {
+  CUresult return_value = LUPINE_GENERATED_CALL();
+  if (return_value == CUDA_SUCCESS) {
+    lupine_invalidate_kernel_attribute_cache();
+    lupine_invalidate_function_attribute_cache();
+  }
+  return return_value;
+}
 /**
  * @routingkey FUNCTION hfunc
  * @param hfunc SEND_ONLY

--- a/codegen/client_templates.py
+++ b/codegen/client_templates.py
@@ -1,71 +1,10 @@
 import textwrap
 from pathlib import Path
 
-from cxxheaderparser.lexer import LexerTokenStream
-
 from ops import ClientCallTemplate
 
 
 GENERATED_CALL_MARKER = "LUPINE_GENERATED_CALL"
-
-
-def _mask_preprocessor_directives(source: str) -> str:
-    masked_lines = []
-    continued = False
-    for line in source.splitlines(keepends=True):
-        is_directive = continued or line.lstrip().startswith("#")
-        continued = is_directive and line.rstrip("\r\n").endswith("\\")
-        if is_directive:
-            masked_lines.append(
-                "".join(
-                    character if character in "\r\n" else " " for character in line
-                )
-            )
-        else:
-            masked_lines.append(line)
-    return "".join(masked_lines)
-
-
-def _lex(source: str) -> list:
-    stream = LexerTokenStream(None, _mask_preprocessor_directives(source))
-    tokens = []
-    try:
-        while True:
-            tokens.append(stream.token())
-    except EOFError:
-        return tokens
-
-
-def _token_values(source: str) -> list[str]:
-    return [token.value for token in _lex(source)]
-
-
-def _matching_open(tokens, close_index: int, opening: str, closing: str) -> int:
-    depth = 1
-    for index in range(close_index - 1, -1, -1):
-        value = tokens[index].value
-        if value == closing:
-            depth += 1
-        elif value == opening:
-            depth -= 1
-            if depth == 0:
-                return index
-    raise RuntimeError(f"unmatched {closing} in client call template")
-
-
-def _function_name(tokens, body_open: int) -> str:
-    parameters_close = body_open - 1
-    if parameters_close < 0 or tokens[parameters_close].value != ")":
-        raise RuntimeError("client call template must be a plain function definition")
-    parameters_open = _matching_open(tokens, parameters_close, "(", ")")
-    name_index = parameters_open - 1
-    if name_index < 0 or tokens[name_index].type != "NAME":
-        raise RuntimeError("could not identify client call template function")
-    return tokens[name_index].value
-
-
-def _line_start(source: str, position: int) -> int:
-    return source.rfind("\n", 0, position) + 1
 
 
 def _template_section(source: str) -> str:
@@ -75,113 +14,45 @@ def _template_section(source: str) -> str:
     return textwrap.dedent(stripped) + "\n"
 
 
+def _definition_body(source: str, name: str, return_type: str) -> str:
+    signature = f"{return_type} {name}("
+    if source.count(signature) != 1:
+        raise RuntimeError(f"{name}: could not locate definition in annotations.h")
+
+    signature_start = source.index(signature)
+    body_start = source.index("{", signature_start) + 1
+    body_end = source.index("\n}", body_start)
+    return source[body_start:body_end]
+
+
 def collect_client_call_templates(
     path: str, definition_return_types: dict[str, str]
 ) -> dict[str, ClientCallTemplate]:
     source = Path(path).read_text(encoding="utf-8")
-    tokens = _lex(source)
-
-    brace_stack = []
-    brace_pairs = {}
-    marker_bodies = {}
-    for index, token in enumerate(tokens):
-        if token.value == "{":
-            brace_stack.append(index)
-        elif token.value == "}":
-            if not brace_stack:
-                raise RuntimeError("unmatched } while reading client call templates")
-            brace_pairs[brace_stack.pop()] = index
-        elif token.value == GENERATED_CALL_MARKER:
-            if not brace_stack:
-                raise RuntimeError(f"{GENERATED_CALL_MARKER} must appear in a function")
-            body_open = brace_stack[-1]
-            if body_open in marker_bodies:
-                raise RuntimeError("client call template must contain exactly one marker")
-            marker_bodies[body_open] = index
-    if brace_stack:
-        raise RuntimeError("unmatched { while reading client call templates")
-
     templates = {}
-    for body_open, marker_index in marker_bodies.items():
-        body_close = brace_pairs[body_open]
-        name = _function_name(tokens, body_open)
-        if name in templates:
-            raise RuntimeError(f"duplicate client call template for {name}")
-        expected_return_type = definition_return_types.get(name)
-        if expected_return_type is None:
-            raise RuntimeError(f"{name}: client call template has no parsed definition")
-
-        expected_marker = [
-            "return_value",
-            "=",
-            GENERATED_CALL_MARKER,
-            "(",
-            ")",
-            ";",
-        ]
-        marker_start = marker_index - 2
-        marker_end = marker_index + 4
-        if (
-            marker_start <= body_open
-            or marker_end > body_close
-            or [token.value for token in tokens[marker_start:marker_end]]
-            != expected_marker
-        ):
+    for name, return_type in definition_return_types.items():
+        body = _definition_body(source, name, return_type)
+        marker = f"  {return_type} return_value = {GENERATED_CALL_MARKER}();"
+        if body.count(marker) != 1:
             raise RuntimeError(
-                f"{name}: expected `return_value = {GENERATED_CALL_MARKER}();`"
+                f"{name}: expected exactly one `{marker.strip()}`"
+            )
+        before_call, after_call = body.split(marker)
+
+        final_return = "  return return_value;"
+        if after_call.count(final_return) != 1:
+            raise RuntimeError(
+                f"{name}: client call template must end with `{final_return.strip()}`"
+            )
+        after_call, trailing = after_call.split(final_return)
+        if trailing.strip():
+            raise RuntimeError(
+                f"{name}: `{final_return.strip()}` must be the final statement"
             )
 
-        declaration_start = marker_start
-        while (
-            declaration_start > body_open + 1
-            and tokens[declaration_start - 1].value not in {";", "{", "}"}
-        ):
-            declaration_start -= 1
-        declared_return_type = [
-            token.value for token in tokens[declaration_start:marker_start]
-        ]
-        if declared_return_type != _token_values(expected_return_type):
-            raise RuntimeError(
-                f"{name}: generated call result must be declared as "
-                f"`{expected_return_type} return_value`"
-            )
-
-        final_return_start = body_close - 3
-        if [
-            token.value for token in tokens[final_return_start:body_close]
-        ] != ["return", "return_value", ";"]:
-            raise RuntimeError(
-                f"{name}: client call template must end with `return return_value;`"
-            )
-
-        body_start_position = tokens[body_open].lexpos + 1
-        declaration_position = _line_start(source, tokens[declaration_start].lexpos)
-        if source[declaration_position : tokens[declaration_start].lexpos].strip():
-            raise RuntimeError(
-                f"{name}: generated call declaration must start on its own line"
-            )
-        marker_end_position = tokens[marker_end - 1].lexpos + len(
-            tokens[marker_end - 1].value
-        )
-        final_return_position = _line_start(source, tokens[final_return_start].lexpos)
-        if source[final_return_position : tokens[final_return_start].lexpos].strip():
-            raise RuntimeError(
-                f"{name}: final return must start on its own line"
-            )
         templates[name] = ClientCallTemplate(
-            return_type=expected_return_type,
-            before_call=_template_section(
-                source[body_start_position:declaration_position]
-            ),
-            after_call=_template_section(
-                source[marker_end_position:final_return_position]
-            ),
-        )
-
-    missing_markers = set(definition_return_types) - set(templates)
-    if missing_markers:
-        raise RuntimeError(
-            "function definitions in annotations.h require "
-            f"{GENERATED_CALL_MARKER}: " + ", ".join(sorted(missing_markers))
+            return_type=return_type,
+            before_call=_template_section(before_call),
+            after_call=_template_section(after_call),
         )
     return templates

--- a/codegen/client_templates.py
+++ b/codegen/client_templates.py
@@ -1,0 +1,187 @@
+import textwrap
+from pathlib import Path
+
+from cxxheaderparser.lexer import LexerTokenStream
+
+from ops import ClientCallTemplate
+
+
+GENERATED_CALL_MARKER = "LUPINE_GENERATED_CALL"
+
+
+def _mask_preprocessor_directives(source: str) -> str:
+    masked_lines = []
+    continued = False
+    for line in source.splitlines(keepends=True):
+        is_directive = continued or line.lstrip().startswith("#")
+        continued = is_directive and line.rstrip("\r\n").endswith("\\")
+        if is_directive:
+            masked_lines.append(
+                "".join(
+                    character if character in "\r\n" else " " for character in line
+                )
+            )
+        else:
+            masked_lines.append(line)
+    return "".join(masked_lines)
+
+
+def _lex(source: str) -> list:
+    stream = LexerTokenStream(None, _mask_preprocessor_directives(source))
+    tokens = []
+    try:
+        while True:
+            tokens.append(stream.token())
+    except EOFError:
+        return tokens
+
+
+def _token_values(source: str) -> list[str]:
+    return [token.value for token in _lex(source)]
+
+
+def _matching_open(tokens, close_index: int, opening: str, closing: str) -> int:
+    depth = 1
+    for index in range(close_index - 1, -1, -1):
+        value = tokens[index].value
+        if value == closing:
+            depth += 1
+        elif value == opening:
+            depth -= 1
+            if depth == 0:
+                return index
+    raise RuntimeError(f"unmatched {closing} in client call template")
+
+
+def _function_name(tokens, body_open: int) -> str:
+    parameters_close = body_open - 1
+    if parameters_close < 0 or tokens[parameters_close].value != ")":
+        raise RuntimeError("client call template must be a plain function definition")
+    parameters_open = _matching_open(tokens, parameters_close, "(", ")")
+    name_index = parameters_open - 1
+    if name_index < 0 or tokens[name_index].type != "NAME":
+        raise RuntimeError("could not identify client call template function")
+    return tokens[name_index].value
+
+
+def _line_start(source: str, position: int) -> int:
+    return source.rfind("\n", 0, position) + 1
+
+
+def _template_section(source: str) -> str:
+    stripped = source.strip("\r\n")
+    if not stripped.strip():
+        return ""
+    return textwrap.dedent(stripped) + "\n"
+
+
+def collect_client_call_templates(
+    path: str, definition_return_types: dict[str, str]
+) -> dict[str, ClientCallTemplate]:
+    source = Path(path).read_text(encoding="utf-8")
+    tokens = _lex(source)
+
+    brace_stack = []
+    brace_pairs = {}
+    marker_bodies = {}
+    for index, token in enumerate(tokens):
+        if token.value == "{":
+            brace_stack.append(index)
+        elif token.value == "}":
+            if not brace_stack:
+                raise RuntimeError("unmatched } while reading client call templates")
+            brace_pairs[brace_stack.pop()] = index
+        elif token.value == GENERATED_CALL_MARKER:
+            if not brace_stack:
+                raise RuntimeError(f"{GENERATED_CALL_MARKER} must appear in a function")
+            body_open = brace_stack[-1]
+            if body_open in marker_bodies:
+                raise RuntimeError("client call template must contain exactly one marker")
+            marker_bodies[body_open] = index
+    if brace_stack:
+        raise RuntimeError("unmatched { while reading client call templates")
+
+    templates = {}
+    for body_open, marker_index in marker_bodies.items():
+        body_close = brace_pairs[body_open]
+        name = _function_name(tokens, body_open)
+        if name in templates:
+            raise RuntimeError(f"duplicate client call template for {name}")
+        expected_return_type = definition_return_types.get(name)
+        if expected_return_type is None:
+            raise RuntimeError(f"{name}: client call template has no parsed definition")
+
+        expected_marker = [
+            "return_value",
+            "=",
+            GENERATED_CALL_MARKER,
+            "(",
+            ")",
+            ";",
+        ]
+        marker_start = marker_index - 2
+        marker_end = marker_index + 4
+        if (
+            marker_start <= body_open
+            or marker_end > body_close
+            or [token.value for token in tokens[marker_start:marker_end]]
+            != expected_marker
+        ):
+            raise RuntimeError(
+                f"{name}: expected `return_value = {GENERATED_CALL_MARKER}();`"
+            )
+
+        declaration_start = marker_start
+        while (
+            declaration_start > body_open + 1
+            and tokens[declaration_start - 1].value not in {";", "{", "}"}
+        ):
+            declaration_start -= 1
+        declared_return_type = [
+            token.value for token in tokens[declaration_start:marker_start]
+        ]
+        if declared_return_type != _token_values(expected_return_type):
+            raise RuntimeError(
+                f"{name}: generated call result must be declared as "
+                f"`{expected_return_type} return_value`"
+            )
+
+        final_return_start = body_close - 3
+        if [
+            token.value for token in tokens[final_return_start:body_close]
+        ] != ["return", "return_value", ";"]:
+            raise RuntimeError(
+                f"{name}: client call template must end with `return return_value;`"
+            )
+
+        body_start_position = tokens[body_open].lexpos + 1
+        declaration_position = _line_start(source, tokens[declaration_start].lexpos)
+        if source[declaration_position : tokens[declaration_start].lexpos].strip():
+            raise RuntimeError(
+                f"{name}: generated call declaration must start on its own line"
+            )
+        marker_end_position = tokens[marker_end - 1].lexpos + len(
+            tokens[marker_end - 1].value
+        )
+        final_return_position = _line_start(source, tokens[final_return_start].lexpos)
+        if source[final_return_position : tokens[final_return_start].lexpos].strip():
+            raise RuntimeError(
+                f"{name}: final return must start on its own line"
+            )
+        templates[name] = ClientCallTemplate(
+            return_type=expected_return_type,
+            before_call=_template_section(
+                source[body_start_position:declaration_position]
+            ),
+            after_call=_template_section(
+                source[marker_end_position:final_return_position]
+            ),
+        )
+
+    missing_markers = set(definition_return_types) - set(templates)
+    if missing_markers:
+        raise RuntimeError(
+            "function definitions in annotations.h require "
+            f"{GENERATED_CALL_MARKER}: " + ", ".join(sorted(missing_markers))
+        )
+    return templates

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -14,7 +14,9 @@ import os
 import glob
 import re
 import subprocess
+import textwrap
 import zlib
+from client_templates import collect_client_call_templates
 from ops import (
     NullableOperation,
     ArrayOperation,
@@ -30,6 +32,7 @@ from ops import (
     ReleaseAnnotation,
     ParentAnnotation,
     CrossServerCopyAnnotation,
+    ClientCallTemplate,
     FunctionAnnotationMetadata,
     GraphExecNodeAnnotation,
     RoutingFallbackAnnotation,
@@ -131,11 +134,6 @@ FUNCTION_MAP_ALIASES = [
         "CUDA_VERSION >= 12030",
     ),
 ]
-
-KERNEL_PARAM_LAYOUT_INVALIDATORS = {
-    "cuLibraryUnload",
-    "cuModuleUnload",
-}
 
 NVML_RPC_FUNCTIONS = [
     "nvmlInit_v2",
@@ -1018,13 +1016,12 @@ def client_record_owner_stmt(owner: OwnerAnnotation) -> str:
     )
 
 
-def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMetadata):
-    if function.name.format() == "cuDriverGetVersion":
-        f.write("    if (driverVersion != nullptr) {\n")
-        f.write("        const char *override_version = getenv(\"LUPINE_DRIVER_VERSION_OVERRIDE\");\n")
-        f.write("        if (override_version != nullptr) *driverVersion = atoi(override_version);\n")
-        f.write("    }\n")
+def write_client_template_section(f, section: str):
+    if section:
+        f.write(textwrap.indent(section, "    "))
 
+
+def write_client_post_call(f, metadata: FunctionAnnotationMetadata):
     for owner in metadata.record_owners:
         f.write(client_record_owner_stmt(owner))
     for parent in metadata.parents:
@@ -1052,53 +1049,11 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
             f"{release_fn}({release.parameter.name});\n"
         )
 
-    if function.name.format() == "cuMemAlloc_v2":
-        f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr) lupine_note_deviceptr_allocation_route(*dptr, bytesize, route);\n")
-    if function.name.format() == "cuMemAllocPitch_v2":
-        f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr) {\n")
-        f.write("        size_t allocation_size = 0;\n")
-        f.write("        if (pPitch != nullptr) allocation_size = (*pPitch) * Height;\n")
-        f.write("        else allocation_size = WidthInBytes * Height;\n")
-        f.write("        lupine_note_deviceptr_allocation_route(*dptr, allocation_size, route);\n")
-        f.write("    }\n")
-    if function.name.format() in {"cuMemAllocAsync", "cuMemAllocFromPoolAsync"}:
-        f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr) lupine_note_deviceptr_allocation_route(*dptr, bytesize, route);\n")
-    if function.name.format() == "cuMemFreeAsync":
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_forget_deviceptr_owner(dptr);\n")
-    if function.name.format() == "cuStreamDestroy_v2":
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_forget_stream_owner(hStream);\n")
-    # Record the global's size so offset pointers into it route by range.
-    if function.name.format() in {"cuModuleGetGlobal_v2", "cuLibraryGetGlobal", "cuLibraryGetManaged"}:
-        f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr && bytes != nullptr) lupine_note_deviceptr_allocation_route(*dptr, *bytes, route);\n")
+    if metadata.client_call_template is not None:
+        write_client_template_section(f, metadata.client_call_template.after_call)
+
     if metadata.synchronize:
         f.write("    if (return_value == CUDA_SUCCESS) return_value = lupine_sync_mapped_device_to_host();\n")
-
-    if function.name.format() == "cuCtxDestroy_v2":
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_forget_destroyed_context(ctx);\n")
-    if function.name.format() == "cuCtxFromGreenCtx":
-        f.write("    if (return_value == CUDA_SUCCESS && pContext != nullptr) lupine_mark_context_green(*pContext);\n")
-    if function.name.format() == "cuGreenCtxDestroy":
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_forget_destroyed_context(reinterpret_cast<CUcontext>(hCtx));\n")
-    if function.name.format() in {
-        "cuCtxDestroy_v2",
-        "cuCtxDetach",
-        "cuDevicePrimaryCtxRelease_v2",
-        "cuDevicePrimaryCtxReset_v2",
-    }:
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_current_context_cache();\n")
-    if function.name.format() in KERNEL_PARAM_LAYOUT_INVALIDATORS:
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_function_caches();\n")
-    if function.name.format() == "cuKernelSetAttribute":
-        f.write("    if (return_value == CUDA_SUCCESS) lupine_kernel_attribute_cache_erase(lupine_route_identity(route), kernel, (int)attrib, (int)dev);\n")
-    if function.name.format() == "cuFuncSetAttribute":
-        f.write("    if (return_value == CUDA_SUCCESS) {\n")
-        f.write("        lupine_invalidate_kernel_attribute_cache();\n")
-        f.write("        lupine_invalidate_function_attribute_cache();\n")
-        f.write("    }\n")
-    if function.name.format() == "cuModuleGetFunction":
-        f.write("    if (return_value == CUDA_SUCCESS && hfunc != nullptr) return_value = lupine_record_module_function(*hfunc, hmod, name, route);\n")
-    if function.name.format() == "cuLibraryGetKernel":
-        f.write("    if (return_value == CUDA_SUCCESS && pKernel != nullptr) return_value = lupine_record_library_kernel(*pKernel, library, name, route);\n")
 
 
 def error_const(return_type: str) -> str:
@@ -1584,6 +1539,29 @@ def validate_async_annotation(
             )
 
 
+def attach_client_call_template(
+    function: Function,
+    metadata: FunctionAnnotationMetadata,
+    client_call_templates: dict[str, ClientCallTemplate],
+) -> None:
+    name = function.name.format()
+    template = client_call_templates.get(name)
+    if template is None:
+        return
+    if metadata.disabled_client:
+        raise RuntimeError(
+            f"{name}: client call template cannot disable "
+            "client generation"
+        )
+    return_type = function.return_type.format()
+    if template.return_type != return_type:
+        raise RuntimeError(
+            f"{name}: client call template returns "
+            f"{template.return_type}, but the API returns {return_type}"
+        )
+    metadata.client_call_template = template
+
+
 def main():
     cuda_header = find_header_file("cuda.h")
     hip_header = find_header_file("hip_runtime_api.h")
@@ -1601,6 +1579,14 @@ def main():
     # Parse the files
     cuda_ast: ParsedData = parse_file(cuda_header, options=options)
     annotations: ParsedData = parse_file(annotations_header, options=options)
+    definition_return_types = {
+        function.name.format(): function.return_type.format()
+        for function in annotations.namespace.functions
+        if function.has_body
+    }
+    client_call_templates = collect_client_call_templates(
+        annotations_header, definition_return_types
+    )
     server_bindings = collect_server_bindings(annotations_header)
     functions = [
         function
@@ -1634,6 +1620,7 @@ def main():
         except Exception as e:
             print(f"Error parsing annotation for {function.name}: {e}")
             continue
+        attach_client_call_template(function, metadata, client_call_templates)
         validate_async_annotation(function, metadata)
         functions_with_annotations.append(
             (function, annotation, metadata.operations, metadata)
@@ -1673,6 +1660,7 @@ def main():
         ):
             continue
         metadata = parse_annotation(annotation.doxygen, annotation.parameters)
+        attach_client_call_template(annotation, metadata, client_call_templates)
         validate_async_annotation(annotation, metadata)
         annotated_function = (
             annotation,
@@ -1691,6 +1679,20 @@ def main():
         if not legacy_abi:
             annotation_only_server_functions.append(annotated_function)
         server_function_names.add(name)
+
+    attached_client_call_templates = {
+        function.name.format()
+        for function, _, _, metadata in functions_with_annotations
+        if metadata.client_call_template is not None
+    }
+    unused_client_call_templates = (
+        set(client_call_templates) - attached_client_call_templates
+    )
+    if unused_client_call_templates:
+        raise RuntimeError(
+            "client call templates do not match generated CUDA functions: "
+            + ", ".join(sorted(unused_client_call_templates))
+        )
 
     found_legacy_abi_functions = {
         function.name.format() for function, _, _, _ in legacy_abi_functions
@@ -1999,27 +2001,22 @@ def main():
                     )
                 )
                 f.write("    }\n")
+            if metadata.client_call_template is not None:
+                write_client_template_section(
+                    f, metadata.client_call_template.before_call
+                )
             f.write(
                 "    {return_type} return_value;\n".format(
                     return_type=function.return_type.format()
                 )
             )
-            if function.name.format() == "cuCtxDestroy_v2":
-                # Destroying the current context implicitly pops it; mirror
-                # that in the client's virtual context state before the call.
-                f.write("    CUcontext lupine_current_before_destroy = nullptr;\n")
-                f.write("    if (cuCtxGetCurrent(&lupine_current_before_destroy) ==\n")
-                f.write("            CUDA_SUCCESS &&\n")
-                f.write("        lupine_current_before_destroy == ctx) {\n")
-                f.write("        cuCtxSetCurrent(nullptr);\n")
-                f.write("    }\n")
             call_args = ", ".join(client_call_args(function, metadata))
             helper_args = f", {call_args}" if call_args else ""
             local_call = 'lupine_call_real_cuda_fn("{name}"{args})'.format(
                 name=function.name.format(), args=helper_args
             )
             local_post_call = io.StringIO()
-            write_client_post_call(local_post_call, function, metadata)
+            write_client_post_call(local_post_call, metadata)
             if local_post_call.getvalue():
                 f.write("    if (lupine_route_is_local(route)) {\n")
                 f.write(f"        return_value = {local_call};\n")
@@ -2092,7 +2089,7 @@ def main():
                 f.write("        return {r};\n".format(r=error_return))
                 f.write("    }\n")
                 post_call = io.StringIO()
-                write_client_post_call(post_call, function, metadata)
+                write_client_post_call(post_call, metadata)
                 if post_call.getvalue():
                     f.write("    return_value = CUDA_SUCCESS;\n")
                     f.write(post_call.getvalue())
@@ -2157,7 +2154,7 @@ def main():
                         retain.handle.name,
                     )
 
-            write_client_post_call(f, function, metadata)
+            write_client_post_call(f, metadata)
             f.write("    return return_value;\n")
             if metadata.routing_kind == "ALL":
                 f.write("        });\n")

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -110,16 +110,8 @@ extern "C" CUresult CUDAAPI cuGraphExecUpdate(
 CUresult cuDriverGetVersion(int *driverVersion) {
   lupine_route route = lupine_route_for_default();
   CUresult return_value;
-  if (lupine_route_is_local(route)) {
-    return_value =
-        lupine_call_real_cuda_fn("cuDriverGetVersion", driverVersion);
-    if (driverVersion != nullptr) {
-      const char *override_version = getenv("LUPINE_DRIVER_VERSION_OVERRIDE");
-      if (override_version != nullptr)
-        *driverVersion = atoi(override_version);
-    }
-    return return_value;
-  }
+  if (lupine_route_is_local(route))
+    return lupine_call_real_cuda_fn("cuDriverGetVersion", driverVersion);
   conn_t *conn = lupine_route_remote_conn(route);
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
@@ -128,11 +120,6 @@ CUresult cuDriverGetVersion(int *driverVersion) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (driverVersion != nullptr) {
-    const char *override_version = getenv("LUPINE_DRIVER_VERSION_OVERRIDE");
-    if (override_version != nullptr)
-      *driverVersion = atoi(override_version);
-  }
   return return_value;
 }
 
@@ -341,12 +328,12 @@ CUresult cuDeviceComputeCapability(int *major, int *minor, CUdevice dev) {
 
 CUresult cuCtxDestroy_v2(CUcontext ctx) {
   lupine_route route = lupine_route_for_context(ctx);
-  CUresult return_value;
   CUcontext lupine_current_before_destroy = nullptr;
   if (cuCtxGetCurrent(&lupine_current_before_destroy) == CUDA_SUCCESS &&
       lupine_current_before_destroy == ctx) {
     cuCtxSetCurrent(nullptr);
   }
+  CUresult return_value;
   if (lupine_route_is_local(route)) {
     return_value = lupine_call_real_cuda_fn("cuCtxDestroy_v2", ctx);
     if (return_value == CUDA_SUCCESS)

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -1146,6 +1146,13 @@ class GraphExecNodeAnnotation:
     node: Parameter
 
 
+@dataclass(frozen=True)
+class ClientCallTemplate:
+    return_type: str
+    before_call: str
+    after_call: str
+
+
 @dataclass
 class FunctionAnnotationMetadata:
     operations: list[Operation]
@@ -1166,6 +1173,7 @@ class FunctionAnnotationMetadata:
     parents: list[ParentAnnotation] = None
     cross_server_copy: Optional[CrossServerCopyAnnotation] = None
     graph_exec_node: Optional[GraphExecNodeAnnotation] = None
+    client_call_template: Optional[ClientCallTemplate] = None
 
     def __post_init__(self):
         if self.record_owners is None:


### PR DESCRIPTION
## Summary

- allow opt-in function definitions in `annotations.h` to wrap generated client calls with typed C++
- validate the `return_value = LUPINE_GENERATED_CALL();` contract and splice pre/post code into local and RPC paths
- migrate the existing CUDA bookkeeping hooks out of name-based Python branches
- remove the undocumented `LUPINE_DRIVER_VERSION_OVERRIDE` behavior so `cuDriverGetVersion` reports the selected route result

## Testing

- `./codegen/run.sh`
- `cmake -S . -B build -G Ninja -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --parallel 4`
- `ctest --test-dir build --output-on-failure` (13/13 passed; 3 expected skips)
- focused template validation for valid, wrong-type, missing-marker, duplicate-marker, and missing-final-return cases