### PR TITLE
Reuse HTTP/2 connections after rejected handshakes

### DIFF
--- a/h2.cpp
+++ b/h2.cpp
@@ -40,6 +40,8 @@ constexpr size_t kH2ProviderMaxFrameBytes = 1024 * 1024;
 constexpr size_t kH2DecodeBufferBytes = 64 * 1024;
 // Retained capacity for drained staging buffers, a few frames' worth.
 constexpr size_t kH2StagingPoolBytes = 4 * 1024 * 1024;
+constexpr std::array<uint8_t, 8> kH2ShutdownPing = {'l', 'u', 'p', 'i',
+                                                    'n', 'e', 0,   1};
 // Linux restarts slow start after an idle period of one retransmission
 // timeout. Keeping response waits below the usual 200 ms minimum RTO avoids
 // collapsing the congestion window between bursts on high-latency links.
@@ -79,6 +81,7 @@ struct h2_transport {
   bool server = false;
   bool request_received = false;
   bool request_handled = false;
+  int request_status = 0;
   int32_t dispatch_stream_id = -1;
   nghttp2_session *session = nullptr;
   std::unordered_map<int32_t, h2_stream> streams;
@@ -104,6 +107,7 @@ struct h2_transport {
   pthread_t heartbeat_thread = {};
   int response_waiters = 0;
   bool transport_failed = false;
+  bool shutdown_acknowledged = false;
   std::string peer_cuda_version;
   std::string peer_capabilities;
   std::string peer_client_etag;
@@ -127,6 +131,12 @@ struct h2_transport {
 
 h2_stream &h2_get_stream(h2_transport *transport, int32_t stream_id) {
   return transport->streams.try_emplace(stream_id).first->second;
+}
+
+bool h2_retryable_handshake_rejection(const h2_transport *transport,
+                                      const h2_stream &stream) {
+  return !transport->server && stream.response_received &&
+         stream.response_status == 409;
 }
 
 void h2_release_codecs(h2_stream &stream) {
@@ -681,6 +691,12 @@ int h2_submit_server_response(h2_transport *transport, int32_t stream_id,
 int h2_on_frame_recv_callback(nghttp2_session *, const nghttp2_frame *frame,
                               void *user_data) {
   auto *transport = static_cast<h2_transport *>(user_data);
+  if (transport->server && frame->hd.type == NGHTTP2_PING &&
+      (frame->hd.flags & NGHTTP2_FLAG_ACK) != 0 &&
+      memcmp(frame->ping.opaque_data, kH2ShutdownPing.data(),
+             kH2ShutdownPing.size()) == 0) {
+    transport->shutdown_acknowledged = true;
+  }
   if (!transport->server && frame->hd.type == NGHTTP2_GOAWAY &&
       lupine_h2_debug_enabled()) {
     std::string debug;
@@ -739,7 +755,8 @@ int h2_on_frame_recv_callback(nghttp2_session *, const nghttp2_frame *frame,
     }
     bool dispatch =
         status == 200 && !probe && transport->dispatch_stream_id < 0;
-    transport->request_handled = probe || status != 200;
+    transport->request_handled = probe || (status != 200 && status != 409);
+    transport->request_status = status;
     if (dispatch) {
       transport->dispatch_stream_id = frame->hd.stream_id;
     } else if (status == 200 && !probe) {
@@ -767,7 +784,10 @@ int h2_on_frame_recv_callback(nghttp2_session *, const nghttp2_frame *frame,
       return NGHTTP2_ERR_CALLBACK_FAILURE;
     }
     stream.remote_end = true;
-    if (frame->hd.stream_id == transport->dispatch_stream_id) {
+    bool retryable_rejection =
+        h2_retryable_handshake_rejection(transport, stream);
+    if (frame->hd.stream_id == transport->dispatch_stream_id &&
+        !retryable_rejection) {
       transport->transport_failed = true;
     }
   }
@@ -781,7 +801,9 @@ int h2_on_stream_close_callback(nghttp2_session *, int32_t stream_id, uint32_t,
   h2_stream &stream = h2_get_stream(transport, stream_id);
   h2_release_codecs(stream);
   stream.closed = true;
-  if (stream_id == transport->dispatch_stream_id) {
+  bool retryable_rejection =
+      h2_retryable_handshake_rejection(transport, stream);
+  if (stream_id == transport->dispatch_stream_id && !retryable_rejection) {
     transport->transport_failed = true;
   }
   pthread_cond_broadcast(&transport->session_progress);
@@ -1038,6 +1060,64 @@ void *h2_read_main(void *arg) {
   }
 }
 
+int32_t h2_submit_client_handshake(h2_transport *transport, conn_t *conn,
+                                   bool probe) {
+  transport->peer_cuda_version.clear();
+  transport->peer_capabilities.clear();
+  transport->peer_client_etag.clear();
+  transport->peer_va_base.clear();
+  transport->peer_va_size.clear();
+  transport->peer_window_base.clear();
+  transport->peer_window_size.clear();
+
+  std::vector<nghttp2_nv> headers = {
+      h2_nv(":method", probe ? "HEAD" : "POST"),
+      h2_nv(":scheme", "http"),
+      h2_nv(":path", "/"),
+      h2_nv(":authority", "lupine"),
+  };
+  if (!probe) {
+    headers.push_back(h2_nv(kContentEncodingHeader, kLz4Encoding));
+    const char *client_etag = getenv("LUPINE_CLIENT_ETAG");
+    const char *client_platform = getenv("LUPINE_CLIENT_PLATFORM");
+    const char *session_id = getenv("LUPINE_SESSION");
+    transport->client_etag =
+        client_etag == nullptr ? std::string() : client_etag;
+    transport->client_platform =
+        client_platform == nullptr ? std::string() : client_platform;
+    transport->session_id = session_id == nullptr ? std::string() : session_id;
+    if (!transport->client_etag.empty()) {
+      headers.push_back(
+          h2_nv(kLupineClientEtagHeader, transport->client_etag.c_str()));
+    }
+    if (!transport->client_platform.empty()) {
+      headers.push_back(h2_nv(kLupineClientPlatformHeader,
+                              transport->client_platform.c_str()));
+    }
+    if (!transport->session_id.empty()) {
+      headers.push_back(
+          h2_nv(kLupineSessionHeader, transport->session_id.c_str()));
+    }
+    if (conn->va_size != 0) {
+      transport->local_va_base = h2_hex(conn->va_base);
+      transport->local_va_size = h2_hex(conn->va_size);
+      headers.push_back(
+          h2_nv(kLupineVaBaseHeader, transport->local_va_base.c_str()));
+      headers.push_back(
+          h2_nv(kLupineVaSizeHeader, transport->local_va_size.c_str()));
+    }
+  }
+  uint8_t flags = probe ? NGHTTP2_FLAG_END_STREAM : NGHTTP2_FLAG_NONE;
+  int32_t stream_id =
+      nghttp2_submit_headers(transport->session, flags, -1, nullptr,
+                             headers.data(), headers.size(), nullptr);
+  if (stream_id >= 0) {
+    transport->dispatch_stream_id = stream_id;
+    h2_get_stream(transport, stream_id);
+  }
+  return stream_id;
+}
+
 int h2_init_direct(conn_t *conn, bool server, bool probe,
                    const rpc_http2_server_metadata *metadata = nullptr) {
   auto *transport = new h2_transport();
@@ -1115,50 +1195,11 @@ int h2_init_direct(conn_t *conn, bool server, bool probe,
   }
 
   if (!server) {
-    const char *session_id = getenv("LUPINE_SESSION");
-    std::vector<nghttp2_nv> headers = {
-        h2_nv(":method", probe ? "HEAD" : "POST"),
-        h2_nv(":scheme", "http"),
-        h2_nv(":path", "/"),
-        h2_nv(":authority", "lupine"),
-    };
-    if (!probe) {
-      headers.push_back(h2_nv(kContentEncodingHeader, kLz4Encoding));
-      const char *client_etag = getenv("LUPINE_CLIENT_ETAG");
-      const char *client_platform = getenv("LUPINE_CLIENT_PLATFORM");
-      if (client_etag != nullptr && client_etag[0] != '\0') {
-        transport->client_etag = client_etag;
-        headers.push_back(
-            h2_nv(kLupineClientEtagHeader, transport->client_etag.c_str()));
-      }
-      if (client_platform != nullptr && client_platform[0] != '\0') {
-        transport->client_platform = client_platform;
-        headers.push_back(h2_nv(kLupineClientPlatformHeader,
-                                transport->client_platform.c_str()));
-      }
-      if (session_id != nullptr && session_id[0] != '\0') {
-        headers.push_back(h2_nv(kLupineSessionHeader, session_id));
-      }
-      if (conn->va_size != 0) {
-        transport->local_va_base = h2_hex(conn->va_base);
-        transport->local_va_size = h2_hex(conn->va_size);
-        headers.push_back(
-            h2_nv(kLupineVaBaseHeader, transport->local_va_base.c_str()));
-        headers.push_back(
-            h2_nv(kLupineVaSizeHeader, transport->local_va_size.c_str()));
-      }
-    }
-    uint8_t flags = probe ? NGHTTP2_FLAG_END_STREAM : NGHTTP2_FLAG_NONE;
-    int32_t stream_id =
-        nghttp2_submit_headers(transport->session, flags, -1, nullptr,
-                               headers.data(), headers.size(), nullptr);
-    if (stream_id < 0) {
+    if (h2_submit_client_handshake(transport, conn, probe) < 0) {
       nghttp2_session_del(transport->session);
       delete transport;
       return -1;
     }
-    transport->dispatch_stream_id = stream_id;
-    h2_get_stream(transport, stream_id);
   }
 
   conn->http2 = transport;
@@ -1483,6 +1524,34 @@ int rpc_http2_client_init(conn_t *conn) {
   return rpc_http2_client_await_ready(conn);
 }
 
+int rpc_http2_client_retry_handshake(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return -1;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  pthread_mutex_lock(&transport->session_mutex);
+  int32_t previous_stream_id = transport->dispatch_stream_id;
+  h2_stream &previous = h2_get_stream(transport, previous_stream_id);
+  int result = -1;
+  if (!transport->server && !transport->transport_failed &&
+      h2_retryable_handshake_rejection(transport, previous)) {
+    // The request side of the rejected stream was deliberately left open in
+    // case it became the long-lived RPC stream. Retire only that stream, then
+    // negotiate the next arena without replacing the HTTP/2 connection.
+    if (nghttp2_submit_rst_stream(transport->session, NGHTTP2_FLAG_NONE,
+                                  previous_stream_id, NGHTTP2_CANCEL) == 0 &&
+        h2_submit_client_handshake(transport, conn, false) >= 0 &&
+        h2_flush_session_locked(transport) == 0) {
+      result = 0;
+    } else {
+      transport->transport_failed = true;
+      pthread_cond_broadcast(&transport->session_progress);
+    }
+  }
+  pthread_mutex_unlock(&transport->session_mutex);
+  return result == 0 ? rpc_http2_client_await_ready(conn) : -1;
+}
+
 // The server answers the request headers before any payload flows, so this
 // costs one round trip and settles both the arena request and the build check
 // on the connection that will carry the session. Kept separate from
@@ -1605,15 +1674,56 @@ int rpc_http2_server_init_with_metadata(
   }
   auto *transport = static_cast<h2_transport *>(conn->http2);
   pthread_mutex_lock(&transport->session_mutex);
-  while (!transport->request_received && !transport->transport_failed) {
-    pthread_cond_wait(&transport->session_progress, &transport->session_mutex);
-  }
   int result = -1;
-  if (transport->request_received) {
+  for (;;) {
+    while (!transport->request_received && !transport->transport_failed) {
+      pthread_cond_wait(&transport->session_progress,
+                        &transport->session_mutex);
+    }
+    if (transport->transport_failed) {
+      break;
+    }
+    if (transport->request_status == 409) {
+      transport->request_received = false;
+      continue;
+    }
     result = transport->request_handled ? 1 : 0;
+    break;
   }
   pthread_mutex_unlock(&transport->session_mutex);
   return result;
+}
+
+int rpc_http2_server_graceful_shutdown(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return -1;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  pthread_mutex_lock(&transport->session_mutex);
+  int32_t last_stream_id =
+      nghttp2_session_get_last_proc_stream_id(transport->session);
+  int result =
+      nghttp2_submit_goaway(transport->session, NGHTTP2_FLAG_NONE,
+                            last_stream_id, NGHTTP2_NO_ERROR, nullptr, 0);
+  if (result == 0) {
+    result = nghttp2_submit_ping(transport->session, NGHTTP2_FLAG_NONE,
+                                 kH2ShutdownPing.data());
+  }
+  if (result == 0) {
+    result = h2_flush_session_locked(transport);
+  }
+  while (result == 0 && !transport->shutdown_acknowledged &&
+         !transport->transport_failed) {
+    if (pthread_cond_wait(&transport->session_progress,
+                          &transport->session_mutex) != 0) {
+      result = -1;
+    }
+  }
+  if (!transport->shutdown_acknowledged) {
+    result = -1;
+  }
+  pthread_mutex_unlock(&transport->session_mutex);
+  return result == 0 ? 0 : -1;
 }
 
 void rpc_http2_destroy(conn_t *conn) {

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -496,6 +496,8 @@ void test_client_await_ready_rejects_stale_bundle() {
   rpc_http2_server_metadata metadata = {nullptr, &kClientBundles};
   require(rpc_http2_server_init_with_metadata(&pair.server, &metadata) == 1,
           "server dispatched a stale client bundle");
+  require(rpc_http2_server_graceful_shutdown(&pair.server) == 0,
+          "server did not finish the rejected handshake gracefully");
   client.join();
 
   lupine_test_unsetenv("LUPINE_CLIENT_ETAG");
@@ -503,6 +505,46 @@ void test_client_await_ready_rejects_stale_bundle() {
   require(ready == LUPINE_RPC_HTTP2_CLIENT_MISMATCH,
           "stale client bundle did not report a client mismatch");
 }
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+void test_client_retries_va_conflict_on_same_connection() {
+  h2_pair pair;
+  init_pair_sockets(&pair);
+
+  long page_size = sysconf(_SC_PAGESIZE);
+  require(page_size > 0, "could not determine the test page size");
+  void *occupied = mmap(nullptr, static_cast<size_t>(page_size), PROT_NONE,
+                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  require(occupied != MAP_FAILED, "could not reserve the test page");
+  pair.client.va_base = reinterpret_cast<uintptr_t>(occupied);
+  pair.client.va_size = static_cast<size_t>(page_size);
+  uintptr_t base = pair.client.va_base;
+  size_t size = pair.client.va_size;
+  lupine_socket_t socket = pair.client.connfd;
+
+  int server_result = -1;
+  std::thread server(
+      [&] { server_result = rpc_http2_server_init(&pair.server); });
+  require(rpc_http2_client_init(&pair.client) == LUPINE_RPC_HTTP2_VA_CONFLICT,
+          "server did not reject the occupied test arena");
+
+  lupine_va_release(&pair.client);
+  pair.client.va_base = base;
+  pair.client.va_size = size;
+  pair.client.va_next = 0;
+  require(rpc_http2_client_retry_handshake(&pair.client) == 0,
+          "client did not retry the arena handshake");
+  server.join();
+
+  require(server_result == 0, "server did not accept the retried arena");
+  require(pair.client.connfd == socket,
+          "arena retry replaced the HTTP/2 connection");
+  // The server owns the accepted test mapping in this single-process pair.
+  pair.client.va_base = 0;
+  pair.client.va_size = 0;
+  pair.client.va_next = 0;
+}
+#endif
 
 void test_client_await_ready_reports_capabilities(bool advertise) {
   h2_pair pair;
@@ -1934,6 +1976,9 @@ int main() {
   RUN_CASE(test_head_probe_cuda_version_metadata(nullptr));
   RUN_CASE(test_client_await_ready_accepts_current_bundle());
   RUN_CASE(test_client_await_ready_rejects_stale_bundle());
+#if !defined(_WIN32) && !defined(__APPLE__)
+  RUN_CASE(test_client_retries_va_conflict_on_same_connection());
+#endif
   RUN_CASE(test_client_await_ready_reports_capabilities(true));
   RUN_CASE(test_client_await_ready_reports_capabilities(false));
   RUN_CASE(test_client_metadata_capability(true, 0));

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -43,7 +43,9 @@ void *lupine_va_reserve_exact(uintptr_t base, size_t size) {
 }
 #endif
 
-void lupine_va_destroy(conn_t *conn) {
+} // namespace
+
+void lupine_va_release(conn_t *conn) {
   if (conn == nullptr || conn->va_size == 0) {
     return;
   }
@@ -56,8 +58,6 @@ void lupine_va_destroy(conn_t *conn) {
   conn->va_size = 0;
   conn->va_next = 0;
 }
-
-} // namespace
 
 lupine_va_window lupine_va_local_window(void) {
 #if defined(_WIN32) || defined(__APPLE__)
@@ -393,7 +393,7 @@ void rpc_conn_destroy(conn_t *conn) {
   }
   rpc_close_transport_socket(conn);
   rpc_http2_destroy(conn);
-  lupine_va_destroy(conn);
+  lupine_va_release(conn);
   rpc_write_buffer_release(conn);
   std::vector<rpc_write_cursor>().swap(conn->write_queue);
   std::vector<rpc_host_allocation_write>().swap(conn->host_allocation_writes);

--- a/rpc.h
+++ b/rpc.h
@@ -152,6 +152,8 @@ extern int lupine_va_reserve_client(conn_t *conn,
                                     const lupine_va_window &window,
                                     unsigned int min_slot, unsigned int *slot);
 extern int lupine_va_reserve_server(conn_t *conn, uintptr_t base, size_t size);
+// Releases a rejected candidate without disturbing the connection transport.
+extern void lupine_va_release(conn_t *conn);
 // Bump-claims an aligned span inside the connection's arena. Concurrent callers
 // each get a disjoint span; false means the arena cannot fit the request.
 extern bool lupine_va_claim(conn_t *conn, size_t size, size_t alignment,
@@ -261,6 +263,9 @@ extern int32_t rpc_http2_lane_stream(conn_t *conn, uint64_t lane_id);
 extern int rpc_http2_end_stream(conn_t *conn, int32_t stream_id);
 extern int32_t rpc_http2_accept_stream(conn_t *conn);
 extern int rpc_http2_client_init(conn_t *conn);
+// Sends another arena preflight on the existing HTTP/2 connection and waits
+// for its result.
+extern int rpc_http2_client_retry_handshake(conn_t *conn);
 // Waits for the peer's response headers on the session's own connection and
 // settles the client-bundle check and, when one was requested, the arena
 // verdict. rpc_http2_client_init already does this when an arena was requested;
@@ -292,6 +297,10 @@ extern int rpc_http2_server_init(conn_t *conn);
 extern int
 rpc_http2_server_init_with_metadata(conn_t *conn,
                                     const rpc_http2_server_metadata *metadata);
+// Finishes an HTTP-handled connection with GOAWAY and waits for a PING
+// acknowledgement, ensuring the response reached the peer before the server's
+// abortive transport cleanup can reset the socket.
+extern int rpc_http2_server_graceful_shutdown(conn_t *conn);
 // Returns the x-lupine-session request header after the server has consumed
 // the HTTP/2 request headers, or nullptr when no session was supplied.
 extern const char *rpc_http2_session_id(conn_t *conn);

--- a/server.cpp
+++ b/server.cpp
@@ -257,6 +257,9 @@ int client_handler(lupine_socket_t connfd) {
 #endif
   }
   if (http2_init_result != 0) {
+    if (rpc_http2_server_graceful_shutdown(&conn) < 0) {
+      LUPINE_LOG_DEBUG("HTTP/2 peer closed before acknowledging shutdown");
+    }
     rpc_conn_destroy(&conn);
 #ifdef LUPINE_BUILD_CUDA_BACKEND
     return lupine_server_checkpoint_child_finish();

--- a/transport.cpp
+++ b/transport.cpp
@@ -162,24 +162,25 @@ int connect_endpoint(client_transport_state &state,
   // says so in its response, and the retry below adopts it, so a matching pair
   // never spends an extra dial to learn what it already assumed.
   lupine_va_window window = lupine_va_local_window();
+  *conn = {};
+  unsigned int retries =
+      state.config.dial_policy == lupine_client_dial_policy::bounded_retry
+          ? kBoundedRetryCount
+          : 0;
+  lupine_socket_t connfd =
+      lupine_tcp_connect(endpoint.host.c_str(), endpoint.port.c_str(), retries);
+  if (connfd == LUPINE_INVALID_SOCKET) {
+    LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
+                                      << endpoint.port << " failed");
+    return -1;
+  }
+  if (rpc_conn_init(conn, connfd, 0) < 0) {
+    return -1;
+  }
+  conn->logical_index = static_cast<int>(index);
+  conn->w_offset = state.config.w_offset;
+  bool first_handshake = true;
   for (;;) {
-    *conn = {};
-    unsigned int retries =
-        state.config.dial_policy == lupine_client_dial_policy::bounded_retry
-            ? kBoundedRetryCount
-            : 0;
-    lupine_socket_t connfd = lupine_tcp_connect(endpoint.host.c_str(),
-                                                endpoint.port.c_str(), retries);
-    if (connfd == LUPINE_INVALID_SOCKET) {
-      LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
-                                        << endpoint.port << " failed");
-      return -1;
-    }
-    if (rpc_conn_init(conn, connfd, 0) < 0) {
-      return -1;
-    }
-    conn->logical_index = static_cast<int>(index);
-    conn->w_offset = state.config.w_offset;
     unsigned int slot = min_slot;
     // A server that stated no window hosts no arena at all; the refusal below
     // reports that rather than spending a dial to be told the same thing.
@@ -191,11 +192,13 @@ int connect_endpoint(client_transport_state &state,
         return -1;
       }
     }
-    if (initialize_tls(conn, endpoint) < 0) {
+    if (first_handshake && initialize_tls(conn, endpoint) < 0) {
       reset_connection(conn);
       return -1;
     }
-    int http2_result = rpc_http2_client_init(conn);
+    int http2_result = first_handshake ? rpc_http2_client_init(conn)
+                                       : rpc_http2_client_retry_handshake(conn);
+    first_handshake = false;
     // No arena was requested, so client_init returned without waiting. Settle
     // the build check on this same connection rather than spending a dial.
     if (http2_result == 0 && conn->va_size == 0) {
@@ -209,6 +212,7 @@ int connect_endpoint(client_transport_state &state,
       lupine_va_window stated = {};
       bool adopt = rpc_http2_peer_va_window(conn, &stated) &&
                    (stated.base != window.base || stated.size != window.size);
+      lupine_va_release(conn);
       if (adopt) {
         LUPINE_LOG_DEBUG("LUPINE server at " << endpoint.host << " port "
                                              << endpoint.port
@@ -216,12 +220,10 @@ int connect_endpoint(client_transport_state &state,
                                                 "retrying in its window");
         window = stated;
         min_slot = 0;
-        reset_connection(conn);
         continue;
       }
       if (slot + 1 < LUPINE_VA_ARENA_COUNT) {
         min_slot = slot + 1;
-        reset_connection(conn);
         continue;
       }
     }


### PR DESCRIPTION
## Summary

- retry virtual-address `409` preflights on a new HTTP/2 stream over the existing TCP/TLS session
- release only the rejected local arena between attempts, avoiding duplicate connection handshakes
- keep graceful `GOAWAY` + PING-acknowledged teardown for terminal preflights (`400`, `426`, and probes)
- cover both same-socket arena retry and terminal-response delivery in HTTP/2 tests

## Flake diagnosis

The CUDA 11.8 `NPP/distanceTransform` flake was not an arbitrary network interruption. Instrumentation on both endpoints consistently showed this sequence:

1. the client requested a virtual-address arena
2. the server rejected that slot with `409`
3. the server treated the rejected stream as a completed connection and immediately performed its normal abortive teardown
4. if unread HTTP/2 control bytes were still in the server socket, Linux emitted a TCP reset that occasionally truncated the response
5. the client therefore saw no HTTP status and CUDA initialization surfaced `no devices supporting CUDA`

The same sample remained stable without Lupine: 2,000/2,000 native concurrent runs on node-006 and 2,000/2,000 on node-008.

A `409` rejects an arena candidate, not the HTTP/2 connection. The client now retires that request stream with `RST_STREAM(CANCEL)`, reserves the next candidate, and submits another preflight stream on the same session. Terminal HTTP-handled connections still use a PING acknowledgement as a delivery barrier before the server abortively closes the socket.

## Validation

- full local build
- 13/13 local CTest targets passed (3 environment-dependent tests skipped)
- `clang-format` and `git diff --check`
- deterministic unit coverage verifies a `409` followed by `200` on the same client socket
- final keepalive implementation: NPP `distanceTransform` passed 325/325 runs across three concurrent server-restart loops on node-008
- teardown-only implementation: NPP `distanceTransform` passed 1,200/1,200 valid runs across three concurrent server-restart loops on node-008
