### PR TITLE
Serve server-selected native client bundles

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -106,6 +106,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             CUDA_VERSION=${{ matrix.cuda.version }}
+            LUPINE_REQUIRE_CLIENT_BUNDLES=1
             UBUNTU_VERSION=${{ matrix.cuda.ubuntu }}
           tags: ${{ steps.image-tags.outputs.server }}
           labels: |

--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -21,8 +21,15 @@ permissions:
   packages: write
 
 jobs:
+  client-bundles:
+    name: Build all client bundle variants
+    uses: ./.github/workflows/python.yml
+    with:
+      checkout_ref: ${{ github.event.release.tag_name || github.sha }}
+
   build:
     name: Server image CUDA ${{ matrix.cuda.version }} / Ubuntu ${{ matrix.cuda.ubuntu }} / ${{ matrix.platform.arch }}
+    needs: client-bundles
     runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
@@ -52,6 +59,12 @@ jobs:
       - name: Resolve source revision
         id: source
         run: echo "revision=$(git rev-parse --verify HEAD^{commit})" >> "$GITHUB_OUTPUT"
+
+      - name: Download all client bundle variants
+        uses: actions/download-artifact@v8
+        with:
+          name: lupine-client-bundles
+          path: client-bundles
 
       - name: Free runner disk space
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -265,6 +265,21 @@ jobs:
           python verify_release.py
           uv run --all-extras pytest
 
+      - name: Assemble server-served client bundles
+        working-directory: python
+        run: |
+          set -euo pipefail
+          revision="$(git rev-parse --verify HEAD^{commit})"
+          ./build.py bundles client-bundles "$revision"
+
+      - name: Upload server-served client bundles
+        uses: actions/upload-artifact@v7
+        with:
+          name: lupine-client-bundles
+          path: python/client-bundles
+          if-no-files-found: error
+          retention-days: 3
+
       - name: Check PyTorch ABI against bundled shims
         working-directory: python
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,7 +1,9 @@
 name: Python
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  # A reusable invocation inherits github.workflow from its caller. Namespace
+  # this group so it cannot cancel the caller that is waiting on it.
+  group: python-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Keep wire-identity negotiation dormant until the release/versioning contract
-# is settled. Empty identities remain mutually compatible.
-set(LUPINE_WIRE_IDENTITY "")
-
 include(CTest)
 find_package(Threads REQUIRED)
 find_path(NGHTTP2_INCLUDE_DIR nghttp2/nghttp2.h REQUIRED)
@@ -220,6 +216,7 @@ add_library(lupine_rpc_core STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/client_bundle.cpp
 )
 lupine_internal_target(lupine_rpc_core)
 target_include_directories(lupine_rpc_core
@@ -227,8 +224,6 @@ target_include_directories(lupine_rpc_core
     PRIVATE ${NGHTTP2_INCLUDE_DIR})
 target_link_libraries(lupine_rpc_core PUBLIC
     Threads::Threads ${NGHTTP2_LIBRARY} lupine_lz4)
-target_compile_definitions(lupine_rpc_core PRIVATE
-    LUPINE_WIRE_IDENTITY="${LUPINE_WIRE_IDENTITY}")
 if(OpenSSL_FOUND)
     target_compile_definitions(lupine_rpc_core PRIVATE LUPINE_TLS_OPENSSL)
     target_link_libraries(lupine_rpc_core PUBLIC OpenSSL::SSL OpenSSL::Crypto)

--- a/Dockerfile
+++ b/Dockerfile
@@ -194,6 +194,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG AMDGPU_INSTALL_VERSION=7.2.4.70204-1
 ARG CUDA_KEYRING_VERSION=1.1-1
 ARG CUDA_VERSION
+ARG LUPINE_REQUIRE_CLIENT_BUNDLES=0
 ARG ROCM_VERSION
 ARG UBUNTU_VERSION
 
@@ -248,14 +249,16 @@ COPY --from=server-build /opt/lupine/build/lupine_driver_server /opt/lupine/bin/
 COPY client-bundles/ /opt/lupine/client-bundles/
 
 RUN set -eux; \
-    for platform in \
-      linux/amd64 linux/arm64 \
-      macos/amd64 macos/arm64 \
-      windows/amd64 windows/arm64; do \
-      test -s "/opt/lupine/client-bundles/${platform}/client.zip"; \
-      test -s "/opt/lupine/client-bundles/${platform}/client.zip.etag"; \
-      test -s "/opt/lupine/client-bundles/${platform}/client.zip.digest"; \
-    done
+    if [ "${LUPINE_REQUIRE_CLIENT_BUNDLES}" = 1 ]; then \
+      for platform in \
+        linux/amd64 linux/arm64 \
+        macos/amd64 macos/arm64 \
+        windows/amd64 windows/arm64; do \
+        test -s "/opt/lupine/client-bundles/${platform}/client.zip"; \
+        test -s "/opt/lupine/client-bundles/${platform}/client.zip.etag"; \
+        test -s "/opt/lupine/client-bundles/${platform}/client.zip.digest"; \
+      done; \
+    fi
 
 RUN chmod +x /opt/lupine/bin/lupine_driver_server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -245,11 +245,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* /tmp/*.deb
 
 COPY --from=server-build /opt/lupine/build/lupine_driver_server /opt/lupine/bin/lupine_driver_server
+COPY client-bundles/ /opt/lupine/client-bundles/
+
+RUN set -eux; \
+    for platform in \
+      linux/amd64 linux/arm64 \
+      macos/amd64 macos/arm64 \
+      windows/amd64 windows/arm64; do \
+      test -s "/opt/lupine/client-bundles/${platform}/client.zip"; \
+      test -s "/opt/lupine/client-bundles/${platform}/client.zip.etag"; \
+      test -s "/opt/lupine/client-bundles/${platform}/client.zip.digest"; \
+    done
 
 RUN chmod +x /opt/lupine/bin/lupine_driver_server
 
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/compat:/opt/rocm/lib
 ENV LUPINE_PORT=14833
+ENV LUPINE_CLIENT_BUNDLE_DIR=/opt/lupine/client-bundles
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The startup hook preserves an explicit `LUPINE_SERVER`; set
 
 ## macOS client
 
-The `lupine` Python wheel bundles universal2 CUDA driver, runtime, and NVML
-client shims. Native CUDA consumers can load those dylibs and use a remote GPU
+The LUPINE server publishes universal2 CUDA driver, runtime, and NVML client
+shims for the Python client. Native CUDA consumers can load those dylibs and use a remote GPU
 without NVIDIA software on the Mac.
 
 The official macOS PyTorch wheel is CPU-only, however, so loading the shims
@@ -89,6 +89,16 @@ Mon May 18 15:40:46 2026
 Inside the client container, `LD_LIBRARY_PATH=/opt/lupine/lib` is already set,
 so CUDA driver users pick up the LUPINE `libcuda.so.1` shim and NVML users such
 as `nvidia-smi` pick up the LUPINE `libnvidia-ml.so.1` shim automatically.
+
+## Client compatibility
+
+Each production server image carries the matching Linux, macOS, and Windows
+client objects for amd64 and arm64. Python clients fetch the current object
+from `/.well-known/lupine/client/v1/<os>/<arch>`, verify its strong ETag,
+content digest, manifest, and file hashes, and cache it locally. The selected
+ETag is also asserted when the RPC connection opens, closing the race between
+discovery and a server upgrade. `LUPINE_LIBDIR` remains an explicit local
+override for development.
 
 ## Graceful Server Checkpoints
 

--- a/client-bundles/README.md
+++ b/client-bundles/README.md
@@ -1,0 +1,6 @@
+# Server client bundles
+
+CI assembles the native client objects into this directory before building a
+production server image; the server image target intentionally fails when any
+variant is absent. A development server binary with no configured bundle tree
+answers the client endpoint with `503`.

--- a/client-bundles/README.md
+++ b/client-bundles/README.md
@@ -1,6 +1,7 @@
 # Server client bundles
 
-CI assembles the native client objects into this directory before building a
-production server image; the server image target intentionally fails when any
-variant is absent. A development server binary with no configured bundle tree
-answers the client endpoint with `503`.
+CI assembles the native client objects into this directory before the server
+publish workflow builds an image. That workflow sets
+`LUPINE_REQUIRE_CLIENT_BUNDLES=1`, so the image build fails when any variant is
+absent. Development and compile-check server images may omit the bundles; the
+server then answers the client endpoint with `503`.

--- a/client_bundle.cpp
+++ b/client_bundle.cpp
@@ -1,0 +1,115 @@
+#include "client_bundle.h"
+
+#include <array>
+#include <fstream>
+#include <utility>
+
+namespace {
+
+constexpr char kClientBundlePrefix[] = "/.well-known/lupine/client/v1/";
+constexpr std::array<const char *, 6> kClientPlatforms = {
+    "linux/amd64", "linux/arm64",   "macos/amd64",
+    "macos/arm64", "windows/amd64", "windows/arm64",
+};
+
+bool platform_supported(const std::string &platform) {
+  for (const char *supported : kClientPlatforms) {
+    if (platform == supported) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool read_line(const std::string &path, std::string *value) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input || !std::getline(input, *value)) {
+    return false;
+  }
+  if (!value->empty() && value->back() == '\r') {
+    value->pop_back();
+  }
+  return !value->empty() && value->find('\r') == std::string::npos &&
+         value->find('\n') == std::string::npos;
+}
+
+bool valid_etag(const std::string &etag) {
+  if (etag.compare(0, 8, "\"sha256:") != 0 || etag.size() != 73 ||
+      etag.back() != '\"') {
+    return false;
+  }
+  for (size_t i = 8; i + 1 < etag.size(); ++i) {
+    if (!((etag[i] >= '0' && etag[i] <= '9') ||
+          (etag[i] >= 'a' && etag[i] <= 'f'))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool valid_content_digest(const std::string &digest) {
+  if (digest.compare(0, 9, "sha-256=:") != 0 || digest.size() <= 10 ||
+      digest.back() != ':') {
+    return false;
+  }
+  for (size_t i = 9; i + 1 < digest.size(); ++i) {
+    char c = digest[i];
+    if (!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') ||
+          (c >= 'a' && c <= 'z') || c == '+' || c == '/' || c == '=')) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+bool lupine_client_bundle_lookup(const char *root, const std::string &platform,
+                                 lupine_client_bundle *bundle) {
+  if (root == nullptr || root[0] == '\0' || bundle == nullptr ||
+      !platform_supported(platform)) {
+    return false;
+  }
+
+  std::string base(root);
+  if (!base.empty() && base.back() != '/' && base.back() != '\\') {
+    base += '/';
+  }
+  base += platform;
+  base += "/client.zip";
+
+  std::ifstream input(base, std::ios::binary | std::ios::ate);
+  if (!input) {
+    return false;
+  }
+  std::streamoff size = input.tellg();
+  if (size < 0) {
+    return false;
+  }
+
+  lupine_client_bundle found;
+  found.path = base;
+  found.size = static_cast<uint64_t>(size);
+  if (!read_line(base + ".etag", &found.etag) || !valid_etag(found.etag) ||
+      !read_line(base + ".digest", &found.content_digest) ||
+      !valid_content_digest(found.content_digest)) {
+    return false;
+  }
+
+  *bundle = std::move(found);
+  return true;
+}
+
+bool lupine_client_bundle_request_platform(const std::string &path,
+                                           std::string *platform) {
+  if (platform == nullptr || path.compare(0, sizeof(kClientBundlePrefix) - 1,
+                                          kClientBundlePrefix) != 0) {
+    return false;
+  }
+  std::string candidate = path.substr(sizeof(kClientBundlePrefix) - 1);
+  if (!platform_supported(candidate)) {
+    return false;
+  }
+  *platform = std::move(candidate);
+  return true;
+}

--- a/client_bundle.h
+++ b/client_bundle.h
@@ -1,0 +1,24 @@
+#ifndef LUPINE_CLIENT_BUNDLE_H
+#define LUPINE_CLIENT_BUNDLE_H
+
+#include <stdint.h>
+#include <string>
+
+struct lupine_client_bundle {
+  std::string path;
+  std::string etag;
+  std::string content_digest;
+  uint64_t size = 0;
+};
+
+// Looks up one immutable client bundle below root. Platform names are the
+// public protocol values (for example "linux/amd64"), not build-system tags.
+// Returns false for an unsupported platform or an incomplete bundle entry.
+bool lupine_client_bundle_lookup(const char *root, const std::string &platform,
+                                 lupine_client_bundle *bundle);
+
+// Extracts the platform from the versioned HTTP endpoint.
+bool lupine_client_bundle_request_platform(const std::string &path,
+                                           std::string *platform);
+
+#endif

--- a/dispatch.cpp
+++ b/dispatch.cpp
@@ -14,11 +14,16 @@
 
 #include "dispatch.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <fstream>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
+#include "client_bundle.h"
 #include "lupine_log.h"
 
 namespace {
@@ -50,11 +55,14 @@ bool send_all(lupine_socket_t fd, const std::string &data) {
   return true;
 }
 
-std::string http1_response(int status, const char *reason,
-                           const std::string &body, bool include_body,
-                           const rpc_http2_server_metadata *metadata) {
-  std::string response = "HTTP/1.1 " + std::to_string(status) + " " + reason +
-                         "\r\n";
+using http_header = std::pair<std::string, std::string>;
+
+std::string http1_headers(int status, const char *reason,
+                          uint64_t content_length, const char *content_type,
+                          const std::vector<http_header> &headers,
+                          const rpc_http2_server_metadata *metadata) {
+  std::string response =
+      "HTTP/1.1 " + std::to_string(status) + " " + reason + "\r\n";
   if (metadata != nullptr && metadata->backend_version != nullptr &&
       metadata->backend_version[0] != '\0') {
     // Same header the HTTP/2 version probe answers with, so an HTTP/1.1
@@ -63,17 +71,135 @@ std::string http1_response(int status, const char *reason,
     response += metadata->backend_version;
     response += "\r\n";
   }
-  response += "content-type: text/plain\r\n";
-  response += "content-length: " + std::to_string(body.size()) + "\r\n";
+  if (content_type != nullptr) {
+    response += "content-type: ";
+    response += content_type;
+    response += "\r\n";
+  }
+  for (const auto &header : headers) {
+    response += header.first;
+    response += ": ";
+    response += header.second;
+    response += "\r\n";
+  }
+  response += "content-length: " + std::to_string(content_length) + "\r\n";
   response += "connection: close\r\n\r\n";
+  return response;
+}
+
+std::string http1_response(int status, const char *reason,
+                           const std::string &body, bool include_body,
+                           const rpc_http2_server_metadata *metadata,
+                           const std::vector<http_header> &headers = {}) {
+  std::string response = http1_headers(status, reason, body.size(),
+                                       "text/plain", headers, metadata);
   if (include_body) {
     response += body;
   }
   return response;
 }
 
-int serve_http1(lupine_socket_t fd,
-                const rpc_http2_server_metadata *metadata) {
+bool send_file(lupine_socket_t fd, const std::string &path) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input) {
+    return false;
+  }
+  char data[64 * 1024];
+  while (input) {
+    input.read(data, sizeof(data));
+    std::streamsize size = input.gcount();
+    if (size > 0 &&
+        !send_all(fd, std::string(data, static_cast<size_t>(size)))) {
+      return false;
+    }
+  }
+  return input.eof();
+}
+
+std::string ascii_lower(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](char c) {
+    return c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c;
+  });
+  return value;
+}
+
+std::string request_header(const std::string &request, const char *wanted) {
+  size_t line_start = request.find("\r\n");
+  if (line_start == std::string::npos) {
+    return "";
+  }
+  line_start += 2;
+  while (line_start < request.size()) {
+    size_t line_end = request.find("\r\n", line_start);
+    if (line_end == std::string::npos || line_end == line_start) {
+      break;
+    }
+    size_t colon = request.find(':', line_start);
+    if (colon != std::string::npos && colon < line_end &&
+        ascii_lower(request.substr(line_start, colon - line_start)) == wanted) {
+      size_t value_start = colon + 1;
+      while (value_start < line_end &&
+             (request[value_start] == ' ' || request[value_start] == '\t')) {
+        ++value_start;
+      }
+      size_t value_end = line_end;
+      while (value_end > value_start && (request[value_end - 1] == ' ' ||
+                                         request[value_end - 1] == '\t')) {
+        --value_end;
+      }
+      return request.substr(value_start, value_end - value_start);
+    }
+    line_start = line_end + 2;
+  }
+  return "";
+}
+
+int serve_client_bundle(lupine_socket_t fd, const std::string &method,
+                        const std::string &path, const std::string &request,
+                        const rpc_http2_server_metadata *metadata) {
+  bool head = method == "HEAD";
+  if (!head && method != "GET") {
+    send_all(fd,
+             http1_response(405, "Method Not Allowed", "method not allowed\n",
+                            true, metadata, {{"allow", "GET, HEAD"}}));
+    return 1;
+  }
+
+  std::string platform;
+  if (!lupine_client_bundle_request_platform(path, &platform)) {
+    return 0;
+  }
+  lupine_client_bundle bundle;
+  const char *root =
+      metadata == nullptr ? nullptr : metadata->client_bundle_dir;
+  if (!lupine_client_bundle_lookup(root, platform, &bundle)) {
+    send_all(fd,
+             http1_response(503, "Service Unavailable",
+                            "client bundle unavailable\n", !head, metadata));
+    return 1;
+  }
+
+  std::vector<http_header> headers = {
+      {"etag", bundle.etag},
+      {"content-digest", bundle.content_digest},
+      {"cache-control", "no-cache"},
+  };
+  if (request_header(request, "if-none-match") == bundle.etag) {
+    return send_all(fd, http1_headers(304, "Not Modified", 0, nullptr, headers,
+                                      metadata))
+               ? 1
+               : -1;
+  }
+
+  if (!send_all(fd, http1_headers(200, "OK", bundle.size,
+                                  "application/vnd.lupine.client-bundle.v1+zip",
+                                  headers, metadata))) {
+    return -1;
+  }
+  return head || send_file(fd, bundle.path) ? 1 : -1;
+}
+
+int serve_http1(lupine_socket_t fd, const rpc_http2_server_metadata *metadata) {
   std::string request;
   while (request.find("\r\n\r\n") == std::string::npos) {
     if (request.size() >= kMaxHttp1RequestBytes) {
@@ -92,9 +218,9 @@ int serve_http1(lupine_socket_t fd,
 
   std::string line = request.substr(0, request.find("\r\n"));
   size_t method_end = line.find(' ');
-  size_t path_end =
-      method_end == std::string::npos ? std::string::npos
-                                      : line.find(' ', method_end + 1);
+  size_t path_end = method_end == std::string::npos
+                        ? std::string::npos
+                        : line.find(' ', method_end + 1);
   if (path_end == std::string::npos) {
     send_all(fd, http1_response(400, "Bad Request", "bad request\n", true,
                                 metadata));
@@ -103,6 +229,14 @@ int serve_http1(lupine_socket_t fd,
   std::string method = line.substr(0, method_end);
   std::string path = line.substr(method_end + 1, path_end - method_end - 1);
   LUPINE_LOG_DEBUG("HTTP/1.1 " << method << " " << path);
+
+  if (path.compare(0, strlen("/.well-known/lupine/client/v1/"),
+                   "/.well-known/lupine/client/v1/") == 0) {
+    int result = serve_client_bundle(fd, method, path, request, metadata);
+    if (result != 0) {
+      return result;
+    }
+  }
 
   bool head = method == "HEAD";
   if (path == "/" && (head || method == "GET")) {
@@ -135,8 +269,7 @@ int lupine_connection_dispatch(lupine_socket_t connfd,
     if (received <= 0) {
       return -1;
     }
-    int verdict =
-        lupine_h2_preface_check(data, static_cast<size_t>(received));
+    int verdict = lupine_h2_preface_check(data, static_cast<size_t>(received));
     if (verdict > 0) {
       return 0;
     }

--- a/dispatch_test.cpp
+++ b/dispatch_test.cpp
@@ -5,6 +5,8 @@
 #include "dispatch.h"
 
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <stdio.h>
 #include <string>
 #include <sys/socket.h>
@@ -24,7 +26,7 @@ void check(bool ok, const char *what) {
 
 constexpr char kPreface[] = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 constexpr size_t kPrefaceLength = sizeof(kPreface) - 1;
-const rpc_http2_server_metadata kMetadata = {"13.0-test"};
+const rpc_http2_server_metadata kMetadata = {"13.0-test", nullptr};
 
 bool make_pair(int fds[2]) {
   return socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0;
@@ -133,8 +135,7 @@ void test_http1_head_root_has_no_body() {
   close(fds[0]);
   std::string response = read_response(fds[1]);
   check(response.rfind("HTTP/1.1 200 OK\r\n", 0) == 0, "HEAD / returns 200");
-  check(response.find("\r\n\r\n") == response.size() - 4,
-        "HEAD / has no body");
+  check(response.find("\r\n\r\n") == response.size() - 4, "HEAD / has no body");
   close(fds[1]);
 }
 
@@ -153,6 +154,96 @@ void test_http1_unknown_path_is_404() {
   check(response.rfind("HTTP/1.1 404 Not Found\r\n", 0) == 0,
         "unknown path returns 404");
   close(fds[1]);
+}
+
+struct bundle_fixture {
+  std::filesystem::path root;
+  rpc_http2_server_metadata metadata;
+
+  bundle_fixture() {
+    char directory[] = "/tmp/lupine-bundle-test-XXXXXX";
+    const char *created = mkdtemp(directory);
+    check(created != nullptr, "create bundle fixture");
+    root = created == nullptr ? "/tmp/lupine-bundle-test-invalid" : created;
+    std::filesystem::path platform = root / "linux" / "amd64";
+    std::filesystem::create_directories(platform);
+    std::ofstream(platform / "client.zip", std::ios::binary) << "zip-body";
+    std::ofstream(platform / "client.zip.etag")
+        << "\"sha256:"
+           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+           "\n";
+    std::ofstream(platform / "client.zip.digest") << "sha-256=:Ym9keQ==:\n";
+    metadata = {"13.0-test", root.c_str()};
+  }
+
+  ~bundle_fixture() { std::filesystem::remove_all(root); }
+};
+
+std::string bundle_request(const rpc_http2_server_metadata *metadata,
+                           const std::string &request) {
+  int fds[2];
+  if (!make_pair(fds)) {
+    check(false, "socketpair");
+    return "";
+  }
+  write(fds[1], request.data(), request.size());
+  check(lupine_connection_dispatch(fds[0], metadata) == 1,
+        "bundle request is served here");
+  close(fds[0]);
+  std::string response = read_response(fds[1]);
+  close(fds[1]);
+  return response;
+}
+
+void test_http1_client_bundle_get_head_and_etag() {
+  bundle_fixture fixture;
+  const std::string path = "/.well-known/lupine/client/v1/linux/amd64";
+
+  std::string response = bundle_request(
+      &fixture.metadata, "GET " + path + " HTTP/1.1\r\nhost: lupine\r\n\r\n");
+  check(response.rfind("HTTP/1.1 200 OK\r\n", 0) == 0,
+        "client bundle GET returns 200");
+  check(response.find(
+            "content-type: application/vnd.lupine.client-bundle.v1+zip\r\n") !=
+            std::string::npos,
+        "client bundle reports its media type");
+  check(response.find("etag: "
+                      "\"sha256:"
+                      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                      "aaaaaaaa\"\r\n") != std::string::npos,
+        "client bundle reports a strong ETag");
+  check(response.find("content-digest: sha-256=:Ym9keQ==:\r\n") !=
+            std::string::npos,
+        "client bundle reports its content digest");
+  check(response.find("\r\n\r\nzip-body") != std::string::npos,
+        "client bundle GET streams the object");
+
+  response =
+      bundle_request(&fixture.metadata, "HEAD " + path + " HTTP/1.1\r\n\r\n");
+  check(response.rfind("HTTP/1.1 200 OK\r\n", 0) == 0,
+        "client bundle HEAD returns 200");
+  check(response.find("content-length: 8\r\n") != std::string::npos,
+        "client bundle HEAD reports object size");
+  check(response.find("\r\n\r\n") == response.size() - 4,
+        "client bundle HEAD has no body");
+
+  response = bundle_request(&fixture.metadata,
+                            "GET " + path +
+                                " HTTP/1.1\r\nIf-None-Match: "
+                                "\"sha256:"
+                                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                                "aaaaaaaaaaaaaaaaaa\"\r\n\r\n");
+  check(response.rfind("HTTP/1.1 304 Not Modified\r\n", 0) == 0,
+        "matching client bundle ETag returns 304");
+  check(response.find("\r\n\r\n") == response.size() - 4, "304 has no body");
+}
+
+void test_http1_client_bundle_missing_is_503() {
+  std::string response = bundle_request(
+      &kMetadata,
+      "GET /.well-known/lupine/client/v1/windows/arm64 HTTP/1.1\r\n\r\n");
+  check(response.rfind("HTTP/1.1 503 Service Unavailable\r\n", 0) == 0,
+        "configured platform without an object returns 503");
 }
 
 void test_closed_peer_fails_dispatch() {
@@ -176,6 +267,8 @@ int main() {
   test_http1_get_root();
   test_http1_head_root_has_no_body();
   test_http1_unknown_path_is_404();
+  test_http1_client_bundle_get_head_and_etag();
+  test_http1_client_bundle_missing_is_503();
   test_closed_peer_fails_dispatch();
   printf("\ndispatch_test: %s\n", failures == 0 ? "PASS" : "FAIL");
   return failures == 0 ? 0 : 1;

--- a/h2.cpp
+++ b/h2.cpp
@@ -1,3 +1,4 @@
+#include "client_bundle.h"
 #include "lupine_log.h"
 #include "rpc.h"
 
@@ -104,7 +105,11 @@ struct h2_transport {
   int response_waiters = 0;
   bool transport_failed = false;
   std::string peer_cuda_version;
-  std::string peer_wire_identity;
+  std::string peer_client_etag;
+  std::string client_etag;
+  std::string client_platform;
+  std::string expected_client_etag;
+  std::string client_bundle_dir;
   std::string server_version;
   std::string session_id;
   std::string peer_va_base;
@@ -569,15 +574,12 @@ constexpr char kLupineCudaVersionHeader[] = "x-lupine-cuda-version";
 constexpr char kLupineSessionHeader[] = "x-lupine-session";
 constexpr char kLupineVaBaseHeader[] = "x-lupine-va-base";
 constexpr char kLupineVaSizeHeader[] = "x-lupine-va-size";
-constexpr char kLupineWireIdentityHeader[] = "x-lupine-wire-identity";
+constexpr char kLupineClientEtagHeader[] = "x-lupine-client-etag";
+constexpr char kLupineClientPlatformHeader[] = "x-lupine-client-platform";
 constexpr char kLupineVaWindowBaseHeader[] = "x-lupine-va-window-base";
 constexpr char kLupineVaWindowSizeHeader[] = "x-lupine-va-window-size";
 constexpr char kContentEncodingHeader[] = "content-encoding";
 constexpr char kLz4Encoding[] = "lz4";
-
-#ifndef LUPINE_WIRE_IDENTITY
-#define LUPINE_WIRE_IDENTITY ""
-#endif
 
 std::string h2_hex(uintptr_t value) {
   std::ostringstream result;
@@ -600,14 +602,6 @@ bool h2_parse_hex(const std::string &value, uintptr_t *parsed) {
   return true;
 }
 
-// An empty identity on either side means that peer was built without git and
-// cannot state what it is; treat that as unverifiable and let the connection
-// proceed rather than refusing every source-tarball build.
-bool h2_wire_identity_compatible(const std::string &local,
-                                 const std::string &peer) {
-  return local.empty() || peer.empty() || local == peer;
-}
-
 bool lupine_h2_debug_enabled() {
   const char *debug = getenv("LUPINE_DEBUG");
   if (debug != nullptr && debug[0] != '\0' && strcmp(debug, "0") != 0) {
@@ -624,6 +618,8 @@ int h2_submit_server_response(h2_transport *transport, int32_t stream_id,
     status_text = "200";
   } else if (status == 409) {
     status_text = "409";
+  } else if (status == 426) {
+    status_text = "426";
   }
   std::vector<nghttp2_nv> headers = {h2_nv(":status", status_text)};
   if (!end_stream) {
@@ -633,8 +629,9 @@ int h2_submit_server_response(h2_transport *transport, int32_t stream_id,
     headers.push_back(
         h2_nv(kLupineCudaVersionHeader, transport->server_version.c_str()));
   }
-  if (LUPINE_WIRE_IDENTITY[0] != '\0') {
-    headers.push_back(h2_nv(kLupineWireIdentityHeader, LUPINE_WIRE_IDENTITY));
+  if (!transport->expected_client_etag.empty()) {
+    headers.push_back(h2_nv(kLupineClientEtagHeader,
+                            transport->expected_client_etag.c_str()));
   }
   // State the window on every response, probe included: the client has to know
   // it before it reserves anything, and no single constant fits both platforms.
@@ -694,6 +691,22 @@ int h2_on_frame_recv_callback(nghttp2_session *, const nghttp2_frame *frame,
     transport->request_received = true;
     bool probe = (frame->hd.flags & NGHTTP2_FLAG_END_STREAM) != 0;
     int status = stream.lz4_encoded || probe ? 200 : 400;
+    if (!probe && status == 200 &&
+        (!transport->client_etag.empty() ||
+         !transport->client_platform.empty())) {
+      lupine_client_bundle bundle;
+      bool complete = !transport->client_etag.empty() &&
+                      !transport->client_platform.empty();
+      bool found = complete && lupine_client_bundle_lookup(
+                                   transport->client_bundle_dir.c_str(),
+                                   transport->client_platform, &bundle);
+      if (found) {
+        transport->expected_client_etag = bundle.etag;
+      }
+      if (!found || transport->client_etag != bundle.etag) {
+        status = 426;
+      }
+    }
     bool has_va_base = !stream.requested_va_base.empty();
     bool has_va_size = !stream.requested_va_size.empty();
     if (!probe && (has_va_base || has_va_size)) {
@@ -782,6 +795,14 @@ int h2_on_header_callback(nghttp2_session *, const nghttp2_frame *frame,
           memcmp(name, kLupineSessionHeader, namelen) == 0) {
         transport->session_id.assign(reinterpret_cast<const char *>(value),
                                      valuelen);
+      } else if (namelen == strlen(kLupineClientEtagHeader) &&
+                 memcmp(name, kLupineClientEtagHeader, namelen) == 0) {
+        transport->client_etag.assign(reinterpret_cast<const char *>(value),
+                                      valuelen);
+      } else if (namelen == strlen(kLupineClientPlatformHeader) &&
+                 memcmp(name, kLupineClientPlatformHeader, namelen) == 0) {
+        transport->client_platform.assign(reinterpret_cast<const char *>(value),
+                                          valuelen);
       } else if (namelen == strlen(kLupineVaBaseHeader) &&
                  memcmp(name, kLupineVaBaseHeader, namelen) == 0) {
         stream.requested_va_base.assign(reinterpret_cast<const char *>(value),
@@ -803,10 +824,10 @@ int h2_on_header_callback(nghttp2_session *, const nghttp2_frame *frame,
                                         valuelen);
     return 0;
   }
-  if (namelen == strlen(kLupineWireIdentityHeader) &&
-      memcmp(name, kLupineWireIdentityHeader, namelen) == 0) {
-    transport->peer_wire_identity.assign(reinterpret_cast<const char *>(value),
-                                         valuelen);
+  if (namelen == strlen(kLupineClientEtagHeader) &&
+      memcmp(name, kLupineClientEtagHeader, namelen) == 0) {
+    transport->peer_client_etag.assign(reinterpret_cast<const char *>(value),
+                                       valuelen);
     return 0;
   }
   if (namelen == strlen(kLupineVaWindowBaseHeader) &&
@@ -1005,6 +1026,9 @@ int h2_init_direct(conn_t *conn, bool server, bool probe,
   if (metadata != nullptr && metadata->backend_version != nullptr) {
     transport->server_version = metadata->backend_version;
   }
+  if (metadata != nullptr && metadata->client_bundle_dir != nullptr) {
+    transport->client_bundle_dir = metadata->client_bundle_dir;
+  }
 
   nghttp2_session_callbacks *callbacks = nullptr;
   if (nghttp2_session_callbacks_new(&callbacks) != 0) {
@@ -1075,6 +1099,18 @@ int h2_init_direct(conn_t *conn, bool server, bool probe,
     };
     if (!probe) {
       headers.push_back(h2_nv(kContentEncodingHeader, kLz4Encoding));
+      const char *client_etag = getenv("LUPINE_CLIENT_ETAG");
+      const char *client_platform = getenv("LUPINE_CLIENT_PLATFORM");
+      if (client_etag != nullptr && client_etag[0] != '\0') {
+        transport->client_etag = client_etag;
+        headers.push_back(
+            h2_nv(kLupineClientEtagHeader, transport->client_etag.c_str()));
+      }
+      if (client_platform != nullptr && client_platform[0] != '\0') {
+        transport->client_platform = client_platform;
+        headers.push_back(h2_nv(kLupineClientPlatformHeader,
+                                transport->client_platform.c_str()));
+      }
       if (session_id != nullptr && session_id[0] != '\0') {
         headers.push_back(h2_nv(kLupineSessionHeader, session_id));
       }
@@ -1115,13 +1151,6 @@ int h2_init_direct(conn_t *conn, bool server, bool probe,
 }
 
 } // namespace
-
-const char *lupine_wire_identity(void) { return LUPINE_WIRE_IDENTITY; }
-
-bool lupine_wire_identity_compatible(const char *local, const char *peer) {
-  return h2_wire_identity_compatible(local == nullptr ? "" : local,
-                                     peer == nullptr ? "" : peer);
-}
 
 int rpc_http2_read_stream(conn_t *conn, int32_t stream_id, void *data,
                           size_t size) {
@@ -1451,18 +1480,18 @@ int rpc_http2_client_await_ready(conn_t *conn) {
                        h2_parse_hex(transport->peer_va_base, &peer_base) &&
                        h2_parse_hex(transport->peer_va_size, &peer_size) &&
                        peer_base == conn->va_base && peer_size == conn->va_size;
-  std::string peer_identity = transport->peer_wire_identity;
+  std::string expected_client_etag = transport->peer_client_etag;
   pthread_mutex_unlock(&transport->session_mutex);
 
-  // Check the build before the arena verdict: a mismatch is fatal, so reporting
-  // it as an arena conflict would send the caller off retrying other slots.
-  if (!h2_wire_identity_compatible(LUPINE_WIRE_IDENTITY, peer_identity)) {
-    LUPINE_LOG_ERROR("LUPINE server was built from "
-                     << (peer_identity.empty() ? "an unstated revision"
-                                               : peer_identity.c_str())
-                     << ", this client from " << LUPINE_WIRE_IDENTITY
-                     << "; rebuild both from the same tree");
-    return LUPINE_RPC_HTTP2_IDENTITY_MISMATCH;
+  // The server can move to a new bundle between discovery and connect. Do not
+  // misreport that as an arena conflict; the launcher needs to refetch and
+  // restart the process before any CUDA state exists.
+  if (responded && status == 426) {
+    LUPINE_LOG_ERROR("LUPINE client bundle is no longer current"
+                     << (expected_client_etag.empty()
+                             ? ""
+                             : "; server expects " + expected_client_etag));
+    return LUPINE_RPC_HTTP2_CLIENT_MISMATCH;
   }
   if (conn->va_size == 0) {
     return responded && status == 200 ? 0 : -1;
@@ -1526,19 +1555,6 @@ bool rpc_http2_peer_va_window(conn_t *conn, lupine_va_window *window) {
   window->base = base;
   window->size = static_cast<size_t>(size);
   return true;
-}
-
-// Valid until the transport is destroyed. A server built without git advertises
-// nothing, so an empty result means "unstated", not "mismatched".
-const char *rpc_http2_peer_wire_identity(conn_t *conn) {
-  if (conn == nullptr || conn->http2 == nullptr) {
-    return "";
-  }
-  auto *transport = static_cast<h2_transport *>(conn->http2);
-  pthread_mutex_lock(&transport->session_mutex);
-  const char *identity = transport->peer_wire_identity.c_str();
-  pthread_mutex_unlock(&transport->session_mutex);
-  return identity;
 }
 
 int rpc_http2_server_init(conn_t *conn) {

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -10,6 +10,8 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <nghttp2/nghttp2.h>
 #include <string>
@@ -422,41 +424,75 @@ void test_head_probe_cuda_version_metadata(const char *expected_cuda_version) {
   }
 }
 
-// The preflight refuses a peer only when both sides state an identity and they
-// differ; an unstated identity must stay connectable so builds without git and
-// servers predating the header are not locked out.
-void test_wire_identity_compatibility_rule() {
-  require(lupine_wire_identity_compatible("abc", "abc"),
-          "matching identities were rejected");
-  require(!lupine_wire_identity_compatible("abc", "def"),
-          "mismatched identities were accepted");
-  require(lupine_wire_identity_compatible("", "def"),
-          "unstated local identity was treated as a mismatch");
-  require(lupine_wire_identity_compatible("abc", ""),
-          "unstated peer identity was treated as a mismatch");
-  require(lupine_wire_identity_compatible(nullptr, nullptr),
-          "null identities were treated as a mismatch");
-}
+struct client_bundle_fixture {
+  std::filesystem::path root;
+  std::string etag =
+      "\"sha256:"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"";
 
-// The identity rides the response on the session's own connection, so the
-// build check costs a round trip rather than a second dial.
-void test_client_await_ready_reports_wire_identity() {
+  client_bundle_fixture() {
+    char directory[] = "/tmp/lupine-h2-bundle-test-XXXXXX";
+    const char *created = mkdtemp(directory);
+    require(created != nullptr, "create h2 bundle fixture failed");
+    root = created;
+    std::filesystem::path platform = root / "linux" / "amd64";
+    std::filesystem::create_directories(platform);
+    std::ofstream(platform / "client.zip", std::ios::binary) << "bundle";
+    std::ofstream(platform / "client.zip.etag") << etag << '\n';
+    std::ofstream(platform / "client.zip.digest") << "sha-256=:YnVuZGxl:\n";
+  }
+
+  ~client_bundle_fixture() { std::filesystem::remove_all(root); }
+};
+
+// The selected object's ETag rides the session's own connection, so the
+// server can close a discovery/connect race without a second dial.
+void test_client_await_ready_accepts_current_bundle() {
+  client_bundle_fixture fixture;
+  lupine_test_setenv("LUPINE_CLIENT_ETAG", fixture.etag.c_str());
+  lupine_test_setenv("LUPINE_CLIENT_PLATFORM", "linux/amd64");
   h2_pair pair;
   init_pair_sockets(&pair);
 
-  std::string peer;
   int ready = -1;
   std::thread client([&] {
     require(rpc_http2_client_init(&pair.client) == 0, "client h2 init failed");
     ready = rpc_http2_client_await_ready(&pair.client);
-    peer = rpc_http2_peer_wire_identity(&pair.client);
   });
-  require(rpc_http2_server_init(&pair.server) == 0, "server h2 init failed");
+  rpc_http2_server_metadata metadata = {nullptr, fixture.root.c_str()};
+  require(rpc_http2_server_init_with_metadata(&pair.server, &metadata) == 0,
+          "server rejected current client bundle");
   client.join();
 
-  require(ready == 0, "matching builds were not accepted");
-  require(peer == lupine_wire_identity(),
-          "response did not carry this build's wire identity");
+  lupine_test_unsetenv("LUPINE_CLIENT_ETAG");
+  lupine_test_unsetenv("LUPINE_CLIENT_PLATFORM");
+  require(ready == 0, "current client bundle was not accepted");
+}
+
+void test_client_await_ready_rejects_stale_bundle() {
+  client_bundle_fixture fixture;
+  lupine_test_setenv(
+      "LUPINE_CLIENT_ETAG",
+      "\"sha256:"
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"");
+  lupine_test_setenv("LUPINE_CLIENT_PLATFORM", "linux/amd64");
+  h2_pair pair;
+  init_pair_sockets(&pair);
+
+  int ready = 0;
+  std::thread client([&] {
+    require(rpc_http2_client_init(&pair.client) == 0, "client h2 init failed");
+    ready = rpc_http2_client_await_ready(&pair.client);
+  });
+  rpc_http2_server_metadata metadata = {nullptr, fixture.root.c_str()};
+  require(rpc_http2_server_init_with_metadata(&pair.server, &metadata) == 1,
+          "server dispatched a stale client bundle");
+  client.join();
+
+  lupine_test_unsetenv("LUPINE_CLIENT_ETAG");
+  lupine_test_unsetenv("LUPINE_CLIENT_PLATFORM");
+  require(ready == LUPINE_RPC_HTTP2_CLIENT_MISMATCH,
+          "stale client bundle did not report a client mismatch");
 }
 
 // Arena bookkeeping is pure arithmetic over the conn fields, so it is checked
@@ -1630,8 +1666,8 @@ int main() {
   RUN_CASE(test_server_to_client_after_request_headers());
   RUN_CASE(test_head_probe_cuda_version_metadata(LUPINE_CUDA_VERSION));
   RUN_CASE(test_head_probe_cuda_version_metadata(nullptr));
-  RUN_CASE(test_wire_identity_compatibility_rule());
-  RUN_CASE(test_client_await_ready_reports_wire_identity());
+  RUN_CASE(test_client_await_ready_accepts_current_bundle());
+  RUN_CASE(test_client_await_ready_rejects_stale_bundle());
   RUN_CASE(test_client_await_ready_reports_va_window());
   RUN_CASE(test_va_window_and_aliases_are_disjoint());
   RUN_CASE(test_va_claim_bumps_within_arena());

--- a/python/README.md
+++ b/python/README.md
@@ -1,11 +1,12 @@
 # lupine Python package
 
-CUDA on any host. The wheel bundles the LUPINE native client shims —
+CUDA on any host. The configured LUPINE server publishes its compatible native client shims —
 CUDA **driver API** (`libcuda` / `nvcuda.dll`), CUDA **runtime API**
 (`libcudart` / `cudart64_13.dll`), and **NVML** — for Linux (x86_64,
 aarch64), macOS (universal2), and Windows (amd64, arm64), plus a small
 PyTorch adapter. No NVIDIA software, CUDA toolkit, or container runtime
-is needed on the client.
+is needed on the client. Wheels retain a bundled copy during the rollout, but
+server selection is authoritative whenever `LUPINE_SERVER` is configured.
 
 ```python
 import lupine
@@ -21,16 +22,17 @@ with lupine.connect(host="gpu-host:14833") as session:
 ## How it works
 
 ```
-torch / any CUDA binary ─▶ bundled shims ──RPC──▶ lupine server ─▶ GPU
+torch / any CUDA binary ─▶ selected shims ──RPC──▶ lupine server ─▶ GPU
 ```
 
-`lupine.connect()` exports `LUPINE_SERVER` and preloads the bundled shims
-with global visibility before CUDA initializes, so:
+`lupine.connect()` exports `LUPINE_SERVER`, downloads and verifies the exact
+client object selected by that server, and preloads it with global visibility
+before CUDA initializes, so:
 
 - **PyTorch builds with CUDA** keep their normal `torch.device("cuda:N")`
   dispatch; every CUDA call lands on the LUPINE shims.
 - **Natively compiled CUDA code** (nvcc/clang binaries) resolves the
-  bundled shims directly — including on platforms where no NVIDIA
+  selected shims directly — including on platforms where no NVIDIA
   runtime has ever shipped.
 - **CPU-only PyTorch builds** cannot gain a CUDA backend by linking (the
   backend is compiled out); use the shims directly via ctypes, or run such
@@ -43,10 +45,10 @@ with global visibility before CUDA initializes, so:
   is the default. Returns a `Session`; usable with or without `with`.
 - `session.devices()` / `session.device(i=0)` — `torch.device("cuda:N")`
   objects from LUPINE's virtual topology across all servers.
-- `lupine.load_native()` / `lupine.libdir()` — load/inspect the bundled
+- `lupine.load_native()` / `lupine.libdir()` — load/inspect the selected
   shims without torch.
 - `LUPINE_LIBDIR` — load shims from a custom directory (e.g. a newer build).
-- `TRITON_LIBCUDA_PATH` — defaults to the bundled Linux shim directory so
+- `TRITON_LIBCUDA_PATH` — defaults to the selected shim directory so
   `torch.compile` can link Triton's launcher; an explicit value is preserved.
 - `LUPINE_DISABLE_LOCAL=0` — include local GPUs (when present) in the
   topology ahead of the remote ones.
@@ -65,7 +67,7 @@ python existing_torch_program.py
 
 The companion package installs a Python startup hook that sets
 `LUPINE_SERVER=demo.lupinemachines.com:14833` only when the application has
-not configured a server, then preloads the bundled native shims before the
+not configured a server, then resolves and preloads its selected native shims before the
 application imports PyTorch. An explicit `LUPINE_SERVER` always wins. Set
 `LUPINE_AUTO=0` to disable the hook for one process.
 

--- a/python/auto/README.md
+++ b/python/auto/README.md
@@ -1,7 +1,7 @@
 # lupine-auto
 
 This companion package is installed by `lupine[auto]`. It activates
-LUPINE's bundled native shims at Python startup and defaults `LUPINE_SERVER`
+LUPINE's server-selected native shims at Python startup and defaults `LUPINE_SERVER`
 to the hosted demo when no server was explicitly configured.
 
 Set `LUPINE_AUTO=0` to disable the startup hook for a process.

--- a/python/build.py
+++ b/python/build.py
@@ -3,6 +3,7 @@
 
 Usage:
     python build.py stage <platform-tag> <dir-with-libs> [<dir>...]
+    python build.py bundles <output-dir> <source-revision>
     python build.py build [--uv]
 
 ``stage`` copies the shims for one platform into ``lupine/_libs/<tag>/``;
@@ -14,9 +15,14 @@ win-amd64, win-arm64.
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import io
+import json
 import shutil
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
@@ -25,12 +31,21 @@ ROOT = Path(__file__).resolve().parent
 def _libs_dir() -> Path:
     return ROOT / "lupine" / "_libs"
 
+
 EXPECTED = {
     "linux-x86_64": ("libcuda.so.1", "libcudart.so.13", "libnvidia-ml.so.1"),
     "linux-aarch64": ("libcuda.so.1", "libcudart.so.13", "libnvidia-ml.so.1"),
     "macosx-universal2": ("libcuda.dylib", "libcudart.dylib", "libnvidia-ml.dylib"),
     "win-amd64": ("nvcuda.dll", "cudart64_13.dll", "nvml.dll"),
     "win-arm64": ("nvcuda.dll", "cudart64_13.dll", "nvml.dll"),
+}
+
+CLIENT_BUNDLES = {
+    ("linux/amd64",): "linux-x86_64",
+    ("linux/arm64",): "linux-aarch64",
+    ("macos/amd64", "macos/arm64"): "macosx-universal2",
+    ("windows/amd64",): "win-amd64",
+    ("windows/arm64",): "win-arm64",
 }
 
 
@@ -49,7 +64,9 @@ def stage(tag: str, sources: list[Path]) -> int:
                 staged.append(name)
     missing = [name for name in EXPECTED[tag] if name not in staged]
     if missing:
-        print(f"warning: {tag}: missing {missing} (searched: {[str(s) for s in sources]})")
+        print(
+            f"warning: {tag}: missing {missing} (searched: {[str(s) for s in sources]})"
+        )
     else:
         print(f"staged {tag}: {sorted(staged)}")
     return 0
@@ -74,6 +91,100 @@ def build(use_uv: bool) -> int:
     return subprocess.call([sys.executable, "-m", "build"], cwd=ROOT)
 
 
+def _zip_entry(
+    name: str, contents: bytes, mode: int = 0o644
+) -> tuple[zipfile.ZipInfo, bytes]:
+    entry = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+    entry.create_system = 3
+    entry.external_attr = mode << 16
+    entry.compress_type = zipfile.ZIP_DEFLATED
+    return entry, contents
+
+
+def _bundle_bytes(tag: str, platforms: tuple[str, ...], revision: str) -> bytes:
+    source = _libs_dir() / tag
+    missing = [name for name in EXPECTED[tag] if not (source / name).is_file()]
+    if missing:
+        raise FileNotFoundError(f"{tag}: missing native libraries: {missing}")
+
+    files = []
+    payloads: list[tuple[zipfile.ZipInfo, bytes]] = []
+    for name in EXPECTED[tag]:
+        contents = (source / name).read_bytes()
+        files.append(
+            {
+                "path": name,
+                "sha256": hashlib.sha256(contents).hexdigest(),
+                "mode": "0755",
+            }
+        )
+        payloads.append(_zip_entry(name, contents, 0o755))
+    manifest = json.dumps(
+        {
+            "schema": 1,
+            "platforms": list(platforms),
+            "source_revision": revision,
+            "files": files,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+    output = io.BytesIO()
+    with zipfile.ZipFile(
+        output, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+    ) as archive:
+        entry, contents = _zip_entry("manifest.json", manifest)
+        archive.writestr(entry, contents)
+        for entry, contents in payloads:
+            archive.writestr(entry, contents)
+    return output.getvalue()
+
+
+def bundles(output: Path, revision: str) -> int:
+    """Build the server-served, content-addressed client objects."""
+
+    if not revision:
+        print("source revision must not be empty")
+        return 2
+    output.mkdir(parents=True, exist_ok=True)
+    entries: dict[str, object] = {}
+    index: dict[str, object] = {
+        "schema": 1,
+        "source_revision": revision,
+        "bundles": entries,
+    }
+
+    try:
+        for platforms, tag in CLIENT_BUNDLES.items():
+            contents = _bundle_bytes(tag, platforms, revision)
+            digest = hashlib.sha256(contents).digest()
+            digest_hex = digest.hex()
+            etag = f'"sha256:{digest_hex}"'
+            content_digest = f"sha-256=:{base64.b64encode(digest).decode()}:"
+            for platform_name in platforms:
+                destination = output / platform_name
+                destination.mkdir(parents=True, exist_ok=True)
+                bundle_path = destination / "client.zip"
+                bundle_path.write_bytes(contents)
+                bundle_path.with_suffix(".zip.etag").write_text(etag + "\n")
+                bundle_path.with_suffix(".zip.digest").write_text(content_digest + "\n")
+                entries[platform_name] = {
+                    "etag": etag,
+                    "content_digest": content_digest,
+                    "size": len(contents),
+                }
+    except FileNotFoundError as exc:
+        print(exc)
+        return 1
+
+    (output / "index.json").write_text(
+        json.dumps(index, indent=2, sort_keys=True) + "\n"
+    )
+    print(f"built {len(entries)} client bundle routes in {output}")
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 2:
         print(__doc__)
@@ -85,6 +196,11 @@ def main(argv: list[str]) -> int:
         return stage(argv[2], [Path(p) for p in argv[3:]])
     if argv[1] == "build":
         return build(use_uv=argv[2:3] != ["--no-uv"])
+    if argv[1] == "bundles":
+        if len(argv) != 4:
+            print("bundles needs: <output-dir> <source-revision>")
+            return 2
+        return bundles(Path(argv[2]), argv[3])
     print(__doc__)
     return 2
 

--- a/python/lupine/__init__.py
+++ b/python/lupine/__init__.py
@@ -1,7 +1,7 @@
 """PyTorch adapter for LUPINE-backed CUDA devices.
 
 ``lupine.connect(...)`` points the process at one or more LUPINE GPU
-servers and preloads the bundled native shims (driver API, runtime API,
+servers and preloads the server-selected native shims (driver API, runtime API,
 NVML) so ordinary CUDA consumers — PyTorch included — transparently run on
 the remote GPUs:
 
@@ -98,7 +98,7 @@ def _servers_from_env() -> tuple[str, ...]:
 class Session:
     """A process-local LUPINE connection declaration.
 
-    Entering the session exports ``LUPINE_SERVER`` and loads the bundled
+    Entering the session exports ``LUPINE_SERVER`` and loads the selected
     native shims; both stay in effect for the process after exit (library
     unloading is not possible once CUDA state references the shims).
     """
@@ -222,7 +222,7 @@ def is_configured() -> bool:
 
 
 def load_native(*, missing_ok: bool = True) -> dict[str, str]:
-    """Load the bundled native shims; see :mod:`lupine._native`."""
+    """Load the server-selected native shims; see :mod:`lupine._native`."""
 
     from . import _native
 
@@ -230,7 +230,7 @@ def load_native(*, missing_ok: bool = True) -> dict[str, str]:
 
 
 def libdir() -> Any:
-    """Directory holding the bundled native shims, if any."""
+    """Directory holding the selected native shims, if any."""
 
     from . import _native
 

--- a/python/lupine/_bundles.py
+++ b/python/lupine/_bundles.py
@@ -1,0 +1,288 @@
+"""Resolve and cache the native client object selected by a LUPINE server."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import os
+import platform
+import re
+import shutil
+import stat
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+_ENDPOINT = "/.well-known/lupine/client/v1/"
+_MAX_BUNDLE_BYTES = 128 * 1024 * 1024
+_ETAG = re.compile(r'^"sha256:([0-9a-f]{64})"$')
+
+
+def platform_name() -> str | None:
+    """Return the public OS/architecture key for this Python process."""
+
+    machine = platform.machine().lower()
+    arch = {
+        "amd64": "amd64",
+        "x86_64": "amd64",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }.get(machine)
+    if arch is None:
+        return None
+    os_name = {"linux": "linux", "darwin": "macos", "win32": "windows"}.get(
+        sys.platform
+    )
+    return None if os_name is None else f"{os_name}/{arch}"
+
+
+def _cache_root() -> Path:
+    override = os.environ.get("LUPINE_CACHE_DIR")
+    if override:
+        return Path(override)
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base) / "Lupine" / "Cache"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "lupine"
+    return Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "lupine"
+
+
+def _bundle_url(server: str, platform_key: str) -> str:
+    from urllib.parse import urlsplit, urlunsplit
+
+    value = server.strip()
+    if "://" not in value:
+        value = "http://" + value
+    parsed = urlsplit(value)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(f"invalid LUPINE_SERVER endpoint: {server!r}")
+    return urlunsplit((parsed.scheme, parsed.netloc, _ENDPOINT + platform_key, "", ""))
+
+
+def _etag_digest(etag: str) -> str:
+    match = _ETAG.fullmatch(etag)
+    if match is None:
+        raise ValueError(f"server returned an invalid strong ETag: {etag!r}")
+    return match.group(1)
+
+
+def _selector_path(cache: Path, server: str, platform_key: str) -> Path:
+    digest = hashlib.sha256(f"{server}\0{platform_key}".encode()).hexdigest()
+    return cache / "selectors" / digest
+
+
+def _read_selector(path: Path) -> str | None:
+    try:
+        value = path.read_text().strip()
+        _etag_digest(value)
+        return value
+    except (OSError, ValueError):
+        return None
+
+
+def _write_selector(path: Path, etag: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=".selector-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as output:
+            output.write(etag + "\n")
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def _manifest(directory: Path) -> dict[str, Any]:
+    with (directory / "manifest.json").open(encoding="utf-8") as source:
+        value = json.load(source)
+    if not isinstance(value, dict):
+        raise TypeError("client bundle manifest is not an object")
+    return value
+
+
+def _validate_directory(
+    directory: Path, etag: str, platform_key: str, expected_names: tuple[str, ...]
+) -> bool:
+    try:
+        if (directory / ".etag").read_text().strip() != etag:
+            return False
+        manifest = _manifest(directory)
+        if manifest.get("schema") != 1 or platform_key not in manifest.get(
+            "platforms", []
+        ):
+            return False
+        files = manifest.get("files")
+        if not isinstance(files, list):
+            return False
+        by_name = {item["path"]: item for item in files if isinstance(item, dict)}
+        if set(by_name) != set(expected_names):
+            return False
+        for name in expected_names:
+            contents = (directory / name).read_bytes()
+            if hashlib.sha256(contents).hexdigest() != by_name[name].get("sha256"):
+                return False
+        return True
+    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def _verified_manifest(
+    archive: zipfile.ZipFile, platform_key: str, expected_names: tuple[str, ...]
+) -> dict[str, Any]:
+    entries = archive.infolist()
+    if sum(entry.file_size for entry in entries) > _MAX_BUNDLE_BYTES:
+        raise ValueError("client bundle expands beyond the size limit")
+    names: set[str] = set()
+    for entry in entries:
+        path = PurePosixPath(entry.filename)
+        if path.is_absolute() or ".." in path.parts or len(path.parts) != 1:
+            raise ValueError(f"unsafe client bundle path: {entry.filename!r}")
+        if stat.S_ISLNK(entry.external_attr >> 16):
+            raise ValueError(f"client bundle contains a symlink: {entry.filename!r}")
+        if entry.filename in names:
+            raise ValueError(f"duplicate client bundle path: {entry.filename!r}")
+        names.add(entry.filename)
+    if names != {"manifest.json", *expected_names}:
+        raise ValueError("client bundle contains an unexpected file set")
+
+    manifest = json.loads(archive.read("manifest.json"))
+    if not isinstance(manifest, dict) or manifest.get("schema") != 1:
+        raise ValueError("unsupported client bundle manifest")
+    if platform_key not in manifest.get("platforms", []):
+        raise ValueError("client bundle does not support this platform")
+    files = manifest.get("files")
+    if not isinstance(files, list):
+        raise TypeError("client bundle manifest has no file list")
+    by_name = {item.get("path"): item for item in files if isinstance(item, dict)}
+    if set(by_name) != set(expected_names):
+        raise ValueError("client bundle manifest has an unexpected file set")
+    for name in expected_names:
+        contents = archive.read(name)
+        if hashlib.sha256(contents).hexdigest() != by_name[name].get("sha256"):
+            raise ValueError(f"client bundle file hash does not match: {name}")
+    return manifest
+
+
+def _install(
+    cache: Path,
+    body: bytes,
+    etag: str,
+    platform_key: str,
+    expected_names: tuple[str, ...],
+) -> Path:
+    digest = _etag_digest(etag)
+    if hashlib.sha256(body).hexdigest() != digest:
+        raise ValueError("client bundle bytes do not match the server ETag")
+    destination = cache / "clients" / digest
+    if _validate_directory(destination, etag, platform_key, expected_names):
+        return destination
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=".client-", dir=destination.parent))
+    try:
+        with zipfile.ZipFile(io.BytesIO(body)) as archive:
+            manifest = _verified_manifest(archive, platform_key, expected_names)
+            for item in manifest["files"]:
+                name = item["path"]
+                target = temporary / name
+                target.write_bytes(archive.read(name))
+                target.chmod(int(item.get("mode", "0755"), 8))
+            (temporary / "manifest.json").write_bytes(archive.read("manifest.json"))
+        (temporary / ".etag").write_text(etag + "\n")
+
+        if destination.exists():
+            shutil.rmtree(destination)
+        try:
+            os.replace(temporary, destination)
+        except OSError:
+            if not _validate_directory(destination, etag, platform_key, expected_names):
+                raise
+        return destination
+    finally:
+        shutil.rmtree(temporary, ignore_errors=True)
+
+
+def _download(
+    server: str,
+    platform_key: str,
+    expected_names: tuple[str, ...],
+    *,
+    unconditional: bool = False,
+) -> tuple[Path, str]:
+    cache = _cache_root()
+    selector = _selector_path(cache, server, platform_key)
+    previous = None if unconditional else _read_selector(selector)
+    headers = {"Accept": "application/vnd.lupine.client-bundle.v1+zip"}
+    session = os.environ.get("LUPINE_SESSION")
+    if session:
+        headers["x-lupine-session"] = session
+    if previous:
+        candidate = cache / "clients" / _etag_digest(previous)
+        if _validate_directory(candidate, previous, platform_key, expected_names):
+            headers["If-None-Match"] = previous
+
+    request = urllib.request.Request(
+        _bundle_url(server, platform_key), headers=headers, method="GET"
+    )
+    try:
+        response = urllib.request.urlopen(request, timeout=300)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 304 and previous:
+            candidate = cache / "clients" / _etag_digest(previous)
+            if _validate_directory(candidate, previous, platform_key, expected_names):
+                return candidate, previous
+            return _download(
+                server,
+                platform_key,
+                expected_names,
+                unconditional=True,
+            )
+        raise
+
+    with response:
+        etag = response.headers.get("ETag", "")
+        _etag_digest(etag)
+        body = response.read(_MAX_BUNDLE_BYTES + 1)
+        if len(body) > _MAX_BUNDLE_BYTES:
+            raise ValueError("client bundle exceeds the download size limit")
+        content_digest = response.headers.get("Content-Digest")
+    digest = hashlib.sha256(body).digest()
+    expected_digest = f"sha-256=:{base64.b64encode(digest).decode()}:"
+    if content_digest and content_digest != expected_digest:
+        raise ValueError("client bundle does not match Content-Digest")
+
+    directory = _install(cache, body, etag, platform_key, expected_names)
+    _write_selector(selector, etag)
+    return directory, etag
+
+
+def resolve(
+    servers: tuple[str, ...], expected_names: tuple[str, ...]
+) -> tuple[Path, str, str]:
+    """Resolve every endpoint and require one compatible native object."""
+
+    platform_key = platform_name()
+    if platform_key is None:
+        raise ValueError(f"unsupported LUPINE client platform: {sys.platform}")
+    selected: tuple[Path, str] | None = None
+    for server in servers:
+        current = _download(server, platform_key, expected_names)
+        if selected is not None and current[1] != selected[1]:
+            raise ValueError(
+                "LUPINE servers selected different client bundles: "
+                f"{selected[1]} != {current[1]}"
+            )
+        selected = current
+    if selected is None:
+        raise ValueError("no LUPINE server was configured")
+    return selected[0], selected[1], platform_key

--- a/python/lupine/_native.py
+++ b/python/lupine/_native.py
@@ -1,7 +1,9 @@
 """Native LUPINE client library loader.
 
-The ``lupine`` wheel ships the LUPINE client shims for every supported
-platform under ``lupine/_libs/<tag>/``:
+LUPINE servers publish the compatible client shims for every supported
+platform. The loader downloads the exact object selected by ``LUPINE_SERVER``
+before CUDA consumers are imported. Wheels may retain ``lupine/_libs`` as a
+release-transition fallback when no server is configured.
 
 ============ ============================== =========================== =======================
 Platform    driver shim (CUDA)             runtime shim                 NVML shim
@@ -21,7 +23,7 @@ stack exists, in front of) the real libraries:
   call to the LUPINE server.
 * Natively compiled CUDA code (nvcc/clang) resolves both shims directly.
 * On platforms without any NVIDIA runtime (macOS, GPU-less Windows hosts)
-  the bundled ``libcudart`` is the only runtime available, so CUDA binaries
+  the selected ``libcudart`` is the only runtime available, so CUDA binaries
   keep working unmodified.
 
 The loader is dependency-free (stdlib only) and never imports torch.
@@ -33,6 +35,8 @@ import ctypes
 import os
 import sys
 from pathlib import Path
+
+from . import _bundles
 
 # Library file names per platform tag shipped in the wheel.
 _LIBS = {
@@ -51,49 +55,53 @@ _DIR_BY_TAG = {
     "win-arm64": "win-arm64",
 }
 
+_TAG_BY_PLATFORM = {
+    "linux/amd64": "linux-x86_64",
+    "linux/arm64": "linux-aarch64",
+    "macos/amd64": "macosx-universal2",
+    "macos/arm64": "macosx-universal2",
+    "windows/amd64": "win-amd64",
+    "windows/arm64": "win-arm64",
+}
+
 _loaded: dict[str, str] = {}
 
 
 def _platform_dir() -> Path | None:
-    # Under WOW64, PROCESSOR_ARCHITECTURE reports the emulated process arch
-    # and PROCESSOR_ARCHITEW6432 the real machine.
-    raw = os.environ.get(
-        "PROCESSOR_ARCHITEW6432", os.environ.get("PROCESSOR_ARCHITECTURE", "")
-    ).lower()
-    machine = {
-        "amd64": "amd64",
-        "x86_64": "x86_64",
-        "arm64": "arm64",
-        "aarch64": "aarch64",
-    }.get(raw)
-    if sys.platform == "win32":
-        if machine in ("amd64", "x86_64"):
-            tag = "win-amd64"
-        elif machine in ("arm64", "aarch64"):
-            tag = "win-arm64"
-        else:
-            tag = None
-    elif sys.platform == "darwin":
-        # The wheel ships one universal2 slice set for macOS.
-        tag = "macosx-universal2"
-    else:
-        import platform
-
-        arch = platform.machine().lower()
-        tag = "linux-x86_64" if arch in ("x86_64", "amd64") else (
-            "linux-aarch64" if arch in ("aarch64", "arm64") else None
-        )
+    platform_key = _bundles.platform_name()
+    tag = None if platform_key is None else _TAG_BY_PLATFORM.get(platform_key)
     if tag is None:
         return None
     return Path(__file__).resolve().parent / "_libs" / _DIR_BY_TAG[tag]
 
 
 def libdir() -> Path | None:
-    """Directory holding the native shims for this platform, if bundled."""
+    """Directory holding the selected native shims for this platform."""
 
     override = os.environ.get("LUPINE_LIBDIR")
     if override:
         return Path(override)
+    servers = tuple(
+        value.strip()
+        for value in os.environ.get("LUPINE_SERVER", "").split(",")
+        if value.strip()
+    )
+    if servers:
+        from . import LupineError
+
+        names = _LIBS.get(sys.platform)
+        if names is None:
+            raise LupineError(f"Unsupported LUPINE client platform: {sys.platform}")
+        try:
+            directory, etag, platform_key = _bundles.resolve(servers, names)
+        except Exception as exc:
+            raise LupineError(
+                f"Could not resolve the server's LUPINE client: {exc}"
+            ) from exc
+        os.environ["LUPINE_LIBDIR"] = str(directory)
+        os.environ["LUPINE_CLIENT_ETAG"] = etag
+        os.environ["LUPINE_CLIENT_PLATFORM"] = platform_key
+        return directory
     return _platform_dir()
 
 
@@ -102,19 +110,24 @@ def load(*, missing_ok: bool = True) -> dict[str, str]:
 
     Returns a map of library name to loaded path. Idempotent: later calls
     only load libraries not already loaded into this process. Raises
-    ``LupineError`` (from :mod:`lupine`) when a bundled library is missing
+    ``LupineError`` (from :mod:`lupine`) when a selected library is missing
     and ``missing_ok`` is false.
     """
 
     from . import LupineError
 
     names = _LIBS.get(sys.platform)
-    directory = libdir()
+    try:
+        directory = libdir()
+    except LupineError:
+        if missing_ok:
+            return dict(_loaded)
+        raise
     if names is None or directory is None or not directory.is_dir():
         if missing_ok:
             return dict(_loaded)
         raise LupineError(
-            "No bundled LUPINE native libraries for this platform "
+            "No LUPINE native libraries for this platform "
             f"({sys.platform}); set LUPINE_LIBDIR or install a wheel with "
             "lupine._libs."
         )
@@ -123,7 +136,7 @@ def load(*, missing_ok: bool = True) -> dict[str, str]:
         # LoadLibrary search order includes directories added here; CUDA
         # consumers load "nvcuda.dll" by name.
         os.add_dll_directory(str(directory))
-    elif sys.platform == "linux" and (directory / "libcuda.so.1").is_file():
+    elif sys.platform in ("linux", "darwin") and (directory / names[0]).is_file():
         # Triton compiles a small launcher against libcuda and therefore needs
         # a filesystem directory even when the shim is already RTLD_GLOBAL.
         os.environ.setdefault("TRITON_LIBCUDA_PATH", str(directory))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "lupine"
 version = "2.0.1"
-description = "CUDA on any host: bundled LUPINE driver/runtime shims plus PyTorch adapter"
+description = "CUDA on any host: server-selected LUPINE shims plus PyTorch adapter"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/python/tests/test_build_bundles.py
+++ b/python/tests/test_build_bundles.py
@@ -1,0 +1,50 @@
+import hashlib
+import json
+import zipfile
+
+import build
+
+
+def test_builds_every_client_route_with_strong_etags(monkeypatch, tmp_path):
+    libs = tmp_path / "libs"
+    for tag, names in build.EXPECTED.items():
+        directory = libs / tag
+        directory.mkdir(parents=True)
+        for name in names:
+            (directory / name).write_bytes(f"{tag}/{name}".encode())
+    monkeypatch.setattr(build, "_libs_dir", lambda: libs)
+
+    output = tmp_path / "bundles"
+    assert build.bundles(output, "deadbeef") == 0
+
+    index = json.loads((output / "index.json").read_text())
+    assert set(index["bundles"]) == {
+        "linux/amd64",
+        "linux/arm64",
+        "macos/amd64",
+        "macos/arm64",
+        "windows/amd64",
+        "windows/arm64",
+    }
+    assert index["source_revision"] == "deadbeef"
+
+    for platform_name, metadata in index["bundles"].items():
+        path = output / platform_name / "client.zip"
+        contents = path.read_bytes()
+        assert metadata["etag"] == f'"sha256:{hashlib.sha256(contents).hexdigest()}"'
+        assert path.with_suffix(".zip.etag").read_text().strip() == metadata["etag"]
+        with zipfile.ZipFile(path) as archive:
+            manifest = json.loads(archive.read("manifest.json"))
+        assert manifest["source_revision"] == "deadbeef"
+        assert platform_name in manifest["platforms"]
+
+    assert (output / "macos/amd64/client.zip").read_bytes() == (
+        output / "macos/arm64/client.zip"
+    ).read_bytes()
+
+    repeated = tmp_path / "repeated"
+    assert build.bundles(repeated, "deadbeef") == 0
+    for platform_name in index["bundles"]:
+        assert (output / platform_name / "client.zip").read_bytes() == (
+            repeated / platform_name / "client.zip"
+        ).read_bytes()

--- a/python/tests/test_bundles.py
+++ b/python/tests/test_bundles.py
@@ -1,0 +1,136 @@
+import base64
+import hashlib
+import io
+import json
+import threading
+import zipfile
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from lupine import _bundles
+
+NAMES = ("libcuda.so.1", "libcudart.so.13", "libnvidia-ml.so.1")
+
+
+def bundle_bytes(*, platforms=("linux/amd64",), extra=None):
+    files = []
+    contents = {}
+    for name in NAMES:
+        contents[name] = name.encode()
+        files.append(
+            {
+                "path": name,
+                "sha256": hashlib.sha256(contents[name]).hexdigest(),
+                "mode": "0755",
+            }
+        )
+    manifest = json.dumps(
+        {"schema": 1, "platforms": list(platforms), "files": files}
+    ).encode()
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.writestr("manifest.json", manifest)
+        for name, value in contents.items():
+            archive.writestr(name, value)
+        if extra is not None:
+            archive.writestr(extra, b"unsafe")
+    return output.getvalue()
+
+
+@contextmanager
+def bundle_server(body):
+    state = {"requests": []}
+    digest = hashlib.sha256(body).digest()
+    etag = f'"sha256:{digest.hex()}"'
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            state["requests"].append(
+                {name.lower(): value for name, value in self.headers.items()}
+            )
+            if self.headers.get("If-None-Match") == etag:
+                self.send_response(304)
+                self.send_header("ETag", etag)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("ETag", etag)
+            self.send_header(
+                "Content-Digest", f"sha-256=:{base64.b64encode(digest).decode()}:"
+            )
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield f"127.0.0.1:{server.server_port}", etag, state
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def test_resolve_downloads_verifies_and_revalidates(monkeypatch, tmp_path):
+    monkeypatch.setenv("LUPINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("LUPINE_SESSION", "lease-test")
+    monkeypatch.setattr(_bundles, "platform_name", lambda: "linux/amd64")
+    with bundle_server(bundle_bytes()) as (server, etag, state):
+        directory, selected, platform_name = _bundles.resolve((server,), NAMES)
+        assert selected == etag
+        assert platform_name == "linux/amd64"
+        assert {path.name for path in directory.iterdir()} == {
+            *NAMES,
+            "manifest.json",
+            ".etag",
+        }
+        assert state["requests"][0]["x-lupine-session"] == "lease-test"
+
+        again, again_etag, _ = _bundles.resolve((server,), NAMES)
+        assert again == directory
+        assert again_etag == etag
+        assert state["requests"][1]["if-none-match"] == etag
+
+
+def test_resolve_repairs_a_corrupt_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("LUPINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(_bundles, "platform_name", lambda: "linux/amd64")
+    with bundle_server(bundle_bytes()) as (server, _, state):
+        directory, _, _ = _bundles.resolve((server,), NAMES)
+        (directory / NAMES[0]).write_bytes(b"corrupt")
+        repaired, _, _ = _bundles.resolve((server,), NAMES)
+        assert repaired == directory
+        assert (repaired / NAMES[0]).read_bytes() == NAMES[0].encode()
+        assert "if-none-match" not in state["requests"][1]
+
+
+def test_resolve_rejects_mixed_server_bundles(monkeypatch, tmp_path):
+    monkeypatch.setenv("LUPINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(_bundles, "platform_name", lambda: "linux/amd64")
+    with (
+        bundle_server(bundle_bytes()) as (first, _, _),
+        bundle_server(bundle_bytes(platforms=("linux/amd64", "linux/arm64"))) as (
+            second,
+            _,
+            _,
+        ),
+        pytest.raises(ValueError, match="different client bundles"),
+    ):
+        _bundles.resolve((first, second), NAMES)
+
+
+def test_resolve_rejects_unsafe_archive_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("LUPINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(_bundles, "platform_name", lambda: "linux/amd64")
+    with (
+        bundle_server(bundle_bytes(extra="../escape")) as (server, _, _),
+        pytest.raises(ValueError, match="unsafe client bundle path"),
+    ):
+        _bundles.resolve((server,), NAMES)

--- a/python/tests/test_lupine_adapter.py
+++ b/python/tests/test_lupine_adapter.py
@@ -64,7 +64,9 @@ def test_session_requires_host_or_env(monkeypatch):
 def test_session_configures_env_and_restores(monkeypatch):
     monkeypatch.delenv("LUPINE_SERVER", raising=False)
     calls = []
-    monkeypatch.setattr(_native, "load", lambda missing_ok=True: calls.append(missing_ok) or {})
+    monkeypatch.setattr(
+        _native, "load", lambda missing_ok=True: calls.append(missing_ok) or {}
+    )
     with connect(host="gpu.example:14833") as session:
         assert os.environ["LUPINE_SERVER"] == "gpu.example:14833"
         assert calls == [False]
@@ -118,7 +120,7 @@ def test_load_does_not_set_disable_local(monkeypatch, tmp_path):
     assert len(result) == len(_native._LIBS[sys.platform])
     assert seen_env == [None] * len(_native._LIBS[sys.platform])
     assert "LUPINE_DISABLE_LOCAL" not in os.environ
-    if sys.platform == "linux":
+    if sys.platform in ("linux", "darwin"):
         assert os.environ["TRITON_LIBCUDA_PATH"] == str(libdir)
     # Idempotent: second call loads nothing new.
     monkeypatch.setattr(

--- a/rpc.h
+++ b/rpc.h
@@ -230,15 +230,9 @@ extern lupine_socket_t lupine_tcp_connect(const char *host, const char *port,
 
 constexpr int LUPINE_RPC_HTTP2_STREAM_END = -2;
 constexpr int LUPINE_RPC_HTTP2_VA_CONFLICT = -3;
-// Peer was built from a different tree. Retrying another arena slot cannot
-// help, so the dial loop gives up rather than treating this as a VA conflict.
-constexpr int LUPINE_RPC_HTTP2_IDENTITY_MISMATCH = -4;
-// This build's wire identity, and the comparison the connect check applies. An
-// empty side means that peer cannot state what it is, which reads as
-// unverifiable rather than as a match.
-extern const char *lupine_wire_identity(void);
-extern bool lupine_wire_identity_compatible(const char *local,
-                                            const char *peer);
+// The selected native client object no longer matches the server. Retrying an
+// arena slot cannot help; the launcher must fetch the advertised bundle.
+constexpr int LUPINE_RPC_HTTP2_CLIENT_MISMATCH = -4;
 extern int rpc_http2_read(conn_t *conn, void *data, size_t size);
 extern int rpc_http2_read_stream(conn_t *conn, int32_t stream_id, void *data,
                                  size_t size);
@@ -252,25 +246,23 @@ extern int rpc_http2_end_stream(conn_t *conn, int32_t stream_id);
 extern int32_t rpc_http2_accept_stream(conn_t *conn);
 extern int rpc_http2_client_init(conn_t *conn);
 // Waits for the peer's response headers on the session's own connection and
-// settles the build check and, when one was requested, the arena verdict.
-// rpc_http2_client_init already does this when an arena was requested; callers
-// that requested none run it themselves, and a caller with no live peer skips
-// it. Returns 0, LUPINE_RPC_HTTP2_VA_CONFLICT, or
-// LUPINE_RPC_HTTP2_IDENTITY_MISMATCH.
+// settles the client-bundle check and, when one was requested, the arena
+// verdict. rpc_http2_client_init already does this when an arena was requested;
+// callers that requested none run it themselves, and a caller with no live peer
+// skips it. Returns 0, LUPINE_RPC_HTTP2_VA_CONFLICT, or
+// LUPINE_RPC_HTTP2_CLIENT_MISMATCH.
 extern int rpc_http2_client_await_ready(conn_t *conn);
 extern void rpc_http2_client_start_heartbeat(conn_t *conn);
 extern void rpc_http2_destroy(conn_t *conn);
 struct rpc_http2_server_metadata {
   const char *backend_version;
+  const char *client_bundle_dir;
 };
 // Sends HEAD / and returns the backend-version response header, or nullptr
 // when the request fails or the server does not advertise a version.
 // The returned pointer remains valid until rpc_http2_destroy() or
 // rpc_conn_destroy(); the probe connection must not be reused for RPC.
 extern const char *rpc_http2_client_probe(conn_t *conn);
-// Read after the peer's response headers arrive. Valid until the transport is
-// destroyed.
-extern const char *rpc_http2_peer_wire_identity(conn_t *conn);
 // The arena window the peer stated it can host. False when it stated none.
 extern bool rpc_http2_peer_va_window(conn_t *conn, lupine_va_window *window);
 // Returns -1 on failure, 0 for an RPC connection, and a positive value when

--- a/server.cpp
+++ b/server.cpp
@@ -174,6 +174,7 @@ int client_handler(lupine_socket_t connfd) {
 #else
       nullptr,
 #endif
+      getenv("LUPINE_CLIENT_BUNDLE_DIR"),
   };
 
   // Identify the protocol before any RPC state exists: HTTP/2 preface means


### PR DESCRIPTION
## Summary

- publish deterministic native client ZIPs for Linux, macOS, and Windows on amd64 and arm64 from every server image
- serve GET and HEAD bootstrap requests with strong ETag, Content-Digest, conditional 304 support, and streamed bodies
- make Python resolve, verify, cache, and preload the exact server-selected object
- replace the dormant git wire identity with a connection-time client ETag assertion and 426 response
- make the server image consume the same all-platform artifacts tested and packaged by the Python workflow

## Compatibility

Clients without bundle headers remain accepted during the rollout. New clients assert the selected ETag, closing the discovery/connect upgrade race. LUPINE_LIBDIR remains an explicit development override.

## Tests

- CMake core-only build of dispatch_test and h2_test
- ctest -R dispatch_test\|h2_test
- LUPINE_AUTO=0 uv run --all-extras pytest -q (23 passed)
- ruff check for the new Python resolver and bundle builder

## Companion PR

lupinemachines/cloud#75 adds the gateway route and CLI consumer. This server endpoint should land first.