### PR TITLE
Prepare Python 2.0.3 release

### DIFF
--- a/python/auto/pyproject.toml
+++ b/python/auto/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lupine-auto"
-version = "2.0.2"
+version = "2.0.3"
 description = "Automatic Python startup bootstrap for LUPINE"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
-dependencies = ["lupine==2.0.2"]
+dependencies = ["lupine==2.0.3"]
 
 [dependency-groups]
 dev = ["pytest>=8.0"]

--- a/python/lupine/_login.py
+++ b/python/lupine/_login.py
@@ -21,7 +21,7 @@ from ._credentials import save_token
 
 DEFAULT_API_URL = "https://api.lupine.sh"
 DEFAULT_CONSOLE_URL = "https://console.lupine.sh"
-_USER_AGENT = "lupine-python/2.0.2"
+_USER_AGENT = "lupine-python/2.0.3"
 _SUCCESS_HTML = b"""<!doctype html><html><body style="font-family:monospace;background:#0a0a0a;color:#a3a3a3;padding:2rem"><h2 style="color:#a78bfa">Logged in to Lupine Cloud</h2><p>You can close this tab and return to your terminal.</p></body></html>"""
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lupine"
-version = "2.0.2"
+version = "2.0.3"
 description = "CUDA on any host: server-selected LUPINE shims plus PyTorch adapter"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -13,7 +13,7 @@ dependencies = []
 
 [project.optional-dependencies]
 torch = ["torch"]
-auto = ["lupine-auto==2.0.2"]
+auto = ["lupine-auto==2.0.3"]
 
 [project.scripts]
 lupine = "lupine.__main__:main"

--- a/python/tests/test_cloud.py
+++ b/python/tests/test_cloud.py
@@ -108,7 +108,7 @@ def test_cloud_session_authenticates_binds_heartbeats_and_releases(
     assert "LUPINE_SERVER" not in os.environ
     assert [request[0] for request in state["requests"]].count("DELETE") == 1
     assert all(request[2] == "Bearer lup_test" for request in state["requests"])
-    assert all(request[4] == "lupine-python/2.0.2" for request in state["requests"])
+    assert all(request[4] == "lupine-python/2.0.3" for request in state["requests"])
     create_body = json.loads(state["requests"][0][3])
     assert create_body == {"gpu_type": "RTX_4090", "gpu_count": 1}
 

--- a/python/tests/test_login.py
+++ b/python/tests/test_login.py
@@ -27,7 +27,7 @@ def test_login_requests_identify_the_python_client(monkeypatch):
         201,
         {},
     )
-    assert seen == {"user_agent": "lupine-python/2.0.2", "timeout": 30}
+    assert seen == {"user_agent": "lupine-python/2.0.3", "timeout": 30}
 
 
 def test_login_runs_browser_flow_and_stores_token(monkeypatch, tmp_path):

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -147,7 +147,7 @@ wheels = [
 
 [[package]]
 name = "lupine"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -175,14 +175,14 @@ dev = [{ name = "pytest", specifier = ">=8.0" }]
 
 [[package]]
 name = "lupine-auto"
-version = "2.0.2"
+version = "2.0.3"
 source = { directory = "auto" }
 dependencies = [
     { name = "lupine" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "lupine", specifier = "==2.0.2" }]
+requires-dist = [{ name = "lupine", specifier = "==2.0.3" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]


### PR DESCRIPTION
## Summary

- bump lupine and lupine-auto to 2.0.3
- keep their exact cross-package requirements and uv lock metadata aligned
- update the Python client user-agent and its assertions

## Validation

- python python/verify_release.py --tag v2.0.3
- uv run --project python --all-extras pytest python (40 passed)

Follow-up to #694.