### PR TITLE
Fix CUDA 13.2 PyTorch runtime imports

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -135,21 +135,6 @@ jobs:
             -DLUPINE_CLIENT_DIR="$PWD/build"
           cmake --build build-cudart --parallel
 
-      - name: Verify CUDA 13 Linux runtime ABI exports
-        if: runner.os == 'Linux'
-        run: |
-          set -euo pipefail
-          for symbol in \
-            cudaDeviceGetGraphMemAttribute \
-            cudaDeviceSetGraphMemAttribute \
-            cudaGraphRetainUserObject \
-            cudaUserObjectCreate \
-            cudaUserObjectRelease
-          do
-            readelf --dyn-syms --wide build-cudart/libcudart.so.13 \
-              | grep -F "${symbol}@@libcudart.so.13"
-          done
-
       - name: Configure and build runtime (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -135,6 +135,21 @@ jobs:
             -DLUPINE_CLIENT_DIR="$PWD/build"
           cmake --build build-cudart --parallel
 
+      - name: Verify CUDA 13 Linux runtime ABI exports
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          for symbol in \
+            cudaDeviceGetGraphMemAttribute \
+            cudaDeviceSetGraphMemAttribute \
+            cudaGraphRetainUserObject \
+            cudaUserObjectCreate \
+            cudaUserObjectRelease
+          do
+            readelf --dyn-syms --wide build-cudart/libcudart.so.13 \
+              | grep -F "${symbol}@@libcudart.so.13"
+          done
+
       - name: Configure and build runtime (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/python/cudart/lupine_cudart.cpp
+++ b/python/cudart/lupine_cudart.cpp
@@ -1,11 +1,10 @@
 // lupine_cudart.cpp — native CUDA runtime API (libcudart) on the LUPINE
 // client shim, for the `lupine` Python package. Implements the surface
-// mapped from CUDA-13 torch (101 symbols: 9 __cuda* registration ABI +
-// 92 cuda*), verified against torch's undefined symbols and the shim's
-// exports. Mechanical forwarders go through the lcudart_call* templates;
-// everything with real logic (registration tables, lazy module loading,
-// memcpy kind dispatch, pointer classification, launch translation) stays
-// explicit.
+// mapped from CUDA-13 torch, verified against torch's undefined symbols and
+// the shim's exports. Mechanical forwarders go through the lcudart_call*
+// templates; everything with real logic (registration tables, lazy module
+// loading, memcpy kind dispatch, pointer classification, launch translation)
+// stays explicit.
 //
 // Build (see python/cudart/CMakeLists.txt; clients must already be built):
 //   Linux:   libcudart.so.13   (version node matching torch's references)
@@ -831,6 +830,30 @@ extern "C" cudaError_t cudaGetDeviceCount(int *count) {
   }
   *count = static_cast<int>(lcudart().visible_devices.size());
   return cudaSuccess;
+}
+
+extern "C" cudaError_t
+cudaDeviceGetGraphMemAttribute(int device, enum cudaGraphMemAttributeType attr,
+                               void *value) {
+  if (value == nullptr) {
+    return lcudart_fail(cudaErrorInvalidValue);
+  }
+  return lcudart_call_device(device, [&](CUdevice cu) {
+    return cuDeviceGetGraphMemAttribute(
+        cu, static_cast<CUgraphMem_attribute>(attr), value);
+  });
+}
+
+extern "C" cudaError_t
+cudaDeviceSetGraphMemAttribute(int device, enum cudaGraphMemAttributeType attr,
+                               void *value) {
+  if (value == nullptr) {
+    return lcudart_fail(cudaErrorInvalidValue);
+  }
+  return lcudart_call_device(device, [&](CUdevice cu) {
+    return cuDeviceSetGraphMemAttribute(
+        cu, static_cast<CUgraphMem_attribute>(attr), value);
+  });
 }
 
 extern "C" cudaError_t cudaDeviceGetAttribute(int *value,
@@ -2142,6 +2165,45 @@ extern "C" cudaError_t cudaLibraryUnload(cudaLibrary_t library) {
 // ---------------------------------------------------------------------------
 // Graphs
 // ---------------------------------------------------------------------------
+
+extern "C" cudaError_t cudaUserObjectCreate(cudaUserObject_t *object_out,
+                                            void *ptr, cudaHostFn_t destroy,
+                                            unsigned int initialRefcount,
+                                            unsigned int flags) {
+  // Destructor callbacks cannot cross the RPC boundary. The driver shim
+  // exposes this entry point as unsupported for the same reason.
+  (void)object_out;
+  (void)ptr;
+  (void)destroy;
+  (void)initialRefcount;
+  (void)flags;
+  return lcudart_fail(cudaErrorNotSupported);
+}
+
+extern "C" cudaError_t cudaUserObjectRetain(cudaUserObject_t object,
+                                            unsigned int count) {
+  return lcudart_call([&] { return cuUserObjectRetain(object, count); });
+}
+
+extern "C" cudaError_t cudaUserObjectRelease(cudaUserObject_t object,
+                                             unsigned int count) {
+  return lcudart_call([&] { return cuUserObjectRelease(object, count); });
+}
+
+extern "C" cudaError_t cudaGraphRetainUserObject(cudaGraph_t graph,
+                                                 cudaUserObject_t object,
+                                                 unsigned int count,
+                                                 unsigned int flags) {
+  return lcudart_call(
+      [&] { return cuGraphRetainUserObject(graph, object, count, flags); });
+}
+
+extern "C" cudaError_t cudaGraphReleaseUserObject(cudaGraph_t graph,
+                                                  cudaUserObject_t object,
+                                                  unsigned int count) {
+  return lcudart_call(
+      [&] { return cuGraphReleaseUserObject(graph, object, count); });
+}
 
 extern "C" cudaError_t cudaGraphAddNode(
     cudaGraphNode_t *pGraphNode, cudaGraph_t graph,


### PR DESCRIPTION
## Summary

- forward CUDA graph-memory attribute runtime calls through the existing driver RPCs
- expose the CUDA user-object ABI required by PyTorch cu132, forwarding supported operations and preserving the existing unsupported callback-creation behavior
- verify the new versioned libcudart.so.13 exports in the Linux runtime build matrix

## Validation

- cmake --build build --parallel
- ctest --test-dir build --output-on-failure (8/8 passed)
- rebuilt libcudart.so.13 and compared its exports with the complete PyTorch cu132 undefined-symbol surface
- imported torch 2.14.0+cu132 successfully with the rebuilt client shims

Closes #693