### PR TITLE
Preserve async CUDA submission order across RPC lanes

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -2078,8 +2078,12 @@ def main():
             if metadata.async_fire_forget:
                 error_return = error_const(function.return_type.format())
                 f.write(
+                    "    uint64_t async_sequence = 0;\n"
                     "    if (lupine_prepare_rpc(conn) < 0 ||\n"
-                    "        rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
+                    "        rpc_write_start_async_request(\n"
+                    "            conn, RPC_{name}, &async_sequence) < 0 ||\n"
+                    "        rpc_write(conn, &async_sequence, "
+                    "sizeof(async_sequence)) < 0 ||\n".format(
                         name=function.name.format()
                     )
                 )
@@ -2297,6 +2301,8 @@ def main():
             for operation in operations:
                 f.write(operation.server_declaration)
 
+            if metadata.async_fire_forget:
+                f.write("    uint64_t async_sequence = 0;\n")
             f.write("    int request_id;\n")
 
             # we only generate return from non-void types
@@ -2312,6 +2318,11 @@ def main():
                 f.write("    void* lupine_intercept_result;\n")
 
             f.write("    if (\n")
+            if metadata.async_fire_forget:
+                f.write(
+                    "        rpc_read(conn, &async_sequence, "
+                    "sizeof(async_sequence)) < 0 ||\n"
+                )
             for operation in operations:
                 if owned_buffer := operation.server_rpc_read(f):
                     owned_buffers.append(owned_buffer)
@@ -2331,6 +2342,12 @@ def main():
                     f"    {node} = lupine_htod_graph_exec_node({graph_exec}, {node});\n"
                 )
 
+            if metadata.async_fire_forget:
+                f.write(
+                    "    if (rpc_async_sequence_begin(conn, async_sequence) < 0)\n"
+                    "        goto ERROR_0;\n\n"
+                )
+
             params: list[str] = []
             # these need to be in function param order, not operation order.
             for param in function.parameters:
@@ -2345,6 +2362,8 @@ def main():
                         params=", ".join(params),
                     )
                 )
+                if metadata.async_fire_forget:
+                    f.write("    rpc_async_sequence_end(conn);\n\n")
             else:
                 f.write(
                     "    lupine_intercept_result = {name}({params});\n\n".format(

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -855,8 +855,11 @@ CUresult cuLibraryUnload(CUlibrary library) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuLibraryUnload,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -1016,8 +1019,11 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuKernelSetAttribute,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_write(conn, &val, sizeof(int)) < 0 ||
       rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
@@ -1510,8 +1516,11 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     return lupine_call_real_cuda_fn("cuMemcpyDtoDAsync_v2", dstDevice,
                                     srcDevice, ByteCount, hStream);
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuMemcpyDtoDAsync_v2,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
@@ -1686,8 +1695,11 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
     return lupine_call_real_cuda_fn("cuMemsetD8Async", dstDevice, uc, N,
                                     hStream);
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuMemsetD8Async,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1706,8 +1718,11 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
     return lupine_call_real_cuda_fn("cuMemsetD16Async", dstDevice, us, N,
                                     hStream);
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuMemsetD16Async,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1726,8 +1741,11 @@ CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
     return lupine_call_real_cuda_fn("cuMemsetD32Async", dstDevice, ui, N,
                                     hStream);
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuMemsetD32Async,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1747,8 +1765,11 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
     return lupine_call_real_cuda_fn("cuMemsetD2D8Async", dstDevice, dstPitch,
                                     uc, Width, Height, hStream);
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuMemsetD2D8Async,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
@@ -1770,8 +1791,11 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
     return lupine_call_real_cuda_fn("cuMemsetD2D16Async", dstDevice, dstPitch,
                                     us, Width, Height, hStream);
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuMemsetD2D16Async,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
@@ -1793,8 +1817,11 @@ CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
     return lupine_call_real_cuda_fn("cuMemsetD2D32Async", dstDevice, dstPitch,
                                     ui, Width, Height, hStream);
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuMemsetD2D32Async,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||

--- a/codegen/gen_cuda_server.cpp
+++ b/codegen/gen_cuda_server.cpp
@@ -1472,8 +1472,10 @@ int handle_cuKernelSetAttribute(conn_t *conn) {
   int val;
   CUkernel kernel;
   CUdevice dev;
+  uint64_t async_sequence = 0;
   int request_id;
-  if (rpc_read(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
       rpc_read(conn, &val, sizeof(int)) < 0 ||
       rpc_read(conn, &kernel, sizeof(CUkernel)) < 0 ||
       rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
@@ -1482,7 +1484,12 @@ int handle_cuKernelSetAttribute(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0)
+    goto ERROR_0;
+
   cuKernelSetAttribute(attrib, val, kernel, dev);
+
+  rpc_async_sequence_end(conn);
 
   return 0;
 ERROR_0:
@@ -2141,8 +2148,10 @@ int handle_cuMemcpyDtoDAsync_v2(conn_t *conn) {
   CUdeviceptr srcDevice;
   size_t ByteCount;
   CUstream hStream;
+  uint64_t async_sequence = 0;
   int request_id;
-  if (rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &ByteCount, sizeof(size_t)) < 0 ||
       rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
@@ -2151,7 +2160,12 @@ int handle_cuMemcpyDtoDAsync_v2(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0)
+    goto ERROR_0;
+
   cuMemcpyDtoDAsync_v2(dstDevice, srcDevice, ByteCount, hStream);
+
+  rpc_async_sequence_end(conn);
 
   return 0;
 ERROR_0:
@@ -2334,8 +2348,10 @@ int handle_cuMemsetD8Async(conn_t *conn) {
   unsigned char uc;
   size_t N;
   CUstream hStream;
+  uint64_t async_sequence = 0;
   int request_id;
-  if (rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_read(conn, &N, sizeof(size_t)) < 0 ||
       rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
@@ -2344,7 +2360,12 @@ int handle_cuMemsetD8Async(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0)
+    goto ERROR_0;
+
   cuMemsetD8Async(dstDevice, uc, N, hStream);
+
+  rpc_async_sequence_end(conn);
 
   return 0;
 ERROR_0:
@@ -2356,8 +2377,10 @@ int handle_cuMemsetD16Async(conn_t *conn) {
   unsigned short us;
   size_t N;
   CUstream hStream;
+  uint64_t async_sequence = 0;
   int request_id;
-  if (rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_read(conn, &N, sizeof(size_t)) < 0 ||
       rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
@@ -2366,7 +2389,12 @@ int handle_cuMemsetD16Async(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0)
+    goto ERROR_0;
+
   cuMemsetD16Async(dstDevice, us, N, hStream);
+
+  rpc_async_sequence_end(conn);
 
   return 0;
 ERROR_0:
@@ -2378,8 +2406,10 @@ int handle_cuMemsetD32Async(conn_t *conn) {
   unsigned int ui;
   size_t N;
   CUstream hStream;
+  uint64_t async_sequence = 0;
   int request_id;
-  if (rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_read(conn, &N, sizeof(size_t)) < 0 ||
       rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
@@ -2388,7 +2418,12 @@ int handle_cuMemsetD32Async(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0)
+    goto ERROR_0;
+
   cuMemsetD32Async(dstDevice, ui, N, hStream);
+
+  rpc_async_sequence_end(conn);
 
   return 0;
 ERROR_0:
@@ -2402,8 +2437,10 @@ int handle_cuMemsetD2D8Async(conn_t *conn) {
   size_t Width;
   size_t Height;
   CUstream hStream;
+  uint64_t async_sequence = 0;
   int request_id;
-  if (rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_read(conn, &uc, sizeof(unsigned char)) < 0 ||
       rpc_read(conn, &Width, sizeof(size_t)) < 0 ||
@@ -2414,7 +2451,12 @@ int handle_cuMemsetD2D8Async(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0)
+    goto ERROR_0;
+
   cuMemsetD2D8Async(dstDevice, dstPitch, uc, Width, Height, hStream);
+
+  rpc_async_sequence_end(conn);
 
   return 0;
 ERROR_0:
@@ -2428,8 +2470,10 @@ int handle_cuMemsetD2D16Async(conn_t *conn) {
   size_t Width;
   size_t Height;
   CUstream hStream;
+  uint64_t async_sequence = 0;
   int request_id;
-  if (rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_read(conn, &us, sizeof(unsigned short)) < 0 ||
       rpc_read(conn, &Width, sizeof(size_t)) < 0 ||
@@ -2440,7 +2484,12 @@ int handle_cuMemsetD2D16Async(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0)
+    goto ERROR_0;
+
   cuMemsetD2D16Async(dstDevice, dstPitch, us, Width, Height, hStream);
+
+  rpc_async_sequence_end(conn);
 
   return 0;
 ERROR_0:
@@ -2454,8 +2503,10 @@ int handle_cuMemsetD2D32Async(conn_t *conn) {
   size_t Width;
   size_t Height;
   CUstream hStream;
+  uint64_t async_sequence = 0;
   int request_id;
-  if (rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &dstPitch, sizeof(size_t)) < 0 ||
       rpc_read(conn, &ui, sizeof(unsigned int)) < 0 ||
       rpc_read(conn, &Width, sizeof(size_t)) < 0 ||
@@ -2466,7 +2517,12 @@ int handle_cuMemsetD2D32Async(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0)
+    goto ERROR_0;
+
   cuMemsetD2D32Async(dstDevice, dstPitch, ui, Width, Height, hStream);
+
+  rpc_async_sequence_end(conn);
 
   return 0;
 ERROR_0:

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -4422,8 +4422,11 @@ extern "C" CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
   }
   lupine_event_invalidate_completion(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuEventRecord, &async_sequence) <
+          0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write_end(conn) < 0) {
@@ -4449,8 +4452,11 @@ extern "C" CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
   }
   lupine_event_invalidate_completion(hEvent);
   conn_t *conn = lupine_route_remote_conn(route);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuEventRecordWithFlags,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 || rpc_write_end(conn) < 0) {
@@ -5266,9 +5272,13 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
        lupine_managed_kernel_requires_launch_sync(route_function) ||
        lupine_managed_kernel_requires_launch_sync(f));
   conn_t *conn = lupine_route_remote_conn(route);
-  // Fire-and-forget; launch errors are sticky and surface at the next sync.
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuLaunchKernel) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  uint64_t async_sequence = 0;
+  if (rpc_write_start_async_request(conn, RPC_cuLaunchKernel, &async_sequence) <
+          0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &f, sizeof(f)) < 0 ||
       rpc_write(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_write(conn, &gridDimY, sizeof(gridDimY)) < 0 ||
@@ -5347,14 +5357,13 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
        lupine_managed_kernel_requires_launch_sync(route_function) ||
        lupine_managed_kernel_requires_launch_sync(f));
   conn_t *conn = lupine_route_remote_conn(route);
-  // Attribute-free launches are fire-and-forget like cuLaunchKernel; launch
-  // errors are sticky and surface at the next sync. Launches carrying
-  // attributes stay synchronous so attribute validation errors (e.g. invalid
-  // cluster dimensions) are reported from the launch itself. The server
-  // applies the same numAttrs rule when deciding whether to respond.
-  bool fire_and_forget = config->numAttrs == 0;
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuLaunchKernelEx) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  uint64_t async_sequence = 0;
+  if (rpc_write_start_async_request(conn, RPC_cuLaunchKernelEx,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, config, sizeof(*config)) < 0 ||
       rpc_write(conn, config->attrs,
                 config->numAttrs * sizeof(*config->attrs)) < 0 ||
@@ -5365,7 +5374,7 @@ extern "C" CUresult cuLaunchKernelEx(const CUlaunchConfig *config, CUfunction f,
       rpc_write_cursors(conn, rpc_params.data(), rpc_params.size()) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  if (fire_and_forget) {
+  if (config->numAttrs == 0) {
     if (rpc_write_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
@@ -5427,8 +5436,13 @@ cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
+  if (lupine_prepare_rpc(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  uint64_t async_sequence = 0;
+  if (rpc_write_start_async_request(conn, RPC_cuLaunchCooperativeKernel,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &f, sizeof(f)) < 0 ||
       rpc_write(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_write(conn, &gridDimY, sizeof(gridDimY)) < 0 ||

--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -3353,8 +3353,11 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
   }
 
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
+  uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuMemcpyDtoHAsync_v2) < 0 ||
+      rpc_write_start_async_request(conn, RPC_cuMemcpyDtoHAsync_v2,
+                                    &async_sequence) < 0 ||
+      rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
       rpc_write(conn, &dstHost, sizeof(dstHost)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -2092,14 +2092,20 @@ int handle_cuLibraryGetModule(conn_t *conn) {
 // caches the CUkernel handles this one owns, but it only ever sends the unload
 // to the route that loaded it, so freeing here would dangle those handles.
 int handle_cuLibraryUnload(conn_t *conn) {
+  uint64_t async_sequence = 0;
   CUlibrary library = nullptr;
 
-  if (rpc_read(conn, &library, sizeof(library)) < 0) {
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &library, sizeof(library)) < 0) {
     return -1;
   }
   if (rpc_read_end(conn) < 0) {
     return -1;
   }
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0) {
+    return -1;
+  }
+  rpc_async_sequence_end(conn);
   return 0;
 }
 
@@ -2161,6 +2167,7 @@ int handle_cuModuleGetGlobal_v2(conn_t *conn) {
 }
 
 int handle_cuLaunchKernel(conn_t *conn) {
+  uint64_t async_sequence = 0;
   CUfunction f = nullptr;
   unsigned int gridDimX = 0;
   unsigned int gridDimY = 0;
@@ -2174,7 +2181,8 @@ int handle_cuLaunchKernel(conn_t *conn) {
   int request_id;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
-  if (rpc_read(conn, &f, sizeof(f)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &f, sizeof(f)) < 0 ||
       rpc_read(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_read(conn, &gridDimY, sizeof(gridDimY)) < 0 ||
       rpc_read(conn, &gridDimZ, sizeof(gridDimZ)) < 0 ||
@@ -2214,11 +2222,18 @@ int handle_cuLaunchKernel(conn_t *conn) {
     return -1;
   }
 
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0) {
+    std::free(param_sizes);
+    std::free(params);
+    std::free(param_storage);
+    return -1;
+  }
   if (result == CUDA_SUCCESS) {
     result =
         cuLaunchKernel(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
                        blockDimZ, sharedMemBytes, hStream, params, nullptr);
   }
+  rpc_async_sequence_end(conn);
   std::free(param_sizes);
   std::free(params);
   std::free(param_storage);
@@ -2229,13 +2244,15 @@ int handle_cuLaunchKernel(conn_t *conn) {
 }
 
 int handle_cuLaunchKernelEx(conn_t *conn) {
+  uint64_t async_sequence = 0;
   CUlaunchConfig config = {};
   CUfunction f = nullptr;
   uint32_t param_count = 0;
   int request_id;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
-  if (rpc_read(conn, &config, sizeof(config)) < 0) {
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &config, sizeof(config)) < 0) {
     return -1;
   }
   CUlaunchAttribute *attributes = static_cast<CUlaunchAttribute *>(
@@ -2279,18 +2296,24 @@ int handle_cuLaunchKernelEx(conn_t *conn) {
     return -1;
   }
 
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0) {
+    std::free(attributes);
+    std::free(param_sizes);
+    std::free(params);
+    std::free(param_storage);
+    return -1;
+  }
 #if CUDA_VERSION >= 11080
   if (result == CUDA_SUCCESS) {
     result = cuLaunchKernelEx(&config, f, params, nullptr);
   }
 #endif
+  rpc_async_sequence_end(conn);
   std::free(attributes);
   std::free(param_sizes);
   std::free(params);
   std::free(param_storage);
 
-  // Mirror the client: attribute-free launches are fire-and-forget, launches
-  // carrying attributes expect a synchronous result.
   if (config.numAttrs != 0) {
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &result, sizeof(result)) < 0 ||
@@ -2306,6 +2329,7 @@ int handle_cuLaunchKernelEx(conn_t *conn) {
 }
 
 int handle_cuLaunchCooperativeKernel(conn_t *conn) {
+  uint64_t async_sequence = 0;
   CUfunction f = nullptr;
   unsigned int gridDimX = 0;
   unsigned int gridDimY = 0;
@@ -2319,7 +2343,8 @@ int handle_cuLaunchCooperativeKernel(conn_t *conn) {
   int request_id;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
-  if (rpc_read(conn, &f, sizeof(f)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &f, sizeof(f)) < 0 ||
       rpc_read(conn, &gridDimX, sizeof(gridDimX)) < 0 ||
       rpc_read(conn, &gridDimY, sizeof(gridDimY)) < 0 ||
       rpc_read(conn, &gridDimZ, sizeof(gridDimZ)) < 0 ||
@@ -2359,11 +2384,18 @@ int handle_cuLaunchCooperativeKernel(conn_t *conn) {
     return -1;
   }
 
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0) {
+    std::free(param_sizes);
+    std::free(params);
+    std::free(param_storage);
+    return -1;
+  }
   if (result == CUDA_SUCCESS) {
     result = cuLaunchCooperativeKernel(f, gridDimX, gridDimY, gridDimZ,
                                        blockDimX, blockDimY, blockDimZ,
                                        sharedMemBytes, hStream, params);
   }
+  rpc_async_sequence_end(conn);
   std::free(param_sizes);
   std::free(params);
   std::free(param_storage);
@@ -3061,11 +3093,13 @@ int handle_cuStreamAddCallback(conn_t *conn) {
 }
 
 static int handle_cuEventRecordCommon(conn_t *conn, bool with_flags) {
+  uint64_t async_sequence = 0;
   CUevent event = nullptr;
   CUstream stream = nullptr;
   unsigned int flags = 0;
 
-  if (rpc_read(conn, &event, sizeof(event)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &event, sizeof(event)) < 0 ||
       rpc_read(conn, &stream, sizeof(stream)) < 0 ||
       (with_flags && rpc_read(conn, &flags, sizeof(flags)) < 0)) {
     return -1;
@@ -3074,12 +3108,16 @@ static int handle_cuEventRecordCommon(conn_t *conn, bool with_flags) {
     return -1;
   }
 
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0) {
+    return -1;
+  }
   CUresult result = with_flags ? cuEventRecordWithFlags(event, stream, flags)
                                : cuEventRecord(event, stream);
   if (result == CUDA_SUCCESS) {
     lupine_record_event_capture_resources(event, stream);
     lupine_note_event_record(conn, event, stream);
   }
+  rpc_async_sequence_end(conn);
   return 0;
 }
 

--- a/cuda_server_memcpy.cpp
+++ b/cuda_server_memcpy.cpp
@@ -2835,13 +2835,15 @@ int handle_cuMemcpyAtoH_v2(conn_t *conn) {
 }
 
 int handle_cuMemcpyDtoHAsync_v2(conn_t *conn) {
+  uint64_t async_sequence = 0;
   void *dstHost = nullptr;
   CUdeviceptr srcDevice = 0;
   size_t byteCount = 0;
   CUstream stream = nullptr;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
-  if (rpc_read(conn, &dstHost, sizeof(dstHost)) < 0 ||
+  if (rpc_read(conn, &async_sequence, sizeof(async_sequence)) < 0 ||
+      rpc_read(conn, &dstHost, sizeof(dstHost)) < 0 ||
       rpc_read(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_read(conn, &byteCount, sizeof(byteCount)) < 0 ||
       rpc_read(conn, &stream, sizeof(stream)) < 0) {
@@ -2849,6 +2851,10 @@ int handle_cuMemcpyDtoHAsync_v2(conn_t *conn) {
   }
 
   if (rpc_read_end(conn) < 0) {
+    return -1;
+  }
+
+  if (rpc_async_sequence_begin(conn, async_sequence) < 0) {
     return -1;
   }
 
@@ -2903,5 +2909,6 @@ int handle_cuMemcpyDtoHAsync_v2(conn_t *conn) {
   } else if (host != nullptr) {
     free(host);
   }
+  rpc_async_sequence_end(conn);
   return 0;
 }

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -227,6 +227,15 @@ void rpc_shutdown_socket(lupine_socket_t socket) {
 #endif
 }
 
+void rpc_wake_async_waiters(conn_t *conn) {
+  if (!conn->async_sync_initialized) {
+    return;
+  }
+  pthread_mutex_lock(&conn->async_mutex);
+  pthread_cond_broadcast(&conn->async_cond);
+  pthread_mutex_unlock(&conn->async_mutex);
+}
+
 } // namespace
 
 void rpc_shutdown_transport_socket(conn_t *conn) {
@@ -242,6 +251,7 @@ void rpc_shutdown_transport_socket(conn_t *conn) {
   const lupine_socket_t socket =
       __atomic_load_n(&conn->connfd, __ATOMIC_ACQUIRE);
 #endif
+  rpc_wake_async_waiters(conn);
   if (socket != LUPINE_INVALID_SOCKET) {
     rpc_shutdown_socket(socket);
   }
@@ -261,6 +271,7 @@ void rpc_close_transport_socket(conn_t *conn) {
   lupine_socket_t socket = __atomic_exchange_n(
       &conn->connfd, LUPINE_INVALID_SOCKET, __ATOMIC_ACQ_REL);
 #endif
+  rpc_wake_async_waiters(conn);
   if (socket == LUPINE_INVALID_SOCKET) {
     return;
   }
@@ -330,6 +341,18 @@ int rpc_conn_init(conn_t *conn, lupine_socket_t connfd, int request_id) {
     pthread_mutex_destroy(&conn->write_mutex);
     goto fail;
   }
+  if (pthread_mutex_init(&conn->async_mutex, nullptr) != 0) {
+    pthread_mutex_destroy(&conn->call_mutex);
+    pthread_mutex_destroy(&conn->write_mutex);
+    goto fail;
+  }
+  if (pthread_cond_init(&conn->async_cond, nullptr) != 0) {
+    pthread_mutex_destroy(&conn->async_mutex);
+    pthread_mutex_destroy(&conn->call_mutex);
+    pthread_mutex_destroy(&conn->write_mutex);
+    goto fail;
+  }
+  conn->async_sync_initialized = 1;
   return 0;
 
 fail:
@@ -337,6 +360,30 @@ fail:
   *conn = {};
   conn->connfd = LUPINE_INVALID_SOCKET;
   return -1;
+}
+
+int rpc_async_sequence_begin(conn_t *conn, uint64_t sequence) {
+  if (pthread_mutex_lock(&conn->async_mutex) != 0) {
+    return -1;
+  }
+  while (!conn->closed && conn->serving_async_sequence != sequence) {
+    if (conn->serving_async_sequence > sequence ||
+        pthread_cond_wait(&conn->async_cond, &conn->async_mutex) != 0) {
+      pthread_mutex_unlock(&conn->async_mutex);
+      return -1;
+    }
+  }
+  if (conn->closed) {
+    pthread_mutex_unlock(&conn->async_mutex);
+    return -1;
+  }
+  return 0;
+}
+
+void rpc_async_sequence_end(conn_t *conn) {
+  ++conn->serving_async_sequence;
+  pthread_cond_broadcast(&conn->async_cond);
+  pthread_mutex_unlock(&conn->async_mutex);
 }
 
 void rpc_conn_destroy(conn_t *conn) {
@@ -349,6 +396,9 @@ void rpc_conn_destroy(conn_t *conn) {
   rpc_write_buffer_release(conn);
   std::vector<rpc_write_cursor>().swap(conn->write_queue);
   std::vector<rpc_host_allocation_write>().swap(conn->host_allocation_writes);
+  conn->async_sync_initialized = 0;
+  pthread_cond_destroy(&conn->async_cond);
+  pthread_mutex_destroy(&conn->async_mutex);
   pthread_mutex_destroy(&conn->write_mutex);
   pthread_mutex_destroy(&conn->call_mutex);
 }
@@ -378,6 +428,7 @@ int rpc_set_lifecycle_hooks(const rpc_lifecycle_hooks *hooks) {
 
 static void rpc_mark_connection_closed(conn_t *conn) {
   conn->closed = 1;
+  rpc_wake_async_waiters(conn);
   auto hook = connection_closed_hook.load(std::memory_order_acquire);
   if (hook != nullptr) {
     hook(conn);
@@ -753,6 +804,16 @@ int rpc_write_start_request(conn_t *conn, const int op) {
   }
   return 0;
 }
+
+int rpc_write_start_async_request(conn_t *conn, const int op,
+                                  uint64_t *sequence) {
+  if (sequence == nullptr || rpc_write_start_request(conn, op) < 0) {
+    return -1;
+  }
+  *sequence = conn->issued_async_sequence++;
+  return 0;
+}
+
 // rpc_write_start_request starts a new request builder on the given connection
 // index with a specific op code.
 //

--- a/rpc.h
+++ b/rpc.h
@@ -115,7 +115,11 @@ struct conn_t {
   int32_t write_stream_id;
 
   pthread_t read_thread;
-  pthread_mutex_t write_mutex, call_mutex;
+  pthread_mutex_t write_mutex, call_mutex, async_mutex;
+  pthread_cond_t async_cond;
+  uint64_t issued_async_sequence;
+  uint64_t serving_async_sequence;
+  int async_sync_initialized;
   std::vector<rpc_write_cursor> write_queue;
   std::vector<rpc_host_allocation_write> host_allocation_writes;
   int host_allocation_writes_pending;
@@ -183,6 +187,11 @@ extern int rpc_wait_for_response(conn_t *conn);
 // remote server) or a closed conn fails here, so callers surface their
 // unavailable-server result without per-call-site null checks.
 extern int rpc_write_start_request(conn_t *conn, const int op);
+// Starts a request and allocates its async-submission ticket while the normal
+// request lock is held. The caller writes the ticket into the request payload;
+// this adds no server acknowledgement or round trip.
+extern int rpc_write_start_async_request(conn_t *conn, const int op,
+                                         uint64_t *sequence);
 extern int rpc_write_start_response(conn_t *conn, const int read_id);
 // A zero-size write is a successful no-op, including when data is null.
 extern int rpc_write(conn_t *conn, const void *data, const size_t size);
@@ -207,6 +216,10 @@ extern void *rpc_write_buffer(conn_t *conn, size_t size, size_t alignment);
 extern int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
                              size_t count);
 extern int rpc_write_end(conn_t *conn);
+// Server handlers wait only after receiving the complete async request, then
+// hold the turn through the native API submission.
+extern int rpc_async_sequence_begin(conn_t *conn, uint64_t sequence);
+extern void rpc_async_sequence_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
 // Signals transport readers to stop without releasing connection resources.
 // Owners use this before joining workers that may be blocked on the transport.

--- a/test/test_cross_lane_launch_order.cu
+++ b/test/test_cross_lane_launch_order.cu
@@ -1,0 +1,154 @@
+// Async CUDA calls issued by different host threads still have to reach the
+// driver in issue order. A large kernel argument keeps one HTTP/2 lane busy
+// long enough for a smaller request on another lane to overtake it unless the
+// server sequences native submission.
+#include <cuda_runtime.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+namespace {
+
+constexpr int kRounds = 512;
+// CUDA toolkits before 12.1 limit kernel parameters to 4 KiB. Leave room for
+// the output pointer while making the launch request as large as possible.
+constexpr size_t kPayloadBytes = 4080;
+
+struct alignas(16) large_payload {
+  int value;
+  unsigned char padding[kPayloadBytes - sizeof(int)];
+};
+
+__global__ void publish(large_payload payload, int *value) {
+  *value = payload.value;
+}
+
+__global__ void verify(const int *value, int expected, int *failures) {
+  if (*value != expected) {
+    atomicAdd(failures, 1);
+  }
+}
+
+__global__ void verify_zero(const int *value, int *failures) {
+  if (*value != 0) {
+    atomicAdd(failures, 1);
+  }
+}
+
+void check(cudaError_t result, const char *operation) {
+  if (result == cudaSuccess) {
+    return;
+  }
+  std::fprintf(stderr, "FAIL: %s: %s\n", operation, cudaGetErrorString(result));
+  std::exit(EXIT_FAILURE);
+}
+
+void wait_for(const std::atomic<int> &phase, int expected) {
+  while (phase.load(std::memory_order_acquire) != expected) {
+    std::this_thread::yield();
+  }
+}
+
+void require_no_failures(int *failures, const char *message) {
+  int observed = -1;
+  check(
+      cudaMemcpy(&observed, failures, sizeof(observed), cudaMemcpyDeviceToHost),
+      "cudaMemcpy failures");
+  if (observed != 0) {
+    std::fprintf(stderr, "FAIL: %d of %d %s\n", observed, kRounds, message);
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+void test_kernel_launch_order(int *value, int *failures) {
+  check(cudaMemset(value, 0xff, sizeof(*value)), "cudaMemset value");
+  check(cudaMemset(failures, 0, sizeof(*failures)), "cudaMemset failures");
+
+  std::atomic<int> phase{0};
+  std::thread producer([&] {
+    check(cudaSetDevice(0), "producer cudaSetDevice");
+    large_payload payload = {};
+    for (int round = 0; round < kRounds; ++round) {
+      wait_for(phase, round * 2);
+      payload.value = round;
+      publish<<<1, 1>>>(payload, value);
+      check(cudaGetLastError(), "publish launch");
+      phase.store(round * 2 + 1, std::memory_order_release);
+    }
+  });
+
+  std::thread consumer([&] {
+    check(cudaSetDevice(0), "consumer cudaSetDevice");
+    for (int round = 0; round < kRounds; ++round) {
+      wait_for(phase, round * 2 + 1);
+      verify<<<1, 1>>>(value, round, failures);
+      check(cudaGetLastError(), "verify launch");
+      phase.store(round * 2 + 2, std::memory_order_release);
+    }
+    check(cudaDeviceSynchronize(), "consumer cudaDeviceSynchronize");
+  });
+
+  producer.join();
+  consumer.join();
+  require_no_failures(failures, "cross-lane kernel launches overtook");
+}
+
+void test_cross_type_order(int *value, int *failures) {
+  check(cudaMemset(failures, 0, sizeof(*failures)), "cudaMemset failures");
+
+  std::atomic<int> phase{0};
+  std::thread producer([&] {
+    check(cudaSetDevice(0), "producer cudaSetDevice");
+    large_payload payload = {};
+    for (int round = 0; round < kRounds; ++round) {
+      wait_for(phase, round * 2);
+      payload.value = round + 1;
+      publish<<<1, 1>>>(payload, value);
+      check(cudaGetLastError(), "publish launch");
+      phase.store(round * 2 + 1, std::memory_order_release);
+    }
+  });
+
+  std::thread consumer([&] {
+    check(cudaSetDevice(0), "consumer cudaSetDevice");
+    for (int round = 0; round < kRounds; ++round) {
+      wait_for(phase, round * 2 + 1);
+      check(cudaMemsetAsync(value, 0, sizeof(*value)), "cudaMemsetAsync");
+      verify_zero<<<1, 1>>>(value, failures);
+      check(cudaGetLastError(), "verify-zero launch");
+      phase.store(round * 2 + 2, std::memory_order_release);
+    }
+    check(cudaDeviceSynchronize(), "consumer cudaDeviceSynchronize");
+  });
+
+  producer.join();
+  consumer.join();
+  require_no_failures(failures, "async memsets overtook kernel launches");
+}
+
+} // namespace
+
+int main() {
+  int device_count = 0;
+  check(cudaGetDeviceCount(&device_count), "cudaGetDeviceCount");
+  if (device_count == 0) {
+    std::printf("SKIP: no CUDA devices found\n");
+    return EXIT_SUCCESS;
+  }
+
+  check(cudaSetDevice(0), "cudaSetDevice");
+  int *value = nullptr;
+  int *failures = nullptr;
+  check(cudaMalloc(&value, sizeof(*value)), "cudaMalloc value");
+  check(cudaMalloc(&failures, sizeof(*failures)), "cudaMalloc failures");
+
+  test_kernel_launch_order(value, failures);
+  test_cross_type_order(value, failures);
+
+  check(cudaFree(failures), "cudaFree failures");
+  check(cudaFree(value), "cudaFree value");
+  std::printf("PASS: async operations preserve order across client lanes\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- attach a monotonically increasing sequence ticket to every fire-and-forget CUDA RPC, including generated async calls and manual kernel, event, and DtoH paths
- transmit requests immediately; after fully reading each payload, the server waits for its ticket immediately before the native CUDA call
- preserve ordering across persistent HTTP/2 client lanes without adding a response or round trip
- add a portable regression test for kernel-to-kernel and kernel-to-async-memset ordering

## Root cause

Different host threads use different persistent RPC lanes. A large fire-and-forget request can be fully transmitted and return to the client before a later call is issued, yet its server handler can still be decoding while the smaller later request reaches the CUDA driver first on another lane. That reverses native CUDA submission order. The failure then surfaces asynchronously at a later operation, commonly the backward-pass cuBLAS GEMM.

## Reproduction

On `inferable-node-006` (RTX 4090), the exact `gpt_bench.py` workload failed on unpatched main on attempt 8 after step 275 with an illegal memory access and Xid 31. The reported cuBLAS internal error is another asynchronous surface of the same corruption.

A deterministic two-lane regression reproduces the ordering violation independently:

- portable 4 KiB kernel request on unpatched main: 216, 258, and 236 reorderings in three 512-round runs
- the earlier kernel-only ticket implementation still allowed async memset to overtake a kernel in 115 of 128 rounds
- generalized async sequencing: three of three portable stress runs passed; the earlier larger-payload variant also passed five of five runs

## Verification

- exact `gpt_bench.py`: 10 of 10 clean-process runs passed and converged after the generalized fix
- `ninja -C build`
- `ctest --test-dir build --output-on-failure` (13 of 13 passed or expected skip)
- `./test/run_sanitizer_tests.sh address,undefined` (5 of 5)
- `./test/run_sanitizer_tests.sh thread` (5 of 5)
- `./codegen/run.sh` and generated-output check
- clang-format and `git diff --check`

The regression payload stays within the CUDA 11.8 4 KiB kernel-parameter limit.