### PR TITLE
Allow trusted fork PRs to authenticate GPU CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .github/
 .claude/
 .vscode/
+gha-creds-*.json
 
 build/
 build-*/

--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -4,14 +4,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Expected repository variables:
-#   GCP_PROJECT_ID, GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT
+# The Google Cloud project, Workload Identity Provider, and service account
+# identifiers are intentionally committed here. They are public resource names,
+# not credentials, and fork pull_request workflows cannot read repository
+# variables. Google still issues short-lived credentials only when the provider's
+# repository, workflow, event, and actor conditions match.
 # The dedicated integration binary cache is:
 #   gs://kevmo314-lupine-gpu-integration-cache
 #
 # Keep GCP_SERVICE_ACCOUNT on a custom role rather than project Owner/Editor.
-# It should be bound through a Workload Identity Provider condition restricted
-# to this repository's numeric GitHub IDs, this workflow path, and trusted refs.
+# Bind it through a Workload Identity Provider condition restricted to this
+# repository's numeric GitHub IDs, this workflow path, trusted events/refs, and
+# maintainer actors.
 # The service account has bucket-scoped Storage Admin access to the dedicated
 # cache bucket, and this workflow owns that bucket's lifecycle configuration.
 
@@ -64,7 +68,9 @@ jobs:
             server_ld_library_path: ""
 
     env:
-      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_PROJECT_ID: kevmo314
+      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/272419586516/locations/global/workloadIdentityPools/lupine-github/providers/github
+      GCP_SERVICE_ACCOUNT: lupine-gpu-ci@kevmo314.iam.gserviceaccount.com
       GCP_BUILD_CACHE_BUCKET: kevmo314-lupine-gpu-integration-cache
       INTEGRATION_BINARY_CACHE_VERSION: v1
       GCP_ZONE: us-central1-a
@@ -103,13 +109,33 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
-          project_id: ${{ vars.GCP_PROJECT_ID }}
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      # google-github-actions/auth writes its generated ADC file into the
+      # workspace. Move it before Docker packages the pull request checkout so
+      # fork-controlled .dockerignore changes cannot add the credential file to
+      # the remote build context.
+      - name: Move Google Cloud credentials outside the build context
+        run: |
+          set -euo pipefail
+          credentials_path="${GOOGLE_GHA_CREDS_PATH:?Google auth did not create credentials}"
+          relocated_path="$RUNNER_TEMP/$(basename "$credentials_path")"
+          mv "$credentials_path" "$relocated_path"
+          chmod 600 "$relocated_path"
+          {
+            echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=$relocated_path"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$relocated_path"
+            echo "GOOGLE_GHA_CREDS_PATH=$relocated_path"
+            echo "LUPINE_GCP_CREDS_PATH=$relocated_path"
+          } >> "$GITHUB_ENV"
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
@@ -687,9 +713,9 @@ jobs:
         if: github.event_name != 'pull_request' && env.INTEGRATION_BINARY_CACHE_HIT != 'true'
         uses: google-github-actions/auth@v3
         with:
-          project_id: ${{ vars.GCP_PROJECT_ID }}
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Save integration binary cache to GCS
         if: github.event_name != 'pull_request' && env.INTEGRATION_BINARY_CACHE_HIT != 'true'
@@ -759,9 +785,9 @@ jobs:
         if: always()
         uses: google-github-actions/auth@v3
         with:
-          project_id: ${{ vars.GCP_PROJECT_ID }}
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
 
       - name: Tear down GCE resources
         if: always()
@@ -814,3 +840,7 @@ jobs:
           done
 
           exit "$leftovers"
+
+      - name: Remove relocated Google Cloud credentials
+        if: always()
+        run: rm -f -- "$LUPINE_GCP_CREDS_PATH"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+gha-creds-*.json
 a.out
 venv/
 build/


### PR DESCRIPTION
## What changed

- Commit the non-secret GCP project, Workload Identity Provider, and service-account resource identifiers in the GPU workflow so fork pull-request jobs do not depend on withheld repository variables.
- Keep Google authentication on short-lived OIDC credentials and retain the cloud-side repository, workflow, event/ref, and maintainer-actor conditions.
- Move the generated ADC file out of the checkout before the Docker context is packaged.
- Disable persisted checkout credentials and ignore generated `gha-creds-*.json` files.

## Why

The GPU integration jobs on fork PR #523 fail before provisioning because `vars.GCP_PROJECT_ID`, `vars.GCP_WORKLOAD_IDENTITY_PROVIDER`, and `vars.GCP_SERVICE_ACCOUNT` evaluate to empty strings. The auth action consequently receives neither a workload identity provider nor a credentials JSON value.

This keeps the existing `pull_request` trigger. It does not use `pull_request_target`, and fork code continues to execute only inside an ephemeral GCE VM created without a service account or OAuth scopes. The current Workload Identity Provider still requires the maintainer actor ID, so arbitrary fork pushes cannot mint credentials.

## Validation

- `actionlint .github/workflows/gpu-integration-gcloud.yml`
- Ruby YAML parse
- `git diff --check`
- Verified the current Google Workload Identity Provider condition and service-account binding