### PR TITLE
Allow retrying partial PyPI publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,3 +30,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python-dist
+          skip-existing: true


### PR DESCRIPTION
Set the PyPI publisher to skip files that already exist so a partial multi-package release can be retried safely. This is needed to finish publishing lupine-auto 2.0.0 after lupine 2.0.0 succeeded.