### PR TITLE
Prepare coherent Python 2.0.1 release

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -46,6 +46,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || github.sha }}
+
+      - name: Resolve source revision
+        id: source
+        run: echo "revision=$(git rev-parse --verify HEAD^{commit})" >> "$GITHUB_OUTPUT"
 
       - name: Free runner disk space
         run: |
@@ -91,7 +97,7 @@ jobs:
           tags: ${{ steps.image-tags.outputs.server }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.source.outputs.revision }}
 
   publish:
     name: Publish server manifest CUDA ${{ matrix.cuda.version }} / Ubuntu ${{ matrix.cuda.ubuntu }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,30 +4,84 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish
+        required: true
+        type: string
 
 jobs:
+  release-metadata:
+    name: Validate release tag and source revision
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      revision: ${{ steps.release.outputs.revision }}
+      tag: ${{ steps.release.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Validate release metadata
+        id: release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          python python/verify_release.py --tag "$RELEASE_TAG"
+          revision="$(git rev-parse --verify HEAD^{commit})"
+          tag_revision="$(git rev-list -n 1 "$RELEASE_TAG")"
+          if [ "$revision" != "$tag_revision" ]; then
+            echo "Checked out $revision, but $RELEASE_TAG points to $tag_revision" >&2
+            exit 1
+          fi
+          echo "revision=$revision" >> "$GITHUB_OUTPUT"
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
   build-python:
+    needs: release-metadata
     uses: ./.github/workflows/python.yml
     permissions:
       contents: read
+    with:
+      checkout_ref: ${{ needs.release-metadata.outputs.revision }}
 
   pypi:
-    needs: build-python
+    needs: [release-metadata, build-python]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     environment:
       name: pypi
       url: https://pypi.org/p/lupine
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-metadata.outputs.revision }}
+
       - name: Download tested Python packages
         uses: actions/download-artifact@v8
         with:
           name: lupine-python-package
           path: python-dist
 
-      - name: Publish Python packages to PyPI
+      - name: Validate tested Python packages
+        env:
+          RELEASE_TAG: ${{ needs.release-metadata.outputs.tag }}
+        run: python python/verify_release.py --tag "$RELEASE_TAG" --dist python-dist
+
+      - name: Publish lupine to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: python-dist
+          packages-dir: python-dist/lupine
+          skip-existing: true
+
+      - name: Publish lupine-auto to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python-dist/lupine-auto
           skip-existing: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,11 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: Exact source revision to build
+        required: false
+        type: string
   pull_request:
   push:
     branches:
@@ -39,6 +44,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
@@ -187,6 +194,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Download thin dylibs
         uses: actions/download-artifact@v8
@@ -227,6 +236,8 @@ jobs:
       LUPINE_AUTO: "0"
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
@@ -250,7 +261,9 @@ jobs:
 
       - name: Run Python tests
         working-directory: python
-        run: uv run --all-extras pytest
+        run: |
+          python verify_release.py
+          uv run --all-extras pytest
 
       - name: Check PyTorch ABI against bundled shims
         working-directory: python
@@ -273,11 +286,12 @@ jobs:
       - name: Build Python packages
         working-directory: python
         run: |
-          uv build --wheel --out-dir dist
-          uv build --wheel auto --out-dir dist
+          uv build --wheel --out-dir dist/lupine
+          uv build --wheel auto --out-dir dist/lupine-auto
+          python verify_release.py --dist dist
 
       - name: Upload Python package artifacts
         uses: actions/upload-artifact@v7
         with:
           name: lupine-python-package
-          path: python/dist/*
+          path: python/dist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,23 +30,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Client and server must come from the same build: the RPC opcode numbering and
-# the struct layouts behind it are shared and unversioned. This identity travels
-# with every connection so a mismatched pair is refused at connect instead of
-# failing later as an opaque runtime error. Builds without git leave it empty,
-# which reads as "cannot verify" rather than as a match. Committed builds compare
-# exactly; a dirty tree is only flagged as dirty, not content-hashed, so two
-# different uncommitted trees at the same commit still compare equal.
-find_package(Git QUIET)
+# Keep wire-identity negotiation dormant until the release/versioning contract
+# is settled. Empty identities remain mutually compatible.
 set(LUPINE_WIRE_IDENTITY "")
-if(Git_FOUND)
-    execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --always --dirty --abbrev=12
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        OUTPUT_VARIABLE LUPINE_WIRE_IDENTITY
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET)
-endif()
 
 include(CTest)
 find_package(Threads REQUIRED)

--- a/python/auto/pyproject.toml
+++ b/python/auto/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lupine-auto"
-version = "2.0.0"
+version = "2.0.1"
 description = "Automatic Python startup bootstrap for LUPINE"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
-dependencies = []
+dependencies = ["lupine==2.0.1"]
 
 [dependency-groups]
 dev = ["pytest>=8.0"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lupine"
-version = "2.0.0"
+version = "2.0.1"
 description = "CUDA on any host: bundled LUPINE driver/runtime shims plus PyTorch adapter"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -13,7 +13,7 @@ dependencies = []
 
 [project.optional-dependencies]
 torch = ["torch"]
-auto = ["lupine-auto==2.0.0"]
+auto = ["lupine-auto==2.0.1"]
 
 [dependency-groups]
 dev = ["pytest>=8.0"]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -147,7 +147,7 @@ wheels = [
 
 [[package]]
 name = "lupine"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -175,10 +175,14 @@ dev = [{ name = "pytest", specifier = ">=8.0" }]
 
 [[package]]
 name = "lupine-auto"
-version = "2.0.0"
+version = "2.0.1"
 source = { directory = "auto" }
+dependencies = [
+    { name = "lupine" },
+]
 
 [package.metadata]
+requires-dist = [{ name = "lupine", specifier = "==2.0.1" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]

--- a/python/verify_release.py
+++ b/python/verify_release.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Verify that the tandem Python distributions form one release unit."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+import zipfile
+from email.parser import BytesParser
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+
+
+def _project(path: Path) -> dict:
+    with path.open("rb") as stream:
+        return tomllib.load(stream)["project"]
+
+
+def _normalized(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def verify_metadata(tag: str | None = None) -> str:
+    lupine = _project(ROOT / "pyproject.toml")
+    auto = _project(ROOT / "auto" / "pyproject.toml")
+    version = lupine["version"]
+
+    if auto["version"] != version:
+        raise ValueError(
+            f"package versions differ: lupine={version}, "
+            f"lupine-auto={auto['version']}"
+        )
+
+    auto_requirement = f"lupine-auto=={version}"
+    if auto_requirement not in lupine["optional-dependencies"]["auto"]:
+        raise ValueError(f"lupine[auto] must require {auto_requirement}")
+
+    lupine_requirement = f"lupine=={version}"
+    if lupine_requirement not in auto["dependencies"]:
+        raise ValueError(f"lupine-auto must require {lupine_requirement}")
+
+    if tag is not None and tag != f"v{version}":
+        raise ValueError(f"release tag {tag!r} does not match version {version}")
+
+    return version
+
+
+def verify_wheels(directory: Path, version: str) -> None:
+    expected = {
+        "lupine": f"lupine-auto=={version}",
+        "lupine-auto": f"lupine=={version}",
+    }
+    found: dict[str, tuple[str, list[str]]] = {}
+
+    for wheel in directory.rglob("*.whl"):
+        with zipfile.ZipFile(wheel) as archive:
+            metadata_paths = [
+                name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_paths) != 1:
+                raise ValueError(f"{wheel} has {len(metadata_paths)} METADATA files")
+            metadata = BytesParser().parsebytes(archive.read(metadata_paths[0]))
+
+        name = _normalized(metadata["Name"])
+        if name in found:
+            raise ValueError(f"multiple wheels found for {name}")
+        found[name] = (metadata["Version"], metadata.get_all("Requires-Dist", []))
+
+    if set(found) != set(expected):
+        raise ValueError(
+            f"expected wheels for {sorted(expected)}, found {sorted(found)}"
+        )
+
+    for name, requirement in expected.items():
+        wheel_version, requirements = found[name]
+        if wheel_version != version:
+            raise ValueError(
+                f"{name} wheel has version {wheel_version}, expected {version}"
+            )
+        if not any(req.split(";", 1)[0].strip() == requirement for req in requirements):
+            raise ValueError(f"{name} wheel must require {requirement}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", help="GitHub release tag to validate")
+    parser.add_argument("--dist", type=Path, help="directory containing built wheels")
+    args = parser.parse_args(argv)
+
+    try:
+        version = verify_metadata(args.tag)
+        if args.dist is not None:
+            verify_wheels(args.dist, version)
+    except (KeyError, OSError, TypeError, ValueError, zipfile.BadZipFile) as exc:
+        print(f"release validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"release metadata is consistent for v{version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- bump `lupine` and `lupine-auto` together to 2.0.1 with exact reciprocal version pins
- validate the release tag, source revision, source metadata, and both built wheels before publishing
- build all Python artifacts from the one commit resolved by the release tag and preserve that revision on release server images
- keep wire identity empty for now
- publish the two distributions independently with retry-safe uploads

## Validation
- `LUPINE_AUTO=0 uv run --all-extras pytest` (18 passed)
- built both wheels and ran `python verify_release.py --tag v2.0.1 --dist ...`
- clean Python 3.10 install of `lupine-auto==2.0.1` resolved both packages at 2.0.1
- built and ran `h2_test`; confirmed compiled `LUPINE_WIRE_IDENTITY` is empty
- actionlint on the three changed workflows (ignoring the repository's existing custom Windows runner-label warning)
