### PR TITLE
Share one writer between the forwarding backends

### DIFF
--- a/codegen/annotations_hip.h
+++ b/codegen/annotations_hip.h
@@ -27,6 +27,7 @@ hipError_t hipDeviceGet(int *device, int ordinal);
  * @param prop RECV_ONLY
  * @param deviceId SEND_ONLY
  * @routingkey HIP_DEVICE deviceId
+ * @clearfields prop hdpMemFlushCntl hdpRegFlushCntl
  */
 hipError_t hipGetDevicePropertiesR0600(hipDeviceProp_tR0600 *prop,
                                        int deviceId);

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from string import Template
 from types import SimpleNamespace
 import argparse
+from collections import namedtuple
 import io
 import os
 import glob
@@ -18,6 +19,15 @@ import subprocess
 import textwrap
 import zlib
 from client_templates import collect_client_call_templates
+from emit import (
+    Backend,
+    format_call_args,
+    format_function_params,
+    write_client_rpc,
+    write_client_wrapper,
+    write_server_buffer_cleanup,
+    write_server_handler,
+)
 from ops import (
     NullableOperation,
     ArrayOperation,
@@ -202,19 +212,6 @@ NVML_RPC_FUNCTIONS = [
     "nvmlDeviceGetCudaComputeCapability",
 ]
 
-HIP_RPC_FUNCTIONS = [
-    "hipInit",
-    "hipGetDeviceCount",
-    "hipDeviceGet",
-    # HIP's public macro resolves to this versioned ABI symbol.
-    "hipGetDevicePropertiesR0600",
-    "hipDeviceGetName",
-    "hipDeviceTotalMem",
-    "hipDeviceGetAttribute",
-    "hipDriverGetVersion",
-    "hipRuntimeGetVersion",
-]
-
 HIP_MANUAL_REMAPPINGS = [
     ("hipGetDeviceProperties", "hipGetDevicePropertiesR0600"),
 ]
@@ -381,6 +378,22 @@ def rpc_id(name: str) -> int:
 
 # One annotation file per shim target. A declaration belongs to the target
 # whose file it lives in, so no API-name prefix is needed to tell them apart.
+NVML = Backend(
+    result="nvmlReturn_t",
+    invalid_argument="NVML_ERROR_INVALID_ARGUMENT",
+    device_routing_kind="NVML_DEVICE",
+    symbol_lookup="nvml_symbol",
+    lookup_on_all_connections=True,
+)
+
+HIP = Backend(
+    result="hipError_t",
+    invalid_argument="hipErrorInvalidValue",
+    device_routing_kind="HIP_DEVICE",
+    symbol_lookup="hip_symbol",
+    guard_null_conn=True,
+)
+
 ANNOTATION_FILES = {
     "cuda": "annotations_cuda.h",
     "nvml": "annotations_nvml.h",
@@ -584,6 +597,13 @@ def parse_annotation(
                 async_="ASYNC" in parts[4:],
             )
             continue
+        if line.startswith("@clearfields"):
+            # @clearfields <param> <member>...
+            parts = line.split()
+            if len(parts) < 3:
+                raise RuntimeError("@clearfields requires a parameter and members")
+            metadata.clear_fields.append((parts[1], tuple(parts[2:])))
+            continue
         if line.startswith("@graphexecnode"):
             parts = line.split()
             if len(parts) != 3 or metadata.graph_exec_node is not None:
@@ -774,87 +794,8 @@ def parse_annotation(
                         length=length_param,
                     )
                 )
-            elif size_arg:
-                # if it has a size, it's an array operation with constant length
-                operations.append(
-                    ArrayOperation(
-                        send=send,
-                        recv=recv,
-                        parameter=param,
-                        ptr=param.type,
-                        length=int(size_arg.split(":")[1]),
-                    )
-                )
-            elif null_terminated:
-                # if it's null terminated, it's a null terminated operation
-                operations.append(
-                    NullTerminatedOperation(
-                        send=send,
-                        recv=recv,
-                        parameter=param,
-                        ptr=param.type,
-                    )
-                )
-            elif nullable:
-                # if it's nullable, it's a nullable operation
-                operations.append(
-                    NullableOperation(
-                        send=send,
-                        recv=recv,
-                        parameter=param,
-                        ptr=param.type,
-                    )
-                )
             else:
-                # otherwise, it's a pointer to a single value or another pointer
-                if recv:
-                    if param.type.ptr_to.format() == "void":
-                        raise NotImplementedError("Cannot dereference a void pointer")
-                    # this is an out parameter so use the base type as the server declaration
-                    operations.append(
-                        DereferenceOperation(
-                            send=send,
-                            recv=recv,
-                            parameter=param,
-                            type_=param.type,
-                        )
-                    )
-                else:
-                    # otherwise, treat it as an opaque type
-                    operations.append(
-                        OpaqueTypeOperation(
-                            send=send,
-                            recv=recv,
-                            parameter=param,
-                            type_=param.type,
-                        )
-                    )
-        elif isinstance(param.type, Type):
-            if param.type.const:
-                recv = False
-            operations.append(
-                OpaqueTypeOperation(
-                    send=send,
-                    recv=recv,
-                    parameter=param,
-                    type_=param.type,
-                )
-            )
-        elif isinstance(param.type, Array):
-            length_param = next(p for p in params if p.name == length_arg.split(":")[1])
-            if param.type.array_of.const:
-                recv = False
-            operations.append(
-                ArrayOperation(
-                    send=send,
-                    recv=recv,
-                    parameter=param,
-                    ptr=param.type,
-                    length=length_param,
-                )
-            )
-        else:
-            raise NotImplementedError("Unknown type")
+                raise NotImplementedError("Unknown type")
     # Promote the count param of any optional out-array to an
     # InOutCountOperation. Several arrays may share one count (cuGraphGetEdges);
     # the first one is the anchor whose presence the client uses to decide
@@ -930,47 +871,33 @@ def parse_annotation(
 def client_routing_key_expr(
     kind: Optional[str], param: Optional[Parameter], metadata: FunctionAnnotationMetadata
 ) -> str:
+    # The kind names the selector, so a new kind needs one but no change here.
     if kind is None:
         return "lupine_route_for_default()"
+    route = f"lupine_route_for_{kind.lower()}"
     if kind == "CURRENT_CONTEXT":
-        return "lupine_route_for_current_context()"
+        return f"{route}()"
     if param is None:
         raise NotImplementedError(f"Routing key {kind} requires a parameter")
     name = param.name
     if kind == "DEVICE":
-        return f"lupine_route_for_device(&{name})"
-    if kind == "CONTEXT":
-        return f"lupine_route_for_context({name})"
-    if kind == "MODULE":
-        return f"lupine_route_for_module({name})"
-    if kind == "LIBRARY":
-        return f"lupine_route_for_library({name})"
-    if kind == "FUNCTION":
-        if param.type.format() == "CUkernel":
-            name = f"reinterpret_cast<CUfunction>({name})"
-        return f"lupine_route_for_function({name})"
-    if kind == "STREAM":
-        if metadata.routing_fallback is not None:
-            fallback = client_routing_key_expr(
+        # By address: the selector rewrites the ordinal to the server's.
+        name = f"&{name}"
+    elif kind == "FUNCTION" and param.type.format() == "CUkernel":
+        name = f"reinterpret_cast<CUfunction>({name})"
+    elif kind == "STREAM":
+        # The default stream belongs to no route, so a null handle falls back.
+        fallback = (
+            client_routing_key_expr(
                 metadata.routing_fallback.kind,
                 metadata.routing_fallback.parameter,
                 metadata,
             )
-            return f"({name} != nullptr ? lupine_route_for_stream({name}) : {fallback})"
-        return f"({name} != nullptr ? lupine_route_for_stream({name}) : lupine_route_for_default())"
-    if kind == "EVENT":
-        return f"lupine_route_for_event({name})"
-    if kind == "MEMORY_POOL":
-        return f"lupine_route_for_memory_pool({name})"
-    if kind == "GRAPH":
-        return f"lupine_route_for_graph({name})"
-    if kind == "GRAPH_NODE":
-        return f"lupine_route_for_graph_node({name})"
-    if kind == "GRAPH_EXEC":
-        return f"lupine_route_for_graph_exec({name})"
-    if kind == "DEVICEPTR":
-        return f"lupine_route_for_deviceptr({name})"
-    raise NotImplementedError(f"Unknown routing key kind: {kind}")
+            if metadata.routing_fallback is not None
+            else "lupine_route_for_default()"
+        )
+        return f"({name} != nullptr ? {route}({name}) : {fallback})"
+    return f"{route}({name})"
 
 
 def client_routing_route_expr(metadata: FunctionAnnotationMetadata) -> str:
@@ -988,37 +915,13 @@ def write_client_rpc_write(f, operation: Operation, metadata: FunctionAnnotation
 
 
 def client_record_owner_stmt(owner: OwnerAnnotation) -> str:
-    kind = owner.kind
     name = owner.parameter.name
-    value = f"*{name}" if isinstance(owner.parameter.type, Pointer) else name
-    null_guard = f" && {name} != nullptr" if isinstance(owner.parameter.type, Pointer) else ""
-    if kind == "CONTEXT":
-        fn = "lupine_note_context_owner"
-    elif kind == "MODULE":
-        fn = "lupine_note_module_owner"
-    elif kind == "LIBRARY":
-        fn = "lupine_note_library_owner"
-    elif kind == "FUNCTION":
-        fn = "lupine_note_function_owner"
-    elif kind == "STREAM":
-        fn = "lupine_note_stream_owner"
-    elif kind == "EVENT":
-        fn = "lupine_note_event_owner"
-    elif kind == "MEMORY_POOL":
-        fn = "lupine_note_memory_pool_owner"
-    elif kind == "GRAPH":
-        fn = "lupine_note_graph_owner"
-    elif kind == "GRAPH_NODE":
-        fn = "lupine_note_graph_node_owner"
-    elif kind == "GRAPH_EXEC":
-        fn = "lupine_note_graph_exec_owner"
-    elif kind == "DEVICEPTR":
-        fn = "lupine_note_deviceptr_owner"
-    else:
-        raise NotImplementedError(f"Unknown owner kind: {kind}")
+    output = isinstance(owner.parameter.type, Pointer)
+    value = f"*{name}" if output else name
+    null_guard = f" && {name} != nullptr" if output else ""
     return (
         f"    if (return_value == CUDA_SUCCESS{null_guard}) {{\n"
-        f"        {fn}_route({value}, route);\n"
+        f"        lupine_note_{owner.kind.lower()}_owner_route({value}, route);\n"
         "    }\n"
     )
 
@@ -1063,88 +966,60 @@ def write_client_post_call(f, metadata: FunctionAnnotationMetadata):
         f.write("    if (return_value == CUDA_SUCCESS) return_value = lupine_sync_mapped_device_to_host();\n")
 
 
+# The results generated code produces on its own. An entry naming a type rather
+# than a code marks a result that carries no error value.
+ResultCodes = namedtuple(
+    "ResultCodes", "unavailable invalid_device invalid_argument"
+)
+
+RESULT_CODES = {
+    "CUresult": ResultCodes(
+        "CUDA_ERROR_DEVICE_UNAVAILABLE",
+        "CUDA_ERROR_INVALID_DEVICE",
+        "CUDA_ERROR_INVALID_VALUE",
+    ),
+    "cudaError_t": ResultCodes(
+        "cudaErrorDevicesUnavailable",
+        "cudaErrorInvalidDevice",
+        "cudaErrorInvalidValue",
+    ),
+    "hipError_t": ResultCodes(
+        "hipErrorUnknown", "hipErrorInvalidDevice", "hipErrorInvalidValue"
+    ),
+    "nvmlReturn_t": ResultCodes("NVML_ERROR_GPU_IS_LOST", None, "NVML_ERROR_INVALID_ARGUMENT"),
+    "cublasStatus_t": ResultCodes(
+        "CUBLAS_STATUS_NOT_INITIALIZED",
+        None,
+        "CUBLAS_STATUS_INVALID_VALUE",
+    ),
+    "cudnnStatus_t": ResultCodes("CUDNN_STATUS_NOT_INITIALIZED", None, "CUDNN_STATUS_BAD_PARAM"),
+    "size_t": ResultCodes("size_t", None, None),
+    "const char*": ResultCodes("const char*", None, None),
+    "void": ResultCodes("void", None, None),
+    "struct cudaChannelFormatDesc": ResultCodes("struct cudaChannelFormatDesc", None, None),
+}
+
+
+def result_code(return_type: str, result: str) -> str:
+    codes = RESULT_CODES.get(return_type)
+    if codes is None or getattr(codes, result) is None:
+        raise NotImplementedError(f"No {result} result for return type: {return_type}")
+    return getattr(codes, result)
+
+
 def error_const(return_type: str) -> str:
-    if return_type == "nvmlReturn_t":
-        return "NVML_ERROR_GPU_IS_LOST"
-    if return_type == "hipError_t":
-        return "hipErrorUnknown"
-    if return_type == "CUresult":
-        return "CUDA_ERROR_DEVICE_UNAVAILABLE"
-    if return_type == "cudaError_t":
-        return "cudaErrorDevicesUnavailable"
-    if return_type == "cublasStatus_t":
-        return "CUBLAS_STATUS_NOT_INITIALIZED"
-    if return_type == "cudnnStatus_t":
-        return "CUDNN_STATUS_NOT_INITIALIZED"
-    if return_type == "size_t":
-        return "size_t"
-    if return_type == "const char*":
-        return "const char*"
-    if return_type == "void":
-        return "void"
-    if return_type == "struct cudaChannelFormatDesc":
-        return "struct cudaChannelFormatDesc"
-    raise NotImplementedError("Unknown return type: %s" % return_type)
+    return result_code(return_type, "unavailable")
 
 
 def invalid_device_const(return_type: str) -> str:
-    if return_type == "CUresult":
-        return "CUDA_ERROR_INVALID_DEVICE"
-    if return_type == "cudaError_t":
-        return "cudaErrorInvalidDevice"
-    if return_type == "hipError_t":
-        return "hipErrorInvalidDevice"
-    raise NotImplementedError(
-        "No invalid-device error for return type: %s" % return_type
-    )
+    return result_code(return_type, "invalid_device")
 
 
 def invalid_argument_const(return_type: str) -> str:
-    if return_type == "nvmlReturn_t":
-        return "NVML_ERROR_INVALID_ARGUMENT"
-    if return_type == "hipError_t":
-        return "hipErrorInvalidValue"
-    if return_type == "CUresult":
-        return "CUDA_ERROR_INVALID_VALUE"
-    if return_type == "cudaError_t":
-        return "cudaErrorInvalidValue"
-    if return_type == "cublasStatus_t":
-        return "CUBLAS_STATUS_INVALID_VALUE"
-    if return_type == "cudnnStatus_t":
-        return "CUDNN_STATUS_BAD_PARAM"
-    return error_const(return_type)
-
-
-def prefix_std(type: str) -> str:
-    # if type in ["size_t", "std::size_t"]:
-    #     return "std::size_t"
-    return type
-
-
-def format_function_params(function: Function) -> list[str]:
-    params = []
-    for param in function.parameters:
-        if param.name and "[]" in param.type.format():
-            params.append(
-                "{type} {name}".format(
-                    type=param.type.format().replace("[]", ""),
-                    name=param.name + "[]",
-                )
-            )
-        elif param.name:
-            params.append(
-                "{type} {name}".format(
-                    type=param.type.format(),
-                    name=param.name,
-                )
-            )
-        else:
-            params.append(param.type.format())
-    return params
-
-
-def format_call_args(function: Function) -> list[str]:
-    return [param.name for param in function.parameters if param.name]
+    codes = RESULT_CODES.get(return_type)
+    if codes is None or codes.invalid_argument is None:
+        return error_const(return_type)
+    return codes.invalid_argument
 
 
 def server_call_name(function_name: str) -> str:
@@ -1153,350 +1028,31 @@ def server_call_name(function_name: str) -> str:
     return function_name
 
 
-def collect_nvml_functions(
-    annotations: ParsedData, server_bindings: dict[str, ServerBinding]
+def collect_backend_functions(
+    annotations: ParsedData,
+    names=None,
+    server_bindings: dict[str, ServerBinding] = {},
+    string_length_type: str = None,
 ):
+    """Calls in the order named, or every call the annotation file declares."""
     by_name = {
         function.name.format(): function
         for function in annotations.namespace.functions
     }
     result = []
-    for name in NVML_RPC_FUNCTIONS:
+    for name in names if names is not None else by_name:
         if name in server_bindings:
             continue
         function = by_name.get(name)
         if function is None:
-            raise RuntimeError(f"NVML annotation for {name} not found")
+            raise RuntimeError(f"Annotation for {name} not found")
         metadata = parse_annotation(function.doxygen, function.parameters)
-        for operation in metadata.operations:
-            if isinstance(operation, NullTerminatedOperation):
-                # Preserve the existing NVML wire format. CUDA RPC strings use
-                # size_t lengths, while the NVML protocol historically used
-                # unsigned int lengths.
-                operation.length_type = "unsigned int"
+        if string_length_type is not None:
+            for operation in metadata.operations:
+                if isinstance(operation, NullTerminatedOperation):
+                    operation.length_type = string_length_type
         result.append((function, function, metadata.operations, metadata))
     return result
-
-
-def write_nvml_client_validation(f, operations):
-    checks = []
-    for operation in operations:
-        name = operation.parameter.name
-        if isinstance(operation, NullTerminatedOperation) and operation.send:
-            checks.append(f"{name} == nullptr")
-        elif isinstance(operation, DereferenceOperation):
-            checks.append(f"{name} == nullptr")
-        elif isinstance(operation, ArrayOperation):
-            checks.append(
-                f"({operation.transfer_size_expr()} != 0 && {name} == nullptr)"
-            )
-    if checks:
-        f.write("  if (" + " ||\n      ".join(checks) + ") {\n")
-        f.write("    return NVML_ERROR_INVALID_ARGUMENT;\n")
-        f.write("  }\n")
-
-
-def write_nvml_client_rpc(f, function, operations):
-    name = function.name.format()
-    params = ", ".join(format_function_params(function))
-    f.write(f"static nvmlReturn_t lupine_rpc_{name}(conn_t *conn")
-    if params:
-        f.write(f", {params}")
-    f.write(") {\n")
-    f.write("  nvmlReturn_t return_value = rpc_error();\n")
-    for operation in operations:
-        if isinstance(operation, NullTerminatedOperation):
-            f.write(
-                "  {length_type} {name}_len = static_cast<{length_type}>("
-                "std::strlen({name}) + 1);\n".format(
-                    length_type=operation.length_type,
-                    name=operation.parameter.name,
-                )
-            )
-        elif isinstance(operation, NullableOperation) and operation.recv:
-            f.write(
-                "  {type_} {name}_null_check = nullptr;\n".format(
-                    type_=operation.ptr.format(), name=operation.parameter.name
-                )
-            )
-
-    f.write(f"  if (rpc_write_start_request(conn, RPC_{name}) < 0 ||\n")
-    for operation in operations:
-        operation.client_rpc_write(f)
-    f.write("      rpc_wait_for_response(conn) < 0 ||\n")
-    for operation in operations:
-        operation.client_rpc_read(f)
-    f.write("      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||\n")
-    f.write("      rpc_read_end(conn) < 0) {\n")
-    f.write("    return rpc_error();\n")
-    f.write("  }\n")
-    f.write("  return return_value;\n")
-    f.write("}\n\n")
-
-
-def write_nvml_client_wrapper(f, function, operations, metadata):
-    if metadata.disabled_client:
-        return
-
-    name = function.name.format()
-    params = ", ".join(format_function_params(function))
-    f.write(f'extern "C" nvmlReturn_t {name}({params}) {{\n')
-    write_nvml_client_validation(f, operations)
-
-    call_args = format_call_args(function)
-    if metadata.routing_kind == "ALL":
-        owners = [
-            owner
-            for owner in metadata.record_owners
-            if owner.kind == "NVML_DEVICE"
-        ]
-        if len(owners) != 1 or not isinstance(owners[0].parameter.type, Pointer):
-            raise RuntimeError(
-                f"{name}: ALL-routed NVML lookup requires one NVML_DEVICE output"
-            )
-        output_name = owners[0].parameter.name
-        lambda_args = [
-            "remote_device" if arg == output_name else arg for arg in call_args
-        ]
-        f.write(
-            f"  return lookup_device_on_all_connections({output_name},\n"
-            "      [&](conn_t *conn, nvmlDevice_t *remote_device) {\n"
-            f"        return lupine_rpc_{name}(conn, {', '.join(lambda_args)});\n"
-            "      });\n"
-        )
-    else:
-        if metadata.routing_kind == "NVML_DEVICE":
-            if metadata.routing_parameter is None:
-                raise RuntimeError(f"{name}: NVML_DEVICE routing requires a parameter")
-            route_name = metadata.routing_parameter.name
-            f.write(f"  conn_t *conn = connection_for_device(&{route_name});\n")
-        elif metadata.routing_kind is None:
-            f.write("  conn_t *conn = connection();\n")
-        else:
-            raise RuntimeError(
-                f"{name}: unsupported NVML routing key {metadata.routing_kind}"
-            )
-        suffix = f", {', '.join(call_args)}" if call_args else ""
-        f.write(f"  return lupine_rpc_{name}(conn{suffix});\n")
-    f.write("}\n\n")
-
-
-def write_server_buffer_cleanup(f, owned_buffers, indent):
-    for buffer_name in reversed(owned_buffers):
-        f.write(f"{indent}free((void *){buffer_name});\n")
-
-
-def write_nvml_server_handler(f, function, operations):
-    name = function.name.format()
-    fn_params = ", ".join(
-        parameter.type.format() for parameter in function.parameters
-    )
-    f.write(f"int handle_{name}(conn_t *conn) {{\n")
-    owned_buffers = []
-    for operation in operations:
-        f.write(operation.server_declaration)
-        if (
-            isinstance(operation, DereferenceOperation)
-            and operation.recv
-            and not operation.send
-        ):
-            f.write(f"  {operation.parameter.name} = {{}};\n")
-    f.write("  int request_id;\n")
-    f.write("  nvmlReturn_t return_value;\n")
-    f.write(f"  using fn_t = nvmlReturn_t (*)({fn_params});\n")
-    f.write("  fn_t fn = nullptr;\n")
-    f.write("  if (\n")
-    for operation in operations:
-        if owned_buffer := operation.server_rpc_read(f):
-            owned_buffers.append(owned_buffer)
-    f.write("      false)\n")
-    f.write("    goto ERROR_0;\n\n")
-    f.write("  request_id = rpc_read_end(conn);\n")
-    f.write("  if (request_id < 0)\n")
-    f.write("    goto ERROR_0;\n\n")
-
-    call_args = []
-    for parameter in function.parameters:
-        operation = next(
-            op for op in operations if op.parameter.name == parameter.name
-        )
-        call_args.append(operation.server_reference)
-    f.write(f'  fn = nvml_symbol<fn_t>("{name}");\n')
-    f.write(
-        "  return_value = fn == nullptr ? function_not_found()\n"
-        f"                               : fn({', '.join(call_args)});\n\n"
-    )
-    f.write("  if (rpc_write_start_response(conn, request_id) < 0 ||\n")
-    for operation in operations:
-        operation.server_rpc_write(f)
-    f.write("      rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||\n")
-    f.write("      rpc_write_end(conn) < 0)\n")
-    f.write("    goto ERROR_0;\n")
-    write_server_buffer_cleanup(f, owned_buffers, "  ")
-    f.write("  return 0;\n")
-    f.write("ERROR_0:\n")
-    write_server_buffer_cleanup(f, owned_buffers, "  ")
-    f.write("  return -1;\n")
-    f.write("}\n\n")
-
-
-def collect_hip_functions(annotations: ParsedData):
-    by_name = {
-        function.name.format(): function
-        for function in annotations.namespace.functions
-    }
-    result = []
-    for name in HIP_RPC_FUNCTIONS:
-        function = by_name.get(name)
-        if function is None:
-            raise RuntimeError(f"HIP annotation for {name} not found")
-        metadata = parse_annotation(function.doxygen, function.parameters)
-        result.append((function, function, metadata.operations, metadata))
-    return result
-
-
-def write_hip_client_validation(f, function, operations):
-    checks = []
-    if function.name.format() == "hipDeviceGetName":
-        checks.append("len < 0")
-    for operation in operations:
-        name = operation.parameter.name
-        if isinstance(operation, NullTerminatedOperation) and operation.send:
-            checks.append(f"{name} == nullptr")
-        elif isinstance(operation, DereferenceOperation):
-            checks.append(f"{name} == nullptr")
-        elif isinstance(operation, ArrayOperation):
-            checks.append(
-                f"({operation.transfer_size_expr()} != 0 && {name} == nullptr)"
-            )
-    if checks:
-        f.write("  if (" + " ||\n      ".join(checks) + ") {\n")
-        f.write("    return hipErrorInvalidValue;\n")
-        f.write("  }\n")
-
-
-def write_hip_client_rpc(f, function, operations):
-    name = function.name.format()
-    params = ", ".join(format_function_params(function))
-    f.write(f"static hipError_t lupine_rpc_{name}(conn_t *conn")
-    if params:
-        f.write(f", {params}")
-    f.write(") {\n")
-    f.write("  hipError_t return_value = rpc_error();\n")
-    f.write("  if (conn == nullptr ||\n")
-    f.write(f"      rpc_write_start_request(conn, RPC_{name}) < 0 ||\n")
-    for operation in operations:
-        operation.client_rpc_write(f)
-    f.write("      rpc_wait_for_response(conn) < 0 ||\n")
-    for operation in operations:
-        operation.client_rpc_read(f)
-    f.write("      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||\n")
-    f.write("      rpc_read_end(conn) < 0) {\n")
-    if name == "hipGetDevicePropertiesR0600":
-        f.write("    prop->hdpMemFlushCntl = nullptr;\n")
-        f.write("    prop->hdpRegFlushCntl = nullptr;\n")
-    f.write("    return rpc_error();\n")
-    f.write("  }\n")
-    if name == "hipGetDevicePropertiesR0600":
-        f.write("  prop->hdpMemFlushCntl = nullptr;\n")
-        f.write("  prop->hdpRegFlushCntl = nullptr;\n")
-    f.write("  return return_value;\n")
-    f.write("}\n\n")
-
-
-def write_hip_client_wrapper(f, function, operations, metadata):
-    if metadata.disabled_client:
-        return
-
-    name = function.name.format()
-    params = ", ".join(format_function_params(function))
-    f.write(f'extern "C" hipError_t {name}({params}) {{\n')
-    write_hip_client_validation(f, function, operations)
-
-    call_args = format_call_args(function)
-    if metadata.routing_kind == "HIP_DEVICE":
-        if metadata.routing_parameter is None:
-            raise RuntimeError(f"{name}: HIP_DEVICE routing requires a parameter")
-        route_name = metadata.routing_parameter.name
-        f.write(f"  conn_t *conn = connection_for_device(&{route_name});\n")
-    elif metadata.routing_kind is None:
-        f.write("  conn_t *conn = connection();\n")
-    else:
-        raise RuntimeError(
-            f"{name}: unsupported HIP routing key {metadata.routing_kind}"
-        )
-    suffix = f", {', '.join(call_args)}" if call_args else ""
-    f.write(f"  return lupine_rpc_{name}(conn{suffix});\n")
-    f.write("}\n\n")
-
-
-def write_hip_server_handler(f, function, operations):
-    name = function.name.format()
-    fn_params = ", ".join(
-        parameter.type.format() for parameter in function.parameters
-    )
-    f.write(f"int handle_{name}(conn_t *conn) {{\n")
-    owned_buffers = []
-    for operation in operations:
-        f.write(operation.server_declaration)
-        if (
-            isinstance(operation, DereferenceOperation)
-            and operation.recv
-            and not operation.send
-        ):
-            if name == "hipGetDevicePropertiesR0600":
-                f.write("  std::memset(&prop, 0, sizeof(prop));\n")
-            else:
-                f.write(f"  {operation.parameter.name} = {{}};\n")
-    f.write("  int request_id;\n")
-    f.write("  hipError_t return_value;\n")
-    f.write(f"  using fn_t = hipError_t (*)({fn_params});\n")
-    f.write("  fn_t fn = nullptr;\n")
-    f.write("  if (\n")
-    for operation in operations:
-        if (
-            name == "hipDeviceGetName"
-            and isinstance(operation, ArrayOperation)
-            and operation.parameter.name == "name"
-        ):
-            # The length is read before the output buffer is allocated. Reject
-            # negative values before signed multiplication can become a huge
-            # allocation or wire size.
-            f.write("      len < 0 ||\n")
-        if owned_buffer := operation.server_rpc_read(f):
-            owned_buffers.append(owned_buffer)
-    f.write("      false)\n")
-    f.write("    goto ERROR_0;\n\n")
-    f.write("  request_id = rpc_read_end(conn);\n")
-    f.write("  if (request_id < 0)\n")
-    f.write("    goto ERROR_0;\n\n")
-
-    call_args = []
-    for parameter in function.parameters:
-        operation = next(
-            op for op in operations if op.parameter.name == parameter.name
-        )
-        call_args.append(operation.server_reference)
-    f.write(f'  fn = hip_symbol<fn_t>("{name}");\n')
-    f.write(
-        "  return_value = fn == nullptr ? function_not_found()\n"
-        f"                               : fn({', '.join(call_args)});\n\n"
-    )
-    if name == "hipGetDevicePropertiesR0600":
-        f.write("  prop.hdpMemFlushCntl = nullptr;\n")
-        f.write("  prop.hdpRegFlushCntl = nullptr;\n\n")
-    f.write("  if (rpc_write_start_response(conn, request_id) < 0 ||\n")
-    for operation in operations:
-        operation.server_rpc_write(f)
-    f.write("      rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||\n")
-    f.write("      rpc_write_end(conn) < 0)\n")
-    f.write("    goto ERROR_0;\n")
-    write_server_buffer_cleanup(f, owned_buffers, "  ")
-    f.write("  return 0;\n")
-    f.write("ERROR_0:\n")
-    write_server_buffer_cleanup(f, owned_buffers, "  ")
-    f.write("  return -1;\n")
-    f.write("}\n\n")
 
 
 HIP_ROOT = (
@@ -1566,6 +1122,609 @@ def attach_client_call_template(
             f"{template.return_type}, but the API returns {return_type}"
         )
     metadata.client_call_template = template
+
+
+def write_rpc_ids(
+    functions_with_annotations, annotated_names, hip_functions_with_annotations
+):
+    with open("gen_rpc_ids.h", "w") as f:
+        f.write("// Generated by codegen.py. Do not edit by hand.\n")
+        f.write("// RPC ids are stable 31-bit CRC32 hashes of their operation names.\n\n")
+
+        seen_rpc_ids: dict[int, str] = {}
+        emitted_macros: set[str] = set()
+
+        def write_rpc_define(macro_name: str, operation_name: str) -> None:
+            if macro_name in emitted_macros:
+                return
+            value = rpc_id(operation_name)
+            if value in seen_rpc_ids:
+                raise RuntimeError(
+                    f"RPC id collision: {operation_name} and {seen_rpc_ids[value]} "
+                    f"both hash to {value}"
+                )
+            seen_rpc_ids[value] = operation_name
+            emitted_macros.add(macro_name)
+            f.write(f"#define {macro_name} {value}\n")
+
+        for function, _, _, _ in functions_with_annotations:
+            name = function.name.format()
+            if name in PRIVATE_RPC_FUNCTIONS:
+                continue
+            write_rpc_define(f"RPC_{name}", name)
+        for name in annotated_names:
+            if name in PRIVATE_RPC_FUNCTIONS:
+                continue
+            write_rpc_define(f"RPC_{name}", name)
+        for name in NVML_RPC_FUNCTIONS:
+            write_rpc_define(f"RPC_{name}", name)
+        for function, _, _, _ in hip_functions_with_annotations:
+            name = function.name.format()
+            write_rpc_define(f"RPC_{name}", name)
+        f.write("\n")
+        for name in PRIVATE_RPC_FUNCTIONS:
+            write_rpc_define(f"LUPINE_RPC_{name}", name)
+
+
+def write_cuda_client(functions_with_annotations, legacy_abi_functions):
+    with open("gen_cuda_client.cpp", "w") as f:
+        f.write(
+            "#include <cuda.h>\n"
+            "\n"
+            "#define LUPINE_CUDA_COMPAT_TYPES_ONLY\n"
+            '#include "cuda_compat.h"\n'
+            "#undef LUPINE_CUDA_COMPAT_TYPES_ONLY\n"
+            "\n"
+            "#include <algorithm>\n"
+            "#include <cstdint>\n"
+            "#include <cstdio>\n"
+            "#include <cstring>\n"
+            "#include <string>\n"
+            "#include <unordered_map>\n"
+            "#include <vector>\n\n"
+            '#include "gen_rpc_ids.h"\n\n'
+            '#include "client_routing.h"\n'
+            '#include "rpc.h"\n\n'
+            "extern int rpc_size();\n"
+            "extern conn_t *rpc_client_get_connection(unsigned int index);\n"
+            "extern void rpc_close(conn_t *conn);\n"
+            'extern "C" void lupine_deep_cache_reset(const void *key);\n'
+            'extern "C" void *lupine_deep_cache_add(const void *key, '
+            "size_t bytes);\n\n"
+            'extern "C" conn_t *lupine_rpc_conn_for_device(CUdevice *device);\n'
+            'extern "C" conn_t *lupine_rpc_conn_for_current_context();\n'
+            'extern "C" conn_t *lupine_rpc_conn_for_context(CUcontext ctx);\n'
+            'extern "C" conn_t *lupine_rpc_conn_for_module(CUmodule module);\n'
+            'extern "C" conn_t *lupine_rpc_conn_for_function(CUfunction function);\n'
+            'extern "C" conn_t *lupine_rpc_conn_for_stream(CUstream stream);\n'
+            'extern "C" conn_t *lupine_rpc_conn_for_event(CUevent event);\n'
+            'extern "C" conn_t *lupine_rpc_conn_for_deviceptr(CUdeviceptr ptr);\n'
+            'extern "C" CUfunction lupine_translate_private_function_for_rpc(CUfunction function);\n'
+            'extern "C" void lupine_note_context_owner(CUcontext ctx, conn_t *conn);\n'
+            'extern "C" void lupine_note_module_owner(CUmodule module, conn_t *conn);\n'
+            'extern "C" void lupine_note_library_owner(CUlibrary library, conn_t *conn);\n'
+            'extern "C" void lupine_note_function_owner(CUfunction function, conn_t *conn);\n'
+            'extern "C" void lupine_note_stream_owner(CUstream stream, conn_t *conn);\n'
+            'extern "C" void lupine_note_event_owner(CUevent event, conn_t *conn);\n'
+            'extern "C" void lupine_note_memory_pool_owner(CUmemoryPool pool, conn_t *conn);\n'
+            'extern "C" void lupine_note_graph_owner(CUgraph graph, conn_t *conn);\n'
+            'extern "C" void lupine_note_graph_node_owner(CUgraphNode node, conn_t *conn);\n'
+            'extern "C" void lupine_note_graph_exec_owner(CUgraphExec exec, conn_t *conn);\n'
+            'extern "C" void lupine_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);\n\n'
+            'extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size, conn_t *conn);\n\n'
+            'extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);\n\n'
+            'extern "C" void lupine_forget_stream_owner(CUstream stream);\n\n'
+            'extern "C" const char *lupine_retain_returned_string(const void *handle, const char *data, size_t size);\n\n'
+            'extern "C" void lupine_release_module_retained_strings(CUmodule module);\n'
+            'extern "C" void lupine_release_library_retained_strings(CUlibrary library);\n\n'
+            'extern "C" void lupine_record_library_module(CUmodule module, CUlibrary library);\n\n'
+            'extern "C" CUresult lupine_record_library_kernel(CUkernel kernel, CUlibrary library, const char *name, lupine_route route);\n\n'
+            'extern "C" CUresult lupine_record_module_function(CUfunction function, CUmodule module, const char *name, lupine_route route);\n\n'
+            'extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first, CUdeviceptr second);\n'
+            'extern "C" CUresult lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice,\n'
+            '                                                   CUdeviceptr srcDevice,\n'
+            '                                                   size_t ByteCount,\n'
+            '                                                   CUstream hStream,\n'
+            '                                                   bool async);\n\n'
+            'extern "C" void lupine_invalidate_current_context_cache();\n'
+            'extern "C" void lupine_forget_destroyed_context(CUcontext ctx);\n'
+            'extern "C" void lupine_mark_context_green(CUcontext ctx);\n'
+            'extern "C" void lupine_invalidate_function_caches();\n'
+            'extern "C" void lupine_invalidate_kernel_attribute_cache();\n'
+            'extern "C" void lupine_kernel_attribute_cache_erase(int route_id, CUkernel kernel, int attrib, int dev);\n'
+            'extern "C" void lupine_invalidate_function_attribute_cache();\n'
+            'extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);\n'
+            'extern "C" int lupine_forward_remote_stdout(conn_t *conn);\n'
+            'extern "C" CUresult lupine_sync_mapped_device_to_host();\n\n'
+        )
+        for function, _, _, _ in legacy_abi_functions:
+            name = function.name.format()
+            f.write(f"#ifdef {name}\n#undef {name}\n#endif\n")
+            f.write(
+                'extern "C" {return_type} CUDAAPI {name}({params});\n\n'.format(
+                    return_type=function.return_type.format(),
+                    name=name,
+                    params=", ".join(format_function_params(function)),
+                )
+            )
+        for function, annotation, operations, metadata in functions_with_annotations:
+            # We don't generate client function definitions for client-disabled
+            # functions; their RPC/server definitions may still be generated.
+            if metadata.disabled_client:
+                continue
+
+            if metadata.guard is not None:
+                f.write(f"#if {metadata.guard}\n")
+
+            joined_params = ", ".join(format_function_params(function))
+
+            f.write(f"{function.return_type.format()} {function.name.format()}({joined_params})\n")
+            f.write("{\n")
+
+            all_output = metadata.routing_parameter
+            if metadata.routing_kind == "ALL":
+                if (
+                    function.return_type.format() != "CUresult"
+                    or all_output is None
+                    or not isinstance(all_output.type, Pointer)
+                    or all_output.type.ptr_to.format() != "CUdevice"
+                ):
+                    raise RuntimeError(
+                        f"{function.name.format()}: ALL routing requires a CUdevice * output"
+                    )
+                if metadata.async_fire_forget:
+                    raise RuntimeError(
+                        f"{function.name.format()}: ALL routing cannot be fire-and-forget"
+                    )
+
+                output_name = all_output.name
+                checks = [f"{output_name} == nullptr"]
+                for operation in operations:
+                    if isinstance(operation, NullTerminatedOperation) and operation.send:
+                        checks.append(f"{operation.parameter.name} == nullptr")
+                    elif (
+                        isinstance(operation, DereferenceOperation)
+                        and operation.parameter.name != output_name
+                    ):
+                        checks.append(f"{operation.parameter.name} == nullptr")
+                    elif isinstance(operation, ArrayOperation):
+                        checks.append(
+                            f"({operation.transfer_size_expr()} != 0 && "
+                            f"{operation.parameter.name} == nullptr)"
+                        )
+                f.write("    if (" + " || ".join(checks) + ") {\n")
+                f.write("        return CUDA_ERROR_INVALID_VALUE;\n")
+                f.write("    }\n")
+                f.write(
+                    f"    return lupine_lookup_device_on_all_routes({output_name},\n"
+                    "        [&](lupine_route route, CUdevice *route_output) {\n"
+                    f"            {all_output.type.format()} {output_name} = route_output;\n"
+                )
+            else:
+                f.write(f"    lupine_route route = {client_routing_route_expr(metadata)};\n")
+                if metadata.routing_kind == "DEVICE":
+                    f.write("    if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)\n")
+                    f.write(
+                        "        return {error_return};\n".format(
+                            error_return=invalid_device_const(
+                                function.return_type.format()
+                            )
+                        )
+                    )
+            if metadata.cross_server_copy is not None:
+                copy = metadata.cross_server_copy
+                stream_arg = (
+                    copy.stream.name
+                    if copy.stream is not None
+                    else "nullptr"
+                )
+                async_arg = "true" if copy.async_ else "false"
+                f.write(
+                    "    if (!lupine_deviceptrs_share_route({dst}, {src})) {{\n".format(
+                        dst=copy.dst.name,
+                        src=copy.src.name,
+                    )
+                )
+                f.write(
+                    "        return lupine_cuMemcpyDtoD_via_client("
+                    f"{copy.dst.name}, {copy.src.name}, {copy.bytes.name}, "
+                    f"{stream_arg}, {async_arg});\n"
+                )
+                f.write("    }\n")
+            if metadata.client_call_template is not None:
+                write_client_template_section(
+                    f, metadata.client_call_template.before_call
+                )
+            f.write(f"    {function.return_type.format()} return_value;\n")
+            call_args = ", ".join(client_call_args(function, metadata))
+            helper_args = f", {call_args}" if call_args else ""
+            local_call = f'lupine_call_real_cuda_fn("{function.name.format()}"{helper_args})'
+            local_post_call = io.StringIO()
+            write_client_post_call(local_post_call, metadata)
+            if local_post_call.getvalue():
+                f.write("    if (lupine_route_is_local(route)) {\n")
+                f.write(f"        return_value = {local_call};\n")
+                f.write(local_post_call.getvalue())
+                f.write("        return return_value;\n")
+                f.write("    }\n")
+            else:
+                f.write("    if (lupine_route_is_local(route))\n")
+                f.write(f"        return {local_call};\n")
+            f.write("    conn_t *conn = lupine_route_remote_conn(route);\n")
+
+            for operation in operations:
+                if isinstance(operation, OpaqueTypeOperation):
+                    f.write(operation.client_declaration())
+                if (
+                    isinstance(operation, InOutCountOperation)
+                    or isinstance(operation, NullableArrayOperation)
+                    or isinstance(operation, DeepStructOperation)
+                    or (
+                        isinstance(operation, NullTerminatedOperation)
+                        and operation.recv
+                    )
+                ):
+                    f.write(operation.client_declaration())
+
+            for operation in operations:
+                if isinstance(operation, NullTerminatedOperation) and operation.send:
+                    f.write(f"    std::size_t {operation.parameter.name}_len = std::strlen({operation.parameter.name}) + 1;\n")
+                if isinstance(operation, NullableOperation) and operation.recv:
+                    f.write(f"    {operation.ptr.format()} {operation.parameter.name}_null_check;\n")
+
+            # Reject invalid send buffers before lupine_prepare_rpc() flushes
+            # pending writes and rpc_write_start_request() acquires the
+            # connection's call/write locks. Conditions in the builder below
+            # may skip optional writes, but only rpc_write* calls themselves
+            # are allowed to fail the builder.
+            for operation in operations:
+                if isinstance(operation, ArrayOperation):
+                    operation.client_preflight(
+                        f, invalid_argument_const(function.return_type.format())
+                    )
+                elif (
+                    isinstance(operation, NullTerminatedOperation)
+                    and operation.recv
+                ):
+                    operation.client_preflight(
+                        f, invalid_argument_const(function.return_type.format())
+                    )
+
+            if metadata.async_fire_forget:
+                error_return = error_const(function.return_type.format())
+                f.write(
+                    f"    uint64_t async_sequence = 0;\n"
+                    f"    if (lupine_prepare_rpc(conn) < 0 ||\n"
+                    f"        rpc_write_start_async_request(\n"
+                    f"            conn, RPC_{function.name.format()}, &async_sequence) < 0 ||\n"
+                    f"        rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||\n"
+                )
+                for operation in operations:
+                    write_client_rpc_write(f, operation, metadata)
+                f.write("        rpc_write_end(conn) < 0) {\n")
+                f.write(f"        return {error_return};\n")
+                f.write("    }\n")
+                post_call = io.StringIO()
+                write_client_post_call(post_call, metadata)
+                if post_call.getvalue():
+                    f.write("    return_value = CUDA_SUCCESS;\n")
+                    f.write(post_call.getvalue())
+                    f.write("    return return_value;\n")
+                else:
+                    f.write("    return CUDA_SUCCESS;\n")
+                f.write("}\n\n")
+                if metadata.guard is not None:
+                    f.write("#endif\n\n")
+                continue
+
+            f.write(
+                f"    if (lupine_prepare_rpc(conn) < 0 ||\n"
+                f"        rpc_write_start_request(conn, RPC_{function.name.format()}) < 0 ||\n"
+            )
+
+            for operation in operations:
+                write_client_rpc_write(f, operation, metadata)
+
+            f.write("        rpc_wait_for_response(conn) < 0 ||\n")
+
+            if metadata.synchronize and metadata.synchronize.deferred_dtoh:
+                f.write("        lupine_read_deferred_dtoh_copies(conn) < 0 ||\n")
+            if metadata.synchronize and metadata.synchronize.stdout:
+                f.write("        lupine_forward_remote_stdout(conn) < 0 ||\n")
+
+            for operation in operations:
+                operation.client_rpc_read(f)
+
+            f.write(f"        rpc_read(conn, &return_value, sizeof({function.return_type.format()})) < 0 ||\n")
+            f.write("        rpc_read_end(conn) < 0)\n")
+            f.write(f"        return {error_const(function.return_type.format())};\n")
+
+            for operation in operations:
+                if isinstance(operation, NullTerminatedOperation) and operation.recv:
+                    retain = next(
+                        (
+                            item
+                            for item in metadata.retains
+                            if item.parameter.name == operation.parameter.name
+                        ),
+                        None,
+                    )
+                    if retain is None:
+                        raise RuntimeError(
+                            f"{function.name.format()}: returned string requires @retain"
+                        )
+                    operation.client_post_rpc(
+                        f,
+                        "CUDA_SUCCESS",
+                        "CUDA_ERROR_OUT_OF_MEMORY",
+                        retain.handle.name,
+                    )
+
+            write_client_post_call(f, metadata)
+            f.write("    return return_value;\n")
+            if metadata.routing_kind == "ALL":
+                f.write("        });\n")
+            f.write("}\n\n")
+            if metadata.guard is not None:
+                f.write("#endif\n\n")
+
+        function_by_name = {
+            function.name.format(): function
+            for function, _, _, metadata in functions_with_annotations
+            if not metadata.disabled_client
+        }
+        for alias, target in MANUAL_REMAPPINGS:
+            if alias in function_by_name or target not in function_by_name:
+                continue
+            target_function = function_by_name[target]
+            f.write(f"#ifdef {alias}\n#undef {alias}\n#endif\n")
+            f.write(
+                'extern "C" {return_type} {name}({params})\n'.format(
+                    return_type=target_function.return_type.format(),
+                    name=alias,
+                    params=", ".join(format_function_params(target_function)),
+                )
+            )
+            f.write("{\n")
+            call = "{target}({args})".format(
+                target=target,
+                args=", ".join(format_call_args(target_function)),
+            )
+            if target_function.return_type.format() == "void":
+                f.write(f"    {call};\n")
+                f.write("}\n\n")
+            else:
+                f.write(f"    return {call};\n")
+                f.write("}\n\n")
+        f.write("std::unordered_map<std::string, void *> functionMap = {\n")
+        for function, _, _, metadata in functions_with_annotations:
+            if metadata.disabled_client and metadata.disabled_server:
+                continue
+
+            if metadata.guard is not None:
+                f.write(f"#if {metadata.guard}\n")
+            f.write(
+                '    {{"{name}", (void *){name}}},\n'.format(
+                    name=function.name.format()
+                )
+            )
+            if metadata.guard is not None:
+                f.write("#endif\n")
+        # write manual overrides
+        function_names = set(
+            f.name.format()
+            for f, _, _, metadata in functions_with_annotations
+            if not metadata.disabled_client
+        )
+        for x, y in MANUAL_REMAPPINGS:
+            # ensure y exists in the function list
+            if y not in function_names:
+                print(f"Skipping manual remapping {x} -> {y}")
+                continue
+            f.write(
+                '    {{"{x}", (void *){y}}},\n'.format(
+                    x=x,
+                    y=y,
+                )
+            )
+        for alias, target, guard in FUNCTION_MAP_ALIASES:
+            if target not in function_names:
+                continue
+            f.write(f"#if {guard}\n")
+            f.write(
+                '    {{"{alias}", (void *){target}}},\n'.format(
+                    alias=alias,
+                    target=target,
+                )
+            )
+            f.write("#endif\n")
+        f.write("};\n\n")
+
+        f.write("void *get_function_pointer(const char *name)\n")
+        f.write("{\n")
+        f.write("    auto it = functionMap.find(name);\n")
+        f.write("    if (it == functionMap.end())\n")
+        f.write("        return nullptr;\n")
+        f.write("    return it->second;\n")
+        f.write("}\n")
+
+
+def write_cuda_server(
+    server_functions_with_annotations,
+    legacy_abi_functions,
+    server_bindings,
+    annotation_only_server_functions,
+):
+    with open("gen_cuda_server.cpp", "w") as f:
+        f.write(
+            "#include <iostream>\n"
+            "#include <cuda.h>\n"
+            '#include "cuda_compat.h"\n'
+            "\n"
+            "#include <cstring>\n"
+            "#include <string>\n"
+            '#include "gen_rpc_ids.h"\n\n'
+            '#include <vector>\n\n'
+            '#include <cstdio>\n\n'
+            '#include "cuda_server_memcpy.h"\n'
+            '#include "rpc.h"\n\n'
+        )
+        annotation_only_functions = (
+            legacy_abi_functions + annotation_only_server_functions
+        )
+        for function, _, _, _ in annotation_only_functions:
+            name = function.name.format()
+            f.write(f"#ifdef {name}\n#undef {name}\n#endif\n")
+            f.write(
+                'extern "C" {return_type} CUDAAPI {name}({params});\n\n'.format(
+                    return_type=function.return_type.format(),
+                    name=name,
+                    params=", ".join(format_function_params(function)),
+                )
+            )
+        for (
+            function,
+            annotation,
+            operations,
+            metadata,
+        ) in server_functions_with_annotations:
+            if (
+                metadata.disabled_server
+                or function.name.format() in server_bindings
+            ):
+                continue
+
+            if metadata.guard is not None:
+                f.write(f"#if {metadata.guard}\n")
+
+            # parse the annotation doxygen
+            f.write(f"int handle_{function.name.format()}(conn_t *conn)\n")
+            f.write("{\n")
+
+            owned_buffers = []
+
+            for operation in operations:
+                f.write(operation.server_declaration)
+
+            if metadata.async_fire_forget:
+                f.write("    uint64_t async_sequence = 0;\n")
+            f.write("    int request_id;\n")
+
+            # we only generate return from non-void types
+            if metadata.async_fire_forget:
+                pass
+            elif function.return_type.format() != "void":
+                f.write(f"    {function.return_type.format()} lupine_intercept_result;\n")
+            else:
+                f.write("    void* lupine_intercept_result;\n")
+
+            f.write("    if (\n")
+            if metadata.async_fire_forget:
+                f.write(
+                    "        rpc_read(conn, &async_sequence, "
+                    "sizeof(async_sequence)) < 0 ||\n"
+                )
+            for operation in operations:
+                if owned_buffer := operation.server_rpc_read(f):
+                    owned_buffers.append(owned_buffer)
+            f.write("        false)\n")
+            f.write("        goto ERROR_0;\n")
+
+            f.write("\n")
+
+            f.write("    request_id = rpc_read_end(conn);\n")
+            f.write("    if (request_id < 0)\n")
+            f.write("        goto ERROR_0;\n")
+
+            if metadata.graph_exec_node is not None:
+                graph_exec = metadata.graph_exec_node.graph_exec.name
+                node = metadata.graph_exec_node.node.name
+                f.write(
+                    f"    {node} = lupine_htod_graph_exec_node({graph_exec}, {node});\n"
+                )
+
+            if metadata.async_fire_forget:
+                f.write(
+                    "    if (rpc_async_sequence_begin(conn, async_sequence) < 0)\n"
+                    "        goto ERROR_0;\n\n"
+                )
+
+            params: list[str] = []
+            # these need to be in function param order, not operation order.
+            for param in function.parameters:
+                for op in operations:
+                    if op.parameter.name == param.name:
+                        params.append(op.server_reference)
+
+            if metadata.async_fire_forget or function.return_type.format() == "void":
+                f.write(
+                    "    {name}({params});\n\n".format(
+                        name=server_call_name(function.name.format()),
+                        params=", ".join(params),
+                    )
+                )
+                if metadata.async_fire_forget:
+                    f.write("    rpc_async_sequence_end(conn);\n\n")
+            else:
+                f.write(
+                    "    lupine_intercept_result = {name}({params});\n\n".format(
+                        name=server_call_name(function.name.format()),
+                        params=", ".join(params),
+                    )
+                )
+
+            if metadata.async_fire_forget:
+                write_server_buffer_cleanup(f, owned_buffers, "    ")
+                f.write("    return 0;\n")
+                f.write("ERROR_0:\n")
+                write_server_buffer_cleanup(f, owned_buffers, "    ")
+                f.write("    return -1;\n")
+                f.write("}\n\n")
+                if metadata.guard is not None:
+                    f.write("#endif\n\n")
+                continue
+
+            f.write("    if (rpc_write_start_response(conn, request_id) < 0 ||\n")
+
+            for operation in operations:
+                operation.server_rpc_write(f)
+
+            f.write(f"        rpc_write(conn, &lupine_intercept_result, sizeof({function.return_type.format()})) < 0 ||\n")
+            f.write("        rpc_write_end(conn) < 0)\n")
+            f.write("        goto ERROR_0;\n")
+            f.write("\n")
+            write_server_buffer_cleanup(f, owned_buffers, "    ")
+            f.write("    return 0;\n")
+
+            f.write("ERROR_0:\n")
+            write_server_buffer_cleanup(f, owned_buffers, "    ")
+            f.write("    return -1;\n")
+            f.write("}\n\n")
+            if metadata.guard is not None:
+                f.write("#endif\n\n")
+
+
+def write_registry(registry_entries, guarded_declarations, guarded_handlers):
+    with open("registry.cpp", "w") as f:
+        f.write(
+            REGISTRY_CPP_TEMPLATE.substitute(
+                cuda_registry_entries=" \\\n".join(registry_entries["CUDA"]),
+                nvml_registry_entries=" \\\n".join(registry_entries["NVML"]),
+                hip_registry_entries=" \\\n".join(registry_entries["HIP"]),
+                cuda_guarded_declarations="\n".join(
+                    guarded_declarations["CUDA"]
+                ),
+                nvml_guarded_declarations="\n".join(
+                    guarded_declarations["NVML"]
+                ),
+                hip_guarded_declarations="\n".join(
+                    guarded_declarations["HIP"]
+                ),
+                cuda_guarded_handlers="\n".join(guarded_handlers["CUDA"]),
+                nvml_guarded_handlers="\n".join(guarded_handlers["NVML"]),
+                hip_guarded_handlers="\n".join(guarded_handlers["HIP"]),
+            )
+        )
 
 
 def main():
@@ -1724,10 +1883,16 @@ def main():
             + ", ".join(sorted(missing_legacy_abi_functions))
         )
 
-    nvml_functions_with_annotations = collect_nvml_functions(
-        annotations, server_bindings
+    nvml_functions_with_annotations = collect_backend_functions(
+        annotations_by_target["nvml"],
+        NVML_RPC_FUNCTIONS,
+        server_bindings,
+        # NVML's protocol predates the size_t string lengths CUDA RPC uses.
+        string_length_type="unsigned int",
     )
-    hip_functions_with_annotations = collect_hip_functions(annotations)
+    hip_functions_with_annotations = collect_backend_functions(
+        annotations_by_target["hip"]
+    )
 
     annotated_names = sorted(
         set(annotated_rpc_names(cuda_annotations))
@@ -1738,57 +1903,24 @@ def main():
         }
     )
 
-    with open("gen_rpc_ids.h", "w") as f:
-        f.write("// Generated by codegen.py. Do not edit by hand.\n")
-        f.write("// RPC ids are stable 31-bit CRC32 hashes of their operation names.\n\n")
-
-        seen_rpc_ids: dict[int, str] = {}
-        emitted_macros: set[str] = set()
-
-        def write_rpc_define(macro_name: str, operation_name: str) -> None:
-            if macro_name in emitted_macros:
-                return
-            value = rpc_id(operation_name)
-            if value in seen_rpc_ids:
-                raise RuntimeError(
-                    f"RPC id collision: {operation_name} and {seen_rpc_ids[value]} "
-                    f"both hash to {value}"
-                )
-            seen_rpc_ids[value] = operation_name
-            emitted_macros.add(macro_name)
-            f.write(f"#define {macro_name} {value}\n")
-
-        for function, _, _, _ in functions_with_annotations:
-            name = function.name.format()
-            if name in PRIVATE_RPC_FUNCTIONS:
-                continue
-            write_rpc_define(f"RPC_{name}", name)
-        for name in annotated_names:
-            if name in PRIVATE_RPC_FUNCTIONS:
-                continue
-            write_rpc_define(f"RPC_{name}", name)
-        for name in NVML_RPC_FUNCTIONS:
-            write_rpc_define(f"RPC_{name}", name)
-        for name in HIP_RPC_FUNCTIONS:
-            write_rpc_define(f"RPC_{name}", name)
-        f.write("\n")
-        for name in PRIVATE_RPC_FUNCTIONS:
-            write_rpc_define(f"LUPINE_RPC_{name}", name)
+    write_rpc_ids(
+        functions_with_annotations, annotated_names, hip_functions_with_annotations
+    )
 
     with open("gen_nvml_client.inc", "w") as f:
         f.write("// Generated by codegen.py. Do not edit by hand.\n\n")
         for function, _, operations, metadata in nvml_functions_with_annotations:
             if metadata.disabled_client:
                 continue
-            write_nvml_client_rpc(f, function, operations)
-            write_nvml_client_wrapper(f, function, operations, metadata)
+            write_client_rpc(f, NVML, function, operations, metadata)
+            write_client_wrapper(f, NVML, function, operations, metadata)
 
     with open("gen_nvml_server.inc", "w") as f:
         f.write("// Generated by codegen.py. Do not edit by hand.\n\n")
         for function, _, operations, metadata in nvml_functions_with_annotations:
             if metadata.disabled_server:
                 continue
-            write_nvml_server_handler(f, function, operations)
+            write_server_handler(f, NVML, function, operations, metadata)
 
     with open("gen_nvml_server.h", "w") as f:
         f.write("// Generated by codegen.py. Do not edit by hand.\n\n")
@@ -1804,8 +1936,8 @@ def main():
             if metadata.disabled_client:
                 continue
             hip_client_functions[function.name.format()] = function
-            write_hip_client_rpc(f, function, operations)
-            write_hip_client_wrapper(f, function, operations, metadata)
+            write_client_rpc(f, HIP, function, operations, metadata)
+            write_client_wrapper(f, HIP, function, operations, metadata)
         for alias, target in HIP_MANUAL_REMAPPINGS:
             if alias in hip_client_functions:
                 continue
@@ -1832,7 +1964,7 @@ def main():
         for function, _, operations, metadata in hip_functions_with_annotations:
             if metadata.disabled_server:
                 continue
-            write_hip_server_handler(f, function, operations)
+            write_server_handler(f, HIP, function, operations, metadata)
 
     with open("gen_hip_server.h", "w") as f:
         f.write("// Generated by codegen.py. Do not edit by hand.\n\n")
@@ -1841,588 +1973,14 @@ def main():
                 continue
             f.write(f"int handle_{function.name.format()}(conn_t *conn);\n")
 
-    with open("gen_cuda_client.cpp", "w") as f:
-        f.write(
-            "#include <cuda.h>\n"
-            "\n"
-            "#define LUPINE_CUDA_COMPAT_TYPES_ONLY\n"
-            '#include "cuda_compat.h"\n'
-            "#undef LUPINE_CUDA_COMPAT_TYPES_ONLY\n"
-            "\n"
-            "#include <algorithm>\n"
-            "#include <cstdint>\n"
-            "#include <cstdio>\n"
-            "#include <cstring>\n"
-            "#include <string>\n"
-            "#include <unordered_map>\n"
-            "#include <vector>\n\n"
-            '#include "gen_rpc_ids.h"\n\n'
-            '#include "client_routing.h"\n'
-            '#include "rpc.h"\n\n'
-            "extern int rpc_size();\n"
-            "extern conn_t *rpc_client_get_connection(unsigned int index);\n"
-            "extern void rpc_close(conn_t *conn);\n"
-            'extern "C" void lupine_deep_cache_reset(const void *key);\n'
-            'extern "C" void *lupine_deep_cache_add(const void *key, '
-            "size_t bytes);\n\n"
-            'extern "C" conn_t *lupine_rpc_conn_for_device(CUdevice *device);\n'
-            'extern "C" conn_t *lupine_rpc_conn_for_current_context();\n'
-            'extern "C" conn_t *lupine_rpc_conn_for_context(CUcontext ctx);\n'
-            'extern "C" conn_t *lupine_rpc_conn_for_module(CUmodule module);\n'
-            'extern "C" conn_t *lupine_rpc_conn_for_function(CUfunction function);\n'
-            'extern "C" conn_t *lupine_rpc_conn_for_stream(CUstream stream);\n'
-            'extern "C" conn_t *lupine_rpc_conn_for_event(CUevent event);\n'
-            'extern "C" conn_t *lupine_rpc_conn_for_deviceptr(CUdeviceptr ptr);\n'
-            'extern "C" CUfunction lupine_translate_private_function_for_rpc(CUfunction function);\n'
-            'extern "C" void lupine_note_context_owner(CUcontext ctx, conn_t *conn);\n'
-            'extern "C" void lupine_note_module_owner(CUmodule module, conn_t *conn);\n'
-            'extern "C" void lupine_note_library_owner(CUlibrary library, conn_t *conn);\n'
-            'extern "C" void lupine_note_function_owner(CUfunction function, conn_t *conn);\n'
-            'extern "C" void lupine_note_stream_owner(CUstream stream, conn_t *conn);\n'
-            'extern "C" void lupine_note_event_owner(CUevent event, conn_t *conn);\n'
-            'extern "C" void lupine_note_memory_pool_owner(CUmemoryPool pool, conn_t *conn);\n'
-            'extern "C" void lupine_note_graph_owner(CUgraph graph, conn_t *conn);\n'
-            'extern "C" void lupine_note_graph_node_owner(CUgraphNode node, conn_t *conn);\n'
-            'extern "C" void lupine_note_graph_exec_owner(CUgraphExec exec, conn_t *conn);\n'
-            'extern "C" void lupine_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);\n\n'
-            'extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size, conn_t *conn);\n\n'
-            'extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);\n\n'
-            'extern "C" void lupine_forget_stream_owner(CUstream stream);\n\n'
-            'extern "C" const char *lupine_retain_returned_string(const void *handle, const char *data, size_t size);\n\n'
-            'extern "C" void lupine_release_module_retained_strings(CUmodule module);\n'
-            'extern "C" void lupine_release_library_retained_strings(CUlibrary library);\n\n'
-            'extern "C" void lupine_record_library_module(CUmodule module, CUlibrary library);\n\n'
-            'extern "C" CUresult lupine_record_library_kernel(CUkernel kernel, CUlibrary library, const char *name, lupine_route route);\n\n'
-            'extern "C" CUresult lupine_record_module_function(CUfunction function, CUmodule module, const char *name, lupine_route route);\n\n'
-            'extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first, CUdeviceptr second);\n'
-            'extern "C" CUresult lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice,\n'
-            '                                                   CUdeviceptr srcDevice,\n'
-            '                                                   size_t ByteCount,\n'
-            '                                                   CUstream hStream,\n'
-            '                                                   bool async);\n\n'
-            'extern "C" void lupine_invalidate_current_context_cache();\n'
-            'extern "C" void lupine_forget_destroyed_context(CUcontext ctx);\n'
-            'extern "C" void lupine_mark_context_green(CUcontext ctx);\n'
-            'extern "C" void lupine_invalidate_function_caches();\n'
-            'extern "C" void lupine_invalidate_kernel_attribute_cache();\n'
-            'extern "C" void lupine_kernel_attribute_cache_erase(int route_id, CUkernel kernel, int attrib, int dev);\n'
-            'extern "C" void lupine_invalidate_function_attribute_cache();\n'
-            'extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);\n'
-            'extern "C" int lupine_forward_remote_stdout(conn_t *conn);\n'
-            'extern "C" CUresult lupine_sync_mapped_device_to_host();\n\n'
-        )
-        for function, _, _, _ in legacy_abi_functions:
-            name = function.name.format()
-            f.write(f"#ifdef {name}\n#undef {name}\n#endif\n")
-            f.write(
-                'extern "C" {return_type} CUDAAPI {name}({params});\n\n'.format(
-                    return_type=function.return_type.format(),
-                    name=name,
-                    params=", ".join(format_function_params(function)),
-                )
-            )
-        for function, annotation, operations, metadata in functions_with_annotations:
-            # We don't generate client function definitions for client-disabled
-            # functions; their RPC/server definitions may still be generated.
-            if metadata.disabled_client:
-                continue
+    write_cuda_client(functions_with_annotations, legacy_abi_functions)
 
-            if metadata.guard is not None:
-                f.write(f"#if {metadata.guard}\n")
-
-            joined_params = ", ".join(format_function_params(function))
-
-            f.write(
-                "{return_type} {name}({params})\n".format(
-                    return_type=function.return_type.format(),
-                    name=function.name.format(),
-                    params=joined_params,
-                )
-            )
-            f.write("{\n")
-
-            all_output = metadata.routing_parameter
-            if metadata.routing_kind == "ALL":
-                if (
-                    function.return_type.format() != "CUresult"
-                    or all_output is None
-                    or not isinstance(all_output.type, Pointer)
-                    or all_output.type.ptr_to.format() != "CUdevice"
-                ):
-                    raise RuntimeError(
-                        f"{function.name.format()}: ALL routing requires a CUdevice * output"
-                    )
-                if metadata.async_fire_forget:
-                    raise RuntimeError(
-                        f"{function.name.format()}: ALL routing cannot be fire-and-forget"
-                    )
-
-                output_name = all_output.name
-                checks = [f"{output_name} == nullptr"]
-                for operation in operations:
-                    if isinstance(operation, NullTerminatedOperation) and operation.send:
-                        checks.append(f"{operation.parameter.name} == nullptr")
-                    elif (
-                        isinstance(operation, DereferenceOperation)
-                        and operation.parameter.name != output_name
-                    ):
-                        checks.append(f"{operation.parameter.name} == nullptr")
-                    elif isinstance(operation, ArrayOperation):
-                        checks.append(
-                            f"({operation.transfer_size_expr()} != 0 && "
-                            f"{operation.parameter.name} == nullptr)"
-                        )
-                f.write("    if (" + " || ".join(checks) + ") {\n")
-                f.write("        return CUDA_ERROR_INVALID_VALUE;\n")
-                f.write("    }\n")
-                f.write(
-                    f"    return lupine_lookup_device_on_all_routes({output_name},\n"
-                    "        [&](lupine_route route, CUdevice *route_output) {\n"
-                    f"            {all_output.type.format()} {output_name} = route_output;\n"
-                )
-            else:
-                f.write(
-                    "    lupine_route route = {route_expr};\n".format(
-                        route_expr=client_routing_route_expr(metadata)
-                    )
-                )
-                if metadata.routing_kind == "DEVICE":
-                    f.write("    if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)\n")
-                    f.write(
-                        "        return {error_return};\n".format(
-                            error_return=invalid_device_const(
-                                function.return_type.format()
-                            )
-                        )
-                    )
-            if metadata.cross_server_copy is not None:
-                copy = metadata.cross_server_copy
-                stream_arg = (
-                    copy.stream.name
-                    if copy.stream is not None
-                    else "nullptr"
-                )
-                async_arg = "true" if copy.async_ else "false"
-                f.write(
-                    "    if (!lupine_deviceptrs_share_route({dst}, {src})) {{\n".format(
-                        dst=copy.dst.name,
-                        src=copy.src.name,
-                    )
-                )
-                f.write(
-                    "        return lupine_cuMemcpyDtoD_via_client({dst}, {src}, {bytes}, {stream}, {async_});\n".format(
-                        dst=copy.dst.name,
-                        src=copy.src.name,
-                        bytes=copy.bytes.name,
-                        stream=stream_arg,
-                        async_=async_arg,
-                    )
-                )
-                f.write("    }\n")
-            if metadata.client_call_template is not None:
-                write_client_template_section(
-                    f, metadata.client_call_template.before_call
-                )
-            f.write(
-                "    {return_type} return_value;\n".format(
-                    return_type=function.return_type.format()
-                )
-            )
-            call_args = ", ".join(client_call_args(function, metadata))
-            helper_args = f", {call_args}" if call_args else ""
-            local_call = 'lupine_call_real_cuda_fn("{name}"{args})'.format(
-                name=function.name.format(), args=helper_args
-            )
-            local_post_call = io.StringIO()
-            write_client_post_call(local_post_call, metadata)
-            if local_post_call.getvalue():
-                f.write("    if (lupine_route_is_local(route)) {\n")
-                f.write(f"        return_value = {local_call};\n")
-                f.write(local_post_call.getvalue())
-                f.write("        return return_value;\n")
-                f.write("    }\n")
-            else:
-                f.write("    if (lupine_route_is_local(route))\n")
-                f.write(f"        return {local_call};\n")
-            f.write("    conn_t *conn = lupine_route_remote_conn(route);\n")
-
-            for operation in operations:
-                if isinstance(operation, OpaqueTypeOperation):
-                    f.write(operation.client_declaration())
-                if (
-                    isinstance(operation, InOutCountOperation)
-                    or isinstance(operation, NullableArrayOperation)
-                    or isinstance(operation, DeepStructOperation)
-                    or (
-                        isinstance(operation, NullTerminatedOperation)
-                        and operation.recv
-                    )
-                ):
-                    f.write(operation.client_declaration())
-
-            for operation in operations:
-                if isinstance(operation, NullTerminatedOperation) and operation.send:
-                    f.write(
-                        "    std::size_t {param_name}_len = std::strlen({param_name}) + 1;\n".format(
-                            param_name=operation.parameter.name
-                        )
-                    )
-                if isinstance(operation, NullableOperation) and operation.recv:
-                    f.write(
-                        "    {server_type} {param_name}_null_check;\n".format(
-                            server_type=operation.ptr.format(),
-                            param_name=operation.parameter.name,
-                        )
-                    )
-
-            # Reject invalid send buffers before lupine_prepare_rpc() flushes
-            # pending writes and rpc_write_start_request() acquires the
-            # connection's call/write locks. Conditions in the builder below
-            # may skip optional writes, but only rpc_write* calls themselves
-            # are allowed to fail the builder.
-            for operation in operations:
-                if isinstance(operation, ArrayOperation):
-                    operation.client_preflight(
-                        f, invalid_argument_const(function.return_type.format())
-                    )
-                elif (
-                    isinstance(operation, NullTerminatedOperation)
-                    and operation.recv
-                ):
-                    operation.client_preflight(
-                        f, invalid_argument_const(function.return_type.format())
-                    )
-
-            if metadata.async_fire_forget:
-                error_return = error_const(function.return_type.format())
-                f.write(
-                    "    uint64_t async_sequence = 0;\n"
-                    "    if (lupine_prepare_rpc(conn) < 0 ||\n"
-                    "        rpc_write_start_async_request(\n"
-                    "            conn, RPC_{name}, &async_sequence) < 0 ||\n"
-                    "        rpc_write(conn, &async_sequence, "
-                    "sizeof(async_sequence)) < 0 ||\n".format(
-                        name=function.name.format()
-                    )
-                )
-                for operation in operations:
-                    write_client_rpc_write(f, operation, metadata)
-                f.write("        rpc_write_end(conn) < 0) {\n")
-                f.write("        return {r};\n".format(r=error_return))
-                f.write("    }\n")
-                post_call = io.StringIO()
-                write_client_post_call(post_call, metadata)
-                if post_call.getvalue():
-                    f.write("    return_value = CUDA_SUCCESS;\n")
-                    f.write(post_call.getvalue())
-                    f.write("    return return_value;\n")
-                else:
-                    f.write("    return CUDA_SUCCESS;\n")
-                f.write("}\n\n")
-                if metadata.guard is not None:
-                    f.write("#endif\n\n")
-                continue
-
-            f.write(
-                "    if (lupine_prepare_rpc(conn) < 0 ||\n"
-                "        rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
-                    name=function.name.format()
-                )
-            )
-
-            for operation in operations:
-                write_client_rpc_write(f, operation, metadata)
-
-            f.write("        rpc_wait_for_response(conn) < 0 ||\n")
-
-            if metadata.synchronize and metadata.synchronize.deferred_dtoh:
-                f.write("        lupine_read_deferred_dtoh_copies(conn) < 0 ||\n")
-            if metadata.synchronize and metadata.synchronize.stdout:
-                f.write("        lupine_forward_remote_stdout(conn) < 0 ||\n")
-
-            for operation in operations:
-                operation.client_rpc_read(f)
-
-            f.write(
-                "        rpc_read(conn, &return_value, sizeof({return_type})) < 0 ||\n".format(
-                    return_type=function.return_type.format()
-                )
-            )
-            f.write("        rpc_read_end(conn) < 0)\n")
-            f.write(
-                "        return {error_return};\n".format(
-                    error_return=error_const(function.return_type.format())
-                )
-            )
-
-            for operation in operations:
-                if isinstance(operation, NullTerminatedOperation) and operation.recv:
-                    retain = next(
-                        (
-                            item
-                            for item in metadata.retains
-                            if item.parameter.name == operation.parameter.name
-                        ),
-                        None,
-                    )
-                    if retain is None:
-                        raise RuntimeError(
-                            f"{function.name.format()}: returned string requires @retain"
-                        )
-                    operation.client_post_rpc(
-                        f,
-                        "CUDA_SUCCESS",
-                        "CUDA_ERROR_OUT_OF_MEMORY",
-                        retain.handle.name,
-                    )
-
-            write_client_post_call(f, metadata)
-            f.write("    return return_value;\n")
-            if metadata.routing_kind == "ALL":
-                f.write("        });\n")
-            f.write("}\n\n")
-            if metadata.guard is not None:
-                f.write("#endif\n\n")
-
-        function_by_name = {
-            function.name.format(): function
-            for function, _, _, metadata in functions_with_annotations
-            if not metadata.disabled_client
-        }
-        for alias, target in MANUAL_REMAPPINGS:
-            if alias in function_by_name or target not in function_by_name:
-                continue
-            target_function = function_by_name[target]
-            f.write("#ifdef {name}\n#undef {name}\n#endif\n".format(name=alias))
-            f.write(
-                'extern "C" {return_type} {name}({params})\n'.format(
-                    return_type=target_function.return_type.format(),
-                    name=alias,
-                    params=", ".join(format_function_params(target_function)),
-                )
-            )
-            f.write("{\n")
-            call = "{target}({args})".format(
-                target=target,
-                args=", ".join(format_call_args(target_function)),
-            )
-            if target_function.return_type.format() == "void":
-                f.write("    {call};\n".format(call=call))
-                f.write("}\n\n")
-            else:
-                f.write("    return {call};\n".format(call=call))
-                f.write("}\n\n")
-        f.write("std::unordered_map<std::string, void *> functionMap = {\n")
-        for function, _, _, metadata in functions_with_annotations:
-            if metadata.disabled_client and metadata.disabled_server:
-                continue
-
-            if metadata.guard is not None:
-                f.write(f"#if {metadata.guard}\n")
-            f.write(
-                '    {{"{name}", (void *){name}}},\n'.format(
-                    name=function.name.format()
-                )
-            )
-            if metadata.guard is not None:
-                f.write("#endif\n")
-        # write manual overrides
-        function_names = set(
-            f.name.format()
-            for f, _, _, metadata in functions_with_annotations
-            if not metadata.disabled_client
-        )
-        for x, y in MANUAL_REMAPPINGS:
-            # ensure y exists in the function list
-            if y not in function_names:
-                print(f"Skipping manual remapping {x} -> {y}")
-                continue
-            f.write(
-                '    {{"{x}", (void *){y}}},\n'.format(
-                    x=x,
-                    y=y,
-                )
-            )
-        for alias, target, guard in FUNCTION_MAP_ALIASES:
-            if target not in function_names:
-                continue
-            f.write(f"#if {guard}\n")
-            f.write(
-                '    {{"{alias}", (void *){target}}},\n'.format(
-                    alias=alias,
-                    target=target,
-                )
-            )
-            f.write("#endif\n")
-        f.write("};\n\n")
-
-        f.write("void *get_function_pointer(const char *name)\n")
-        f.write("{\n")
-        f.write("    auto it = functionMap.find(name);\n")
-        f.write("    if (it == functionMap.end())\n")
-        f.write("        return nullptr;\n")
-        f.write("    return it->second;\n")
-        f.write("}\n")
-
-    with open("gen_cuda_server.cpp", "w") as f:
-        f.write(
-            "#include <iostream>\n"
-            "#include <cuda.h>\n"
-            '#include "cuda_compat.h"\n'
-            "\n"
-            "#include <cstring>\n"
-            "#include <string>\n"
-            '#include "gen_rpc_ids.h"\n\n'
-            '#include <vector>\n\n'
-            '#include <cstdio>\n\n'
-            '#include "cuda_server_memcpy.h"\n'
-            '#include "rpc.h"\n\n'
-        )
-        annotation_only_functions = (
-            legacy_abi_functions + annotation_only_server_functions
-        )
-        for function, _, _, _ in annotation_only_functions:
-            name = function.name.format()
-            f.write(f"#ifdef {name}\n#undef {name}\n#endif\n")
-            f.write(
-                'extern "C" {return_type} CUDAAPI {name}({params});\n\n'.format(
-                    return_type=function.return_type.format(),
-                    name=name,
-                    params=", ".join(format_function_params(function)),
-                )
-            )
-        for (
-            function,
-            annotation,
-            operations,
-            metadata,
-        ) in server_functions_with_annotations:
-            if (
-                metadata.disabled_server
-                or function.name.format() in server_bindings
-            ):
-                continue
-
-            if metadata.guard is not None:
-                f.write(f"#if {metadata.guard}\n")
-
-            # parse the annotation doxygen
-            f.write(
-                "int handle_{name}(conn_t *conn)\n".format(
-                    name=function.name.format(),
-                )
-            )
-            f.write("{\n")
-
-            owned_buffers = []
-
-            for operation in operations:
-                f.write(operation.server_declaration)
-
-            if metadata.async_fire_forget:
-                f.write("    uint64_t async_sequence = 0;\n")
-            f.write("    int request_id;\n")
-
-            # we only generate return from non-void types
-            if metadata.async_fire_forget:
-                pass
-            elif function.return_type.format() != "void":
-                f.write(
-                    "    {return_type} lupine_intercept_result;\n".format(
-                        return_type=function.return_type.format()
-                    )
-                )
-            else:
-                f.write("    void* lupine_intercept_result;\n")
-
-            f.write("    if (\n")
-            if metadata.async_fire_forget:
-                f.write(
-                    "        rpc_read(conn, &async_sequence, "
-                    "sizeof(async_sequence)) < 0 ||\n"
-                )
-            for operation in operations:
-                if owned_buffer := operation.server_rpc_read(f):
-                    owned_buffers.append(owned_buffer)
-            f.write("        false)\n")
-            f.write("        goto ERROR_0;\n")
-
-            f.write("\n")
-
-            f.write("    request_id = rpc_read_end(conn);\n")
-            f.write("    if (request_id < 0)\n")
-            f.write("        goto ERROR_0;\n")
-
-            if metadata.graph_exec_node is not None:
-                graph_exec = metadata.graph_exec_node.graph_exec.name
-                node = metadata.graph_exec_node.node.name
-                f.write(
-                    f"    {node} = lupine_htod_graph_exec_node({graph_exec}, {node});\n"
-                )
-
-            if metadata.async_fire_forget:
-                f.write(
-                    "    if (rpc_async_sequence_begin(conn, async_sequence) < 0)\n"
-                    "        goto ERROR_0;\n\n"
-                )
-
-            params: list[str] = []
-            # these need to be in function param order, not operation order.
-            for param in function.parameters:
-                for op in operations:
-                    if op.parameter.name == param.name:
-                        params.append(op.server_reference)
-
-            if metadata.async_fire_forget or function.return_type.format() == "void":
-                f.write(
-                    "    {name}({params});\n\n".format(
-                        name=server_call_name(function.name.format()),
-                        params=", ".join(params),
-                    )
-                )
-                if metadata.async_fire_forget:
-                    f.write("    rpc_async_sequence_end(conn);\n\n")
-            else:
-                f.write(
-                    "    lupine_intercept_result = {name}({params});\n\n".format(
-                        name=server_call_name(function.name.format()),
-                        params=", ".join(params),
-                    )
-                )
-
-            if metadata.async_fire_forget:
-                write_server_buffer_cleanup(f, owned_buffers, "    ")
-                f.write("    return 0;\n")
-                f.write("ERROR_0:\n")
-                write_server_buffer_cleanup(f, owned_buffers, "    ")
-                f.write("    return -1;\n")
-                f.write("}\n\n")
-                if metadata.guard is not None:
-                    f.write("#endif\n\n")
-                continue
-
-            f.write("    if (rpc_write_start_response(conn, request_id) < 0 ||\n")
-
-            for operation in operations:
-                operation.server_rpc_write(f)
-
-            f.write(
-                "        rpc_write(conn, &lupine_intercept_result, sizeof({return_type})) < 0 ||\n".format(
-                    return_type=function.return_type.format()
-                )
-            )
-            f.write("        rpc_write_end(conn) < 0)\n")
-            f.write("        goto ERROR_0;\n")
-            f.write("\n")
-            write_server_buffer_cleanup(f, owned_buffers, "    ")
-            f.write("    return 0;\n")
-
-            f.write("ERROR_0:\n")
-            write_server_buffer_cleanup(f, owned_buffers, "    ")
-            f.write("    return -1;\n")
-            f.write("}\n\n")
-            if metadata.guard is not None:
-                f.write("#endif\n\n")
+    write_cuda_server(
+        server_functions_with_annotations,
+        legacy_abi_functions,
+        server_bindings,
+        annotation_only_server_functions,
+    )
 
     generated_bindings = [
         ServerBinding(
@@ -2481,26 +2039,7 @@ def main():
                 f'#endif'
             )
 
-    with open("registry.cpp", "w") as f:
-        f.write(
-            REGISTRY_CPP_TEMPLATE.substitute(
-                cuda_registry_entries=" \\\n".join(registry_entries["CUDA"]),
-                nvml_registry_entries=" \\\n".join(registry_entries["NVML"]),
-                hip_registry_entries=" \\\n".join(registry_entries["HIP"]),
-                cuda_guarded_declarations="\n".join(
-                    guarded_declarations["CUDA"]
-                ),
-                nvml_guarded_declarations="\n".join(
-                    guarded_declarations["NVML"]
-                ),
-                hip_guarded_declarations="\n".join(
-                    guarded_declarations["HIP"]
-                ),
-                cuda_guarded_handlers="\n".join(guarded_handlers["CUDA"]),
-                nvml_guarded_handlers="\n".join(guarded_handlers["NVML"]),
-                hip_guarded_handlers="\n".join(guarded_handlers["HIP"]),
-            )
-        )
+    write_registry(registry_entries, guarded_declarations, guarded_handlers)
 
     subprocess.run(
         [

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -372,10 +372,6 @@ def collect_server_bindings(path: str) -> dict[str, ServerBinding]:
     return bindings
 
 
-def rpc_id(name: str) -> int:
-    return zlib.crc32(name.encode("utf-8")) & 0x7FFFFFFF
-
-
 # One annotation file per shim target. A declaration belongs to the target
 # whose file it lives in, so no API-name prefix is needed to tell them apart.
 NVML = Backend(
@@ -399,12 +395,6 @@ ANNOTATION_FILES = {
     "nvml": "annotations_nvml.h",
     "hip": "annotations_hip.h",
 }
-
-
-def annotated_rpc_names(annotations: ParsedData) -> list[str]:
-    return sorted(
-        {function.name.format() for function in annotations.namespace.functions}
-    )
 
 
 SKIP_FUNCTIONS = {
@@ -459,6 +449,17 @@ def infer_routing_key(
 
 
 # Parses a function annotation into marshalling operations and metadata.
+# Directives that name their annotation's fields in order. A field called
+# "kind" is taken as written; the rest name parameters.
+UNIFORM_ANNOTATIONS = {
+    "routingfallback": (RoutingFallbackAnnotation, None),
+    "recordowner": (OwnerAnnotation, "record_owners"),
+    "recordparent": (ParentAnnotation, "parents"),
+    "retain": (RetainAnnotation, "retains"),
+    "release": (ReleaseAnnotation, "releases"),
+}
+
+
 def parse_annotation(
     annotation: str, params: list[Parameter]
 ) -> FunctionAnnotationMetadata:
@@ -526,57 +527,24 @@ def parse_annotation(
             if len(parts) >= 3:
                 metadata.routing_parameter = annotation_param(params, parts[2])
             continue
-        if line.startswith("@routingfallback"):
+        directive = next(
+            (name for name in UNIFORM_ANNOTATIONS if line.startswith("@" + name)),
+            None,
+        )
+        if directive is not None:
+            annotation, target = UNIFORM_ANNOTATIONS[directive]
+            fields = list(annotation.__annotations__)
             parts = line.split()
-            if len(parts) < 3:
-                continue
-            metadata.routing_fallback = RoutingFallbackAnnotation(
-                kind=parts[1].upper(),
-                parameter=annotation_param(params, parts[2]),
-            )
-            continue
-        if line.startswith("@recordowner"):
-            parts = line.split()
-            if len(parts) < 3:
-                continue
-            param = annotation_param(params, parts[2])
-            metadata.record_owners.append(OwnerAnnotation(parts[1].upper(), param))
-            continue
-        if line.startswith("@retain"):
-            parts = line.split()
-            if len(parts) != 3:
-                raise RuntimeError("@retain requires an output parameter and a handle")
-            metadata.retains.append(
-                RetainAnnotation(
-                    parameter=annotation_param(params, parts[1]),
-                    handle=annotation_param(params, parts[2]),
-                )
-            )
-            continue
-        if line.startswith("@release"):
-            parts = line.split()
-            if len(parts) != 3:
-                raise RuntimeError("@release requires a handle kind and parameter")
-            metadata.releases.append(
-                ReleaseAnnotation(
-                    kind=parts[1].upper(),
-                    parameter=annotation_param(params, parts[2]),
-                )
-            )
-            continue
-        if line.startswith("@recordparent"):
-            parts = line.split()
-            if len(parts) != 4:
-                raise RuntimeError(
-                    "@recordparent requires a parent kind, child, and parent"
-                )
-            metadata.parents.append(
-                ParentAnnotation(
-                    kind=parts[1].upper(),
-                    child=annotation_param(params, parts[2]),
-                    parent=annotation_param(params, parts[3]),
-                )
-            )
+            if len(parts) != len(fields) + 1:
+                raise RuntimeError(f"@{directive} requires {' '.join(fields)}")
+            values = {
+                field: part.upper() if field == "kind" else annotation_param(params, part)
+                for field, part in zip(fields, parts[1:])
+            }
+            if target is None:
+                metadata.routing_fallback = annotation(**values)
+            else:
+                getattr(metadata, target).append(annotation(**values))
             continue
         if line.startswith("@crossservercopy"):
             parts = line.split()
@@ -900,20 +868,6 @@ def client_routing_key_expr(
     return f"{route}({name})"
 
 
-def client_routing_route_expr(metadata: FunctionAnnotationMetadata) -> str:
-    return client_routing_key_expr(
-        metadata.routing_kind, metadata.routing_parameter, metadata
-    )
-
-
-def client_call_args(function: Function, metadata: FunctionAnnotationMetadata) -> list[str]:
-    return [param.name for param in function.parameters if param.name]
-
-
-def write_client_rpc_write(f, operation: Operation, metadata: FunctionAnnotationMetadata):
-    operation.client_rpc_write(f)
-
-
 def client_record_owner_stmt(owner: OwnerAnnotation) -> str:
     name = owner.parameter.name
     output = isinstance(owner.parameter.type, Pointer)
@@ -924,11 +878,6 @@ def client_record_owner_stmt(owner: OwnerAnnotation) -> str:
         f"        lupine_note_{owner.kind.lower()}_owner_route({value}, route);\n"
         "    }\n"
     )
-
-
-def write_client_template_section(f, section: str):
-    if section:
-        f.write(textwrap.indent(section, "    "))
 
 
 def write_client_post_call(f, metadata: FunctionAnnotationMetadata):
@@ -960,7 +909,7 @@ def write_client_post_call(f, metadata: FunctionAnnotationMetadata):
         )
 
     if metadata.client_call_template is not None:
-        write_client_template_section(f, metadata.client_call_template.after_call)
+        f.write(textwrap.indent(metadata.client_call_template.after_call, "    "))
 
     if metadata.synchronize:
         f.write("    if (return_value == CUDA_SUCCESS) return_value = lupine_sync_mapped_device_to_host();\n")
@@ -1000,26 +949,11 @@ RESULT_CODES = {
 }
 
 
-def result_code(return_type: str, result: str) -> str:
+def result_code(return_type: str, result: str = "unavailable") -> str:
     codes = RESULT_CODES.get(return_type)
-    if codes is None or getattr(codes, result) is None:
-        raise NotImplementedError(f"No {result} result for return type: {return_type}")
-    return getattr(codes, result)
-
-
-def error_const(return_type: str) -> str:
-    return result_code(return_type, "unavailable")
-
-
-def invalid_device_const(return_type: str) -> str:
-    return result_code(return_type, "invalid_device")
-
-
-def invalid_argument_const(return_type: str) -> str:
-    codes = RESULT_CODES.get(return_type)
-    if codes is None or codes.invalid_argument is None:
-        return error_const(return_type)
-    return codes.invalid_argument
+    if codes is None:
+        raise NotImplementedError(f"Unknown return type: {return_type}")
+    return getattr(codes, result) or codes.unavailable
 
 
 def server_call_name(function_name: str) -> str:
@@ -1137,7 +1071,7 @@ def write_rpc_ids(
         def write_rpc_define(macro_name: str, operation_name: str) -> None:
             if macro_name in emitted_macros:
                 return
-            value = rpc_id(operation_name)
+            value = zlib.crc32(operation_name.encode("utf-8")) & 0x7FFFFFFF
             if value in seen_rpc_ids:
                 raise RuntimeError(
                     f"RPC id collision: {operation_name} and {seen_rpc_ids[value]} "
@@ -1301,16 +1235,16 @@ def write_cuda_client(functions_with_annotations, legacy_abi_functions):
                     f"            {all_output.type.format()} {output_name} = route_output;\n"
                 )
             else:
-                f.write(f"    lupine_route route = {client_routing_route_expr(metadata)};\n")
+                route_expr = client_routing_key_expr(
+                    metadata.routing_kind, metadata.routing_parameter, metadata
+                )
+                f.write(f"    lupine_route route = {route_expr};\n")
                 if metadata.routing_kind == "DEVICE":
                     f.write("    if (route.kind == LUPINE_ROUTE_UNKNOWN_DEVICE)\n")
-                    f.write(
-                        "        return {error_return};\n".format(
-                            error_return=invalid_device_const(
-                                function.return_type.format()
-                            )
-                        )
+                    invalid = result_code(
+                        function.return_type.format(), "invalid_device"
                     )
+                    f.write(f"        return {invalid};\n")
             if metadata.cross_server_copy is not None:
                 copy = metadata.cross_server_copy
                 stream_arg = (
@@ -1332,11 +1266,13 @@ def write_cuda_client(functions_with_annotations, legacy_abi_functions):
                 )
                 f.write("    }\n")
             if metadata.client_call_template is not None:
-                write_client_template_section(
-                    f, metadata.client_call_template.before_call
+                f.write(
+                    textwrap.indent(metadata.client_call_template.before_call, "    ")
                 )
             f.write(f"    {function.return_type.format()} return_value;\n")
-            call_args = ", ".join(client_call_args(function, metadata))
+            call_args = ", ".join(
+                param.name for param in function.parameters if param.name
+            )
             helper_args = f", {call_args}" if call_args else ""
             local_call = f'lupine_call_real_cuda_fn("{function.name.format()}"{helper_args})'
             local_post_call = io.StringIO()
@@ -1380,18 +1316,18 @@ def write_cuda_client(functions_with_annotations, legacy_abi_functions):
             for operation in operations:
                 if isinstance(operation, ArrayOperation):
                     operation.client_preflight(
-                        f, invalid_argument_const(function.return_type.format())
+                        f, result_code(function.return_type.format(), "invalid_argument")
                     )
                 elif (
                     isinstance(operation, NullTerminatedOperation)
                     and operation.recv
                 ):
                     operation.client_preflight(
-                        f, invalid_argument_const(function.return_type.format())
+                        f, result_code(function.return_type.format(), "invalid_argument")
                     )
 
             if metadata.async_fire_forget:
-                error_return = error_const(function.return_type.format())
+                error_return = result_code(function.return_type.format())
                 f.write(
                     f"    uint64_t async_sequence = 0;\n"
                     f"    if (lupine_prepare_rpc(conn) < 0 ||\n"
@@ -1400,7 +1336,7 @@ def write_cuda_client(functions_with_annotations, legacy_abi_functions):
                     f"        rpc_write(conn, &async_sequence, sizeof(async_sequence)) < 0 ||\n"
                 )
                 for operation in operations:
-                    write_client_rpc_write(f, operation, metadata)
+                    operation.client_rpc_write(f)
                 f.write("        rpc_write_end(conn) < 0) {\n")
                 f.write(f"        return {error_return};\n")
                 f.write("    }\n")
@@ -1423,7 +1359,7 @@ def write_cuda_client(functions_with_annotations, legacy_abi_functions):
             )
 
             for operation in operations:
-                write_client_rpc_write(f, operation, metadata)
+                operation.client_rpc_write(f)
 
             f.write("        rpc_wait_for_response(conn) < 0 ||\n")
 
@@ -1437,7 +1373,7 @@ def write_cuda_client(functions_with_annotations, legacy_abi_functions):
 
             f.write(f"        rpc_read(conn, &return_value, sizeof({function.return_type.format()})) < 0 ||\n")
             f.write("        rpc_read_end(conn) < 0)\n")
-            f.write(f"        return {error_const(function.return_type.format())};\n")
+            f.write(f"        return {result_code(function.return_type.format())};\n")
 
             for operation in operations:
                 if isinstance(operation, NullTerminatedOperation) and operation.recv:
@@ -1895,7 +1831,7 @@ def main():
     )
 
     annotated_names = sorted(
-        set(annotated_rpc_names(cuda_annotations))
+        {function.name.format() for function in cuda_annotations.namespace.functions}
         | {
             name
             for name, binding in server_bindings.items()
@@ -2002,7 +1938,7 @@ def main():
 
     operations_by_id = {}
     for binding in bindings:
-        operation = rpc_id(binding.name)
+        operation = zlib.crc32(binding.name.encode("utf-8")) & 0x7FFFFFFF
         if operation in operations_by_id:
             raise RuntimeError(
                 f"Duplicate RPC operation for {operations_by_id[operation]} "

--- a/codegen/emit.py
+++ b/codegen/emit.py
@@ -1,0 +1,251 @@
+"""Writers shared by the forwarding backends.
+
+A forwarding backend sends every annotated call to the server and resolves the
+vendor entry point there by name. A backend states its own types and codes;
+nothing here asks which one it is writing.
+"""
+
+from dataclasses import dataclass
+
+from cxxheaderparser.types import Function, Parameter, Pointer
+
+from ops import (
+    ArrayOperation,
+    DereferenceOperation,
+    NullableOperation,
+    NullTerminatedOperation,
+)
+
+
+@dataclass(frozen=True)
+class Backend:
+    result: str
+    invalid_argument: str
+    device_routing_kind: str
+    symbol_lookup: str
+    # A route may have no server behind it.
+    guard_null_conn: bool = False
+    # A device named by handle rather than by ordinal has to be looked for on
+    # every connection.
+    lookup_on_all_connections: bool = False
+
+
+def format_function_params(function: Function) -> list[str]:
+    params = []
+    for param in function.parameters:
+        if param.name and "[]" in param.type.format():
+            params.append(
+                "{type} {name}".format(
+                    type=param.type.format().replace("[]", ""),
+                    name=param.name + "[]",
+                )
+            )
+        elif param.name:
+            params.append(
+                f"{param.type.format()} {param.name}"
+            )
+        else:
+            params.append(param.type.format())
+    return params
+
+
+def format_call_args(function: Function) -> list[str]:
+    return [param.name for param in function.parameters if param.name]
+
+
+def signed_length_arrays(operations) -> list[ArrayOperation]:
+    # A signed element count is read before the buffer it sizes is allocated.
+    # Rejecting negatives keeps signed multiplication from becoming a huge
+    # allocation or wire size.
+    return [
+        operation
+        for operation in operations
+        if isinstance(operation, ArrayOperation)
+        and isinstance(operation.length, Parameter)
+        and operation.length.type.format() == "int"
+    ]
+
+
+def write_client_validation(f, backend: Backend, operations):
+    checks = [
+        f"{operation.length.name} < 0"
+        for operation in signed_length_arrays(operations)
+    ]
+    for operation in operations:
+        name = operation.parameter.name
+        if isinstance(operation, NullTerminatedOperation) and operation.send:
+            checks.append(f"{name} == nullptr")
+        elif isinstance(operation, DereferenceOperation):
+            checks.append(f"{name} == nullptr")
+        elif isinstance(operation, ArrayOperation):
+            checks.append(
+                f"({operation.transfer_size_expr()} != 0 && {name} == nullptr)"
+            )
+    if checks:
+        f.write("  if (" + " ||\n      ".join(checks) + ") {\n")
+        f.write(f"    return {backend.invalid_argument};\n")
+        f.write("  }\n")
+
+
+def write_cleared_fields(f, metadata, indent, reference):
+    for parameter, fields in metadata.clear_fields:
+        for name in fields:
+            f.write(f"{indent}{parameter}{reference}{name} = nullptr;\n")
+
+
+def write_client_rpc(f, backend: Backend, function, operations, metadata):
+    name = function.name.format()
+    params = ", ".join(format_function_params(function))
+    f.write(f"static {backend.result} lupine_rpc_{name}(conn_t *conn")
+    if params:
+        f.write(f", {params}")
+    f.write(") {\n")
+    f.write(f"  {backend.result} return_value = rpc_error();\n")
+    for operation in operations:
+        if isinstance(operation, NullTerminatedOperation):
+            f.write(
+                f"  {operation.length_type} {operation.parameter.name}_len = static_cast<{operation.length_type}>(std::strlen({operation.parameter.name}) + 1);\n"
+            )
+        elif isinstance(operation, NullableOperation) and operation.recv:
+            f.write(
+                f"  {operation.ptr.format()} {operation.parameter.name}_null_check = nullptr;\n"
+            )
+
+    opening = "  if (conn == nullptr ||\n      " if backend.guard_null_conn else "  if ("
+    f.write(f"{opening}rpc_write_start_request(conn, RPC_{name}) < 0 ||\n")
+    for operation in operations:
+        operation.client_rpc_write(f)
+    f.write("      rpc_wait_for_response(conn) < 0 ||\n")
+    for operation in operations:
+        operation.client_rpc_read(f)
+    f.write("      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||\n")
+    f.write("      rpc_read_end(conn) < 0) {\n")
+    write_cleared_fields(f, metadata, "    ", "->")
+    f.write("    return rpc_error();\n")
+    f.write("  }\n")
+    write_cleared_fields(f, metadata, "  ", "->")
+    f.write("  return return_value;\n")
+    f.write("}\n\n")
+
+
+def write_client_wrapper(f, backend: Backend, function, operations, metadata):
+    if metadata.disabled_client:
+        return
+
+    name = function.name.format()
+    params = ", ".join(format_function_params(function))
+    f.write(f'extern "C" {backend.result} {name}({params}) {{\n')
+    write_client_validation(f, backend, operations)
+
+    call_args = format_call_args(function)
+    if metadata.routing_kind == "ALL" and backend.lookup_on_all_connections:
+        owners = [
+            owner
+            for owner in metadata.record_owners
+            if owner.kind == backend.device_routing_kind
+        ]
+        if len(owners) != 1 or not isinstance(owners[0].parameter.type, Pointer):
+            raise RuntimeError(
+                f"{name}: ALL routing requires one "
+                f"{backend.device_routing_kind} output"
+            )
+        output_name = owners[0].parameter.name
+        lambda_args = [
+            "remote_device" if arg == output_name else arg for arg in call_args
+        ]
+        f.write(
+            f"  return lookup_device_on_all_connections({output_name},\n"
+            "      [&](conn_t *conn, nvmlDevice_t *remote_device) {\n"
+            f"        return lupine_rpc_{name}(conn, {', '.join(lambda_args)});\n"
+            "      });\n"
+        )
+        f.write("}\n\n")
+        return
+
+    if metadata.routing_kind == backend.device_routing_kind:
+        if metadata.routing_parameter is None:
+            raise RuntimeError(
+                f"{name}: {metadata.routing_kind} routing requires a parameter"
+            )
+        f.write(
+            "  conn_t *conn = connection_for_device("
+            f"&{metadata.routing_parameter.name});\n"
+        )
+    elif metadata.routing_kind is None:
+        f.write("  conn_t *conn = connection();\n")
+    else:
+        raise RuntimeError(f"{name}: unsupported routing key {metadata.routing_kind}")
+    suffix = f", {', '.join(call_args)}" if call_args else ""
+    f.write(f"  return lupine_rpc_{name}(conn{suffix});\n")
+    f.write("}\n\n")
+
+
+def write_server_buffer_cleanup(f, owned_buffers, indent):
+    for buffer_name in reversed(owned_buffers):
+        f.write(f"{indent}free((void *){buffer_name});\n")
+
+
+def write_server_handler(f, backend: Backend, function, operations, metadata):
+    name = function.name.format()
+    fn_params = ", ".join(
+        parameter.type.format() for parameter in function.parameters
+    )
+    cleared = {parameter for parameter, _ in metadata.clear_fields}
+    f.write(f"int handle_{name}(conn_t *conn) {{\n")
+    owned_buffers = []
+    for operation in operations:
+        f.write(operation.server_declaration)
+        if (
+            isinstance(operation, DereferenceOperation)
+            and operation.recv
+            and not operation.send
+        ):
+            argument = operation.parameter.name
+            # Zeroed whole so the cleared fields read as unset, not padding.
+            if argument in cleared:
+                f.write(f"  std::memset(&{argument}, 0, sizeof({argument}));\n")
+            else:
+                f.write(f"  {argument} = {{}};\n")
+    f.write("  int request_id;\n")
+    f.write(f"  {backend.result} return_value;\n")
+    f.write(f"  using fn_t = {backend.result} (*)({fn_params});\n")
+    f.write("  fn_t fn = nullptr;\n")
+    f.write("  if (\n")
+    signed_lengths = signed_length_arrays(operations)
+    for operation in operations:
+        if operation in signed_lengths:
+            f.write(f"      {operation.length.name} < 0 ||\n")
+        if owned_buffer := operation.server_rpc_read(f):
+            owned_buffers.append(owned_buffer)
+    f.write("      false)\n")
+    f.write("    goto ERROR_0;\n\n")
+    f.write("  request_id = rpc_read_end(conn);\n")
+    f.write("  if (request_id < 0)\n")
+    f.write("    goto ERROR_0;\n\n")
+
+    call_args = []
+    for parameter in function.parameters:
+        operation = next(
+            op for op in operations if op.parameter.name == parameter.name
+        )
+        call_args.append(operation.server_reference)
+    f.write(f'  fn = {backend.symbol_lookup}<fn_t>("{name}");\n')
+    f.write(
+        "  return_value = fn == nullptr ? function_not_found()\n"
+        f"                               : fn({', '.join(call_args)});\n\n"
+    )
+    if metadata.clear_fields:
+        write_cleared_fields(f, metadata, "  ", ".")
+        f.write("\n")
+    f.write("  if (rpc_write_start_response(conn, request_id) < 0 ||\n")
+    for operation in operations:
+        operation.server_rpc_write(f)
+    f.write("      rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||\n")
+    f.write("      rpc_write_end(conn) < 0)\n")
+    f.write("    goto ERROR_0;\n")
+    write_server_buffer_cleanup(f, owned_buffers, "  ")
+    f.write("  return 0;\n")
+    f.write("ERROR_0:\n")
+    write_server_buffer_cleanup(f, owned_buffers, "  ")
+    f.write("  return -1;\n")
+    f.write("}\n\n")

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -25,10 +25,7 @@ class NullableOperation:
         if not (self.send or self.recv):
             return
         f.write(
-            "        rpc_write(conn, &{param_name}, sizeof({server_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                server_type=self.ptr.format(),
-            )
+            f"        rpc_write(conn, &{self.parameter.name}, sizeof({self.ptr.format()})) < 0 ||\n"
         )
 
         if not self.send:
@@ -47,11 +44,9 @@ class NullableOperation:
 
     def client_unified_copy(self, f, direction, error):
         f.write(
-            "    if (maybe_copy_unified_arg(conn, (void*){name}, cudaMemcpyDeviceToHost) < 0)\n".format(
-                name=self.parameter.name
-            )
+            f"    if (maybe_copy_unified_arg(conn, (void*){self.parameter.name}, cudaMemcpyDeviceToHost) < 0)\n"
         )
-        f.write("      return {error};\n".format(error=error))
+        f.write(f"      return {error};\n")
 
     @property
     def server_declaration(self) -> str:
@@ -69,10 +64,7 @@ class NullableOperation:
         if not (self.send or self.recv):
             return
         f.write(
-            "        rpc_read(conn, &{param_name}_null_check, sizeof({server_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                server_type=self.ptr.format(),
-            )
+            f"        rpc_read(conn, &{self.parameter.name}_null_check, sizeof({self.ptr.format()})) < 0 ||\n"
         )
         if not self.send:
             return
@@ -96,32 +88,20 @@ class NullableOperation:
         if not self.recv:
             return
         f.write(
-            "        rpc_write(conn, &{param_name}_null_check, sizeof({server_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                server_type=self.ptr.format(),
-            )
+            f"        rpc_write(conn, &{self.parameter.name}_null_check, sizeof({self.ptr.format()})) < 0 ||\n"
         )
         f.write(
-            "        ({param_name}_null_check && rpc_write(conn, &{param_name}, sizeof({base_type})) < 0) ||\n".format(
-                param_name=self.parameter.name,
-                base_type=self.ptr.ptr_to.format(),
-            )
+            f"        ({self.parameter.name}_null_check && rpc_write(conn, &{self.parameter.name}, sizeof({self.ptr.ptr_to.format()})) < 0) ||\n"
         )
 
     def client_rpc_read(self, f):
         if not self.recv:
             return
         f.write(
-            "        rpc_read(conn, &{param_name}_null_check, sizeof({server_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                server_type=self.ptr.format(),
-            )
+            f"        rpc_read(conn, &{self.parameter.name}_null_check, sizeof({self.ptr.format()})) < 0 ||\n"
         )
         f.write(
-            "        ({param_name}_null_check && rpc_read(conn, {param_name}, sizeof({base_type})) < 0) ||\n".format(
-                param_name=self.parameter.name,
-                base_type=self.ptr.ptr_to.format(),
-            )
+            f"        ({self.parameter.name}_null_check && rpc_read(conn, {self.parameter.name}, sizeof({self.ptr.ptr_to.format()})) < 0) ||\n"
         )
 
 
@@ -196,101 +176,70 @@ class ArrayOperation:
         ):
             return
         f.write(
-            "    if ({size} != 0 && {param_name} == nullptr)\n"
-            "        return {error_return};\n".format(
-                param_name=self.parameter.name,
-                size=self.transfer_size_expr(),
-                error_return=error_return,
-            )
+            f"    if ({self.transfer_size_expr()} != 0 && {self.parameter.name} == nullptr)\n"
+                f"        return {error_return};\n"
         )
     def client_rpc_write(self, f):
         if not self.send:
             return
         if isinstance(self.length, int):
             f.write(
-                "        rpc_write(conn, {param_name}, {size}) < 0 ||\n".format(
-                    param_name=self.parameter.name,
-                    size=self.length,
-                )
+                f"        rpc_write(conn, {self.parameter.name}, {self.length}) < 0 ||\n"
             )
         # array length operations are handled differently than char
         elif isinstance(self.ptr, Array):
             f.write(
-                "        rpc_write(conn, &{param_name}, sizeof({param_type})) < 0 ||\n".format(
-                    param_name=self.parameter.name,
-                    param_type=self.ptr.array_of.format(),
-                )
+                f"        rpc_write(conn, &{self.parameter.name}, sizeof({self.ptr.array_of.format()})) < 0 ||\n"
             )
         else:
             f.write(
-                "        rpc_write(conn, {param_name}, {size}) < 0 ||\n".format(
-                    param_name=self.parameter.name,
-                    size=self.transfer_size_expr(),
-                )
+                f"        rpc_write(conn, {self.parameter.name}, {self.transfer_size_expr()}) < 0 ||\n"
             )
 
 
     def client_unified_copy(self, f, direction, error):
         f.write(
-            "    if (maybe_copy_unified_arg(conn, (void*){name}, {direction}) < 0)\n".format(
-                name=self.parameter.name, direction=direction
-            )
+            f"    if (maybe_copy_unified_arg(conn, (void*){self.parameter.name}, {direction}) < 0)\n"
         )
-        f.write("      return {error};\n".format(error=error))
+        f.write(f"      return {error};\n")
 
         if isinstance(self.length, int):
             f.write(
-                "    for (int i = 0; i < {name} && is_unified_pointer(conn, (void*){param}); i++)\n".format(
-                    param=self.parameter.name, name=self.length
-                )
+                f"    for (int i = 0; i < {self.length} && is_unified_pointer(conn, (void*){self.parameter.name}); i++)\n"
             )
             f.write(
-                "      if (maybe_copy_unified_arg(conn, (void*)&{name}[i], {direction}) < 0 )\n".format(
-                    name=self.parameter.name, direction=direction
-                )
+                f"      if (maybe_copy_unified_arg(conn, (void*)&{self.parameter.name}[i], {direction}) < 0 )\n"
             )
-            f.write("        return {error};\n".format(error=error))
+            f.write(f"        return {error};\n")
 
             return
 
         if hasattr(self.length.type, "ptr_to"):
             # need to cast the int a bit differently here
             f.write(
-                "    for (int i = 0; i < static_cast<int>(*{name}) && is_unified_pointer(conn, (void*){param}); i++)\n".format(
-                    param=self.parameter.name, name=self.length.name
-                )
+                f"    for (int i = 0; i < static_cast<int>(*{self.length.name}) && is_unified_pointer(conn, (void*){self.parameter.name}); i++)\n"
             )
             f.write(
-                "      if (maybe_copy_unified_arg(conn, (void*)&{name}[i], {direction}) < 0)\n".format(
-                    name=self.parameter.name, direction=direction
-                )
+                f"      if (maybe_copy_unified_arg(conn, (void*)&{self.parameter.name}[i], {direction}) < 0)\n"
             )
-            f.write("        return {error};\n".format(error=error))
+            f.write(f"        return {error};\n")
         else:
             if hasattr(self.parameter.type, "ptr_to"):
                 f.write(
-                    "    for (int i = 0; i < static_cast<int>({name}) && is_unified_pointer(conn, (void*){param}); i++)\n".format(
-                        param=self.parameter.name, name=self.length.name
-                    )
+                    f"    for (int i = 0; i < static_cast<int>({self.length.name}) && is_unified_pointer(conn, (void*){self.parameter.name}); i++)\n"
                 )
                 f.write(
-                    "      if (maybe_copy_unified_arg(conn, (void*)&{name}[i], {direction}) < 0)\n".format(
-                        name=self.parameter.name, direction=direction
-                    )
+                    f"      if (maybe_copy_unified_arg(conn, (void*)&{self.parameter.name}[i], {direction}) < 0)\n"
                 )
-                f.write("        return {error};\n".format(error=error))
+                f.write(f"        return {error};\n")
             else:
                 f.write(
-                    "    for (int i = 0; i < static_cast<int>({name}) && is_unified_pointer(conn, (void*){param}); i++)\n".format(
-                        param=self.parameter.name, name=self.length.name
-                    )
+                    f"    for (int i = 0; i < static_cast<int>({self.length.name}) && is_unified_pointer(conn, (void*){self.parameter.name}); i++)\n"
                 )
                 f.write(
-                    "      if (maybe_copy_unified_arg(conn, (void*){name}[i], {direction}) < 0)\n".format(
-                        name=self.parameter.name, direction=direction
-                    )
+                    f"      if (maybe_copy_unified_arg(conn, (void*){self.parameter.name}[i], {direction}) < 0)\n"
                 )
-                f.write("        return {error};\n".format(error=error))
+                f.write(f"        return {error};\n")
 
     @property
     def server_declaration(self) -> str:
@@ -315,17 +264,10 @@ class ArrayOperation:
                 f.write("        false)\n")
                 f.write("        goto ERROR_0;\n")
                 f.write(
-                    "    {param_name} = ({server_type})malloc({size});\n".format(
-                        param_name=self.parameter.name,
-                        server_type=self.ptr.format(),
-                        size=self.server_transfer_size_expr(),
-                    )
+                    f"    {self.parameter.name} = ({self.ptr.format()})malloc({self.server_transfer_size_expr()});\n"
                 )
                 f.write(
-                    "    if (({size} != 0 && {param_name} == nullptr) ||\n".format(
-                        param_name=self.parameter.name,
-                        size=self.server_transfer_size_expr(),
-                    )
+                    f"    if (({self.server_transfer_size_expr()} != 0 && {self.parameter.name} == nullptr) ||\n"
                 )
                 return self.parameter.name
             return
@@ -333,10 +275,7 @@ class ArrayOperation:
             f.write("        false)\n")
             f.write("        goto ERROR_0;\n")
             f.write(
-                "    {param_name}_size = {size};\n".format(
-                    param_name=self.parameter.name,
-                    size=self.server_transfer_size_expr(),
-                )
+                f"    {self.parameter.name}_size = {self.server_transfer_size_expr()};\n"
             )
             f.write(
                 "    {param_name} = ({server_type})malloc({size});\n".format(
@@ -346,9 +285,7 @@ class ArrayOperation:
                 )
             )
             f.write(
-                "    if ({param_name}_size != 0 && {param_name} == nullptr)\n".format(
-                    param_name=self.parameter.name
-                )
+                f"    if ({self.parameter.name}_size != 0 && {self.parameter.name} == nullptr)\n"
             )
             f.write("        goto ERROR_0;\n")
             f.write("    if(\n")
@@ -361,24 +298,15 @@ class ArrayOperation:
             return self.parameter.name
         elif isinstance(self.length, int):
             f.write(
-                "        rpc_read(conn, &{param_name}, {size}) < 0 ||\n".format(
-                    param_name=self.parameter.name,
-                    size=self.length,
-                )
+                f"        rpc_read(conn, &{self.parameter.name}, {self.length}) < 0 ||\n"
             )
         elif isinstance(self.ptr, Array):
             f.write(
-                "        rpc_read(conn, &{param_name}, sizeof({param_type}*)) < 0 ||\n".format(
-                    param_name=self.parameter.name,
-                    param_type=self.ptr.array_of.format(),
-                )
+                f"        rpc_read(conn, &{self.parameter.name}, sizeof({self.ptr.array_of.format()}*)) < 0 ||\n"
             )
         else:
             f.write(
-                "        rpc_read(conn, {param_name}, {size}) < 0 ||\n".format(
-                    param_name=self.parameter.name,
-                    size=self.transfer_size_expr(),
-                )
+                f"        rpc_read(conn, {self.parameter.name}, {self.transfer_size_expr()}) < 0 ||\n"
             )
 
         return None
@@ -397,17 +325,11 @@ class ArrayOperation:
             return
         if isinstance(self.length, int):
             f.write(
-                "        rpc_write(conn, {param_name}, {size}) < 0 ||\n".format(
-                    param_name=self.parameter.name,
-                    size=self.length,
-                )
+                f"        rpc_write(conn, {self.parameter.name}, {self.length}) < 0 ||\n"
             )
         else:
             f.write(
-                "        rpc_write(conn, {param_name}, {size}) < 0 ||\n".format(
-                    param_name=self.parameter.name,
-                    size=self.server_transfer_size_expr(),
-                )
+                f"        rpc_write(conn, {self.parameter.name}, {self.server_transfer_size_expr()}) < 0 ||\n"
             )
 
     def client_rpc_read(self, f):
@@ -415,17 +337,11 @@ class ArrayOperation:
             return
         if isinstance(self.length, int):
             f.write(
-                "        ({size} != 0 && rpc_read(conn, {param_name}, {size}) < 0) ||\n".format(
-                    param_name=self.parameter.name,
-                    size=self.length,
-                )
+                f"        ({self.length} != 0 && rpc_read(conn, {self.parameter.name}, {self.length}) < 0) ||\n"
             )
         else:
             f.write(
-                "        ({size} != 0 && rpc_read(conn, {param_name}, {size}) < 0) ||\n".format(
-                    param_name=self.parameter.name,
-                    size=self.transfer_size_expr(),
-                )
+                f"        ({self.transfer_size_expr()} != 0 && rpc_read(conn, {self.parameter.name}, {self.transfer_size_expr()}) < 0) ||\n"
             )
 
 
@@ -791,15 +707,10 @@ class NullTerminatedOperation:
         if not self.send:
             return
         f.write(
-            "        rpc_write(conn, &{param_name}_len, sizeof({length_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                length_type=self.length_type,
-            )
+            f"        rpc_write(conn, &{self.parameter.name}_len, sizeof({self.length_type})) < 0 ||\n"
         )
         f.write(
-            "        rpc_write(conn, {param_name}, {param_name}_len) < 0 ||\n".format(
-                param_name=self.parameter.name,
-            )
+            f"        rpc_write(conn, {self.parameter.name}, {self.parameter.name}_len) < 0 ||\n"
         )
 
     @property
@@ -821,33 +732,23 @@ class NullTerminatedOperation:
 
     def client_unified_copy(self, f, direction, error):
         f.write(
-            "    if (maybe_copy_unified_arg(conn, (void*){name}, {direction}) < 0)\n".format(
-                name=self.parameter.name, direction=direction
-            )
+            f"    if (maybe_copy_unified_arg(conn, (void*){self.parameter.name}, {direction}) < 0)\n"
         )
-        f.write("      return {error};\n".format(error=error))
+        f.write(f"      return {error};\n")
 
     def server_rpc_read(self, f) -> Optional[str]:
         if not self.send:
             return None
         f.write(
-            "        rpc_read(conn, &{param_name}_len, sizeof({length_type})) < 0)\n".format(
-                param_name=self.parameter.name,
-                length_type=self.length_type,
-            )
+            f"        rpc_read(conn, &{self.parameter.name}_len, sizeof({self.length_type})) < 0)\n"
         )
         f.write("        goto ERROR_0;\n")
         f.write(
-            "    {param_name} = ({server_type})malloc({param_name}_len);\n".format(
-                param_name=self.parameter.name,
-                server_type=self.ptr.format(),
-            )
+            f"    {self.parameter.name} = ({self.ptr.format()})malloc({self.parameter.name}_len);\n"
         )
         f.write(
-            "    if (({param_name}_len != 0 && {param_name} == nullptr) ||\n"
-            "        rpc_read(conn, (void *){param_name}, {param_name}_len) < 0 ||\n".format(
-                param_name=self.parameter.name
-            )
+            f"    if (({self.parameter.name}_len != 0 && {self.parameter.name} == nullptr) ||\n"
+                f"        rpc_read(conn, (void *){self.parameter.name}, {self.parameter.name}_len) < 0 ||\n"
         )
         return self.parameter.name
 
@@ -937,10 +838,7 @@ class OpaqueTypeOperation:
                 else self.parameter.name
             )
             f.write(
-                "        rpc_write(conn, &{param_name}, sizeof({param_type})) < 0 ||\n".format(
-                    param_name=param_name,
-                    param_type=self.type_.format(),
-                )
+                f"        rpc_write(conn, &{param_name}, sizeof({self.type_.format()})) < 0 ||\n"
             )
 
     @property
@@ -961,27 +859,20 @@ class OpaqueTypeOperation:
     def client_unified_copy(self, f, direction, error):
         if isinstance(self.type_, Pointer):
             f.write(
-                "    if (maybe_copy_unified_arg(conn, (void*){name}, {direction}) < 0)\n".format(
-                    name=self.parameter.name, direction=direction
-                )
+                f"    if (maybe_copy_unified_arg(conn, (void*){self.parameter.name}, {direction}) < 0)\n"
             )
-            f.write("      return {error};\n".format(error=error))
+            f.write(f"      return {error};\n")
         else:
             f.write(
-                "    if (maybe_copy_unified_arg(conn, (void*)&{name}, {direction}) < 0)\n".format(
-                    name=self.parameter.name, direction=direction
-                )
+                f"    if (maybe_copy_unified_arg(conn, (void*)&{self.parameter.name}, {direction}) < 0)\n"
             )
-            f.write("      return {error};\n".format(error=error))
+            f.write(f"      return {error};\n")
 
     def server_rpc_read(self, f):
         if not self.send:
             return
         f.write(
-            "        rpc_read(conn, &{param_name}, sizeof({param_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                param_type=self.type_.format(),
-            )
+            f"        rpc_read(conn, &{self.parameter.name}, sizeof({self.type_.format()})) < 0 ||\n"
         )
 
     @property
@@ -994,20 +885,14 @@ class OpaqueTypeOperation:
         if not self.recv:
             return
         f.write(
-            "        rpc_write(conn, &{param_name}, sizeof({param_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                param_type=self.type_.format(),
-            )
+            f"        rpc_write(conn, &{self.parameter.name}, sizeof({self.type_.format()})) < 0 ||\n"
         )
 
     def client_rpc_read(self, f):
         if not self.recv:
             return
         f.write(
-            "        rpc_read(conn, &{param_name}, sizeof({param_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                param_type=self.type_.format(),
-            )
+            f"        rpc_read(conn, &{self.parameter.name}, sizeof({self.type_.format()})) < 0 ||\n"
         )
 
 
@@ -1027,10 +912,7 @@ class DereferenceOperation:
         if not self.send:
             return
         f.write(
-            "        rpc_write(conn, {param_name}, sizeof({param_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                param_type=self.type_.ptr_to.format(),
-            )
+            f"        rpc_write(conn, {self.parameter.name}, sizeof({self.type_.ptr_to.format()})) < 0 ||\n"
         )
 
     @property
@@ -1045,19 +927,14 @@ class DereferenceOperation:
         if not self.send:
             return
         f.write(
-            "        rpc_read(conn, &{param_name}, sizeof({param_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                param_type=self.type_.ptr_to.format(),
-            )
+            f"        rpc_read(conn, &{self.parameter.name}, sizeof({self.type_.ptr_to.format()})) < 0 ||\n"
         )
 
     def client_unified_copy(self, f, direction, error):
         f.write(
-            "    if (maybe_copy_unified_arg(conn, (void*){name}, {direction}) < 0)\n".format(
-                name=self.parameter.name, direction=direction
-            )
+            f"    if (maybe_copy_unified_arg(conn, (void*){self.parameter.name}, {direction}) < 0)\n"
         )
-        f.write("      return {error};\n".format(error=error))
+        f.write(f"      return {error};\n")
 
     @property
     def server_reference(self) -> str:
@@ -1067,10 +944,7 @@ class DereferenceOperation:
         if not self.recv:
             return
         f.write(
-            "        rpc_write(conn, &{param_name}, sizeof({param_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                param_type=self.type_.ptr_to.format(),
-            )
+            f"        rpc_write(conn, &{self.parameter.name}, sizeof({self.type_.ptr_to.format()})) < 0 ||\n"
         )
 
     def client_rpc_read(self, f):
@@ -1078,10 +952,7 @@ class DereferenceOperation:
             return
         # if this parameter is recv only then dereference it.
         f.write(
-            "        rpc_read(conn, {param_name}, sizeof({param_type})) < 0 ||\n".format(
-                param_name=self.parameter.name,
-                param_type=self.type_.ptr_to.format(),
-            )
+            f"        rpc_read(conn, {self.parameter.name}, sizeof({self.type_.ptr_to.format()})) < 0 ||\n"
         )
 
 
@@ -1174,6 +1045,8 @@ class FunctionAnnotationMetadata:
     cross_server_copy: Optional[CrossServerCopyAnnotation] = None
     graph_exec_node: Optional[GraphExecNodeAnnotation] = None
     client_call_template: Optional[ClientCallTemplate] = None
+    # @clearfields: members holding host addresses, cleared on both sides.
+    clear_fields: list[tuple[str, tuple[str, ...]]] = None
 
     def __post_init__(self):
         if self.record_owners is None:
@@ -1184,3 +1057,5 @@ class FunctionAnnotationMetadata:
             self.releases = []
         if self.parents is None:
             self.parents = []
+        if self.clear_fields is None:
+            self.clear_fields = []


### PR DESCRIPTION
NVML and HIP had a writer set each: two validators, two client-RPC writers, two
wrappers and two server handlers, differing only in a result type, an error
code and a symbol resolver. `emit.py` now holds one of each, taking a `Backend`
that states those facts, and `codegen.py` names the two backends.

The divergence was already real. `write_shim_client_wrapper`'s HIP path emitted
`return_value == cudaSuccess` for `@recordowner`; HIP has no such annotation
today, so the first one added would have produced a HIP file referencing a CUDA
constant.

Two hardcoded function names left the generator with it:

- `hipDeviceGetName`'s `len < 0` guard now follows from the length parameter
  being signed, which is the reason the guard exists.
- `hipGetDevicePropertiesR0600`'s pointer fixups became `@clearfields`, which
  also selects the whole-struct zeroing the server does for it.

Along the way:

- `main()` goes from 950 lines to 320; the four output files it wrote inline
  are now `write_rpc_ids`, `write_cuda_client`, `write_cuda_server` and
  `write_registry`.
- The `@param` type dispatch had two unreachable tails: four branches no type
  could reach, and an `elif` chain hanging off the *line* dispatch that only a
  non-`@param` line could enter, using whatever parameter a previous line had
  bound.
- Routing keys and owner kinds name their manual-client function
  (`lupine_route_for_<kind>`, `lupine_note_<kind>_owner`) instead of listing it,
  so a new kind needs a selector rather than a codegen change.
- The three per-return-type error functions became one `RESULT_CODES` table.
- `HIP_RPC_FUNCTIONS` is gone; the annotation file is the list.
- `.format()` templates are f-strings.

Net 335 fewer lines of Python. Every generated file is byte-identical: the
check for each step was to run `codegen/run.sh` and confirm `git status` reports
no change under `codegen/gen_*` or `codegen/registry.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XTA5PTDB1TCN85nEKpJFh