### PR TITLE
Fix oversized HTTP/2 flow-control test

### DIFF
--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1112,20 +1112,21 @@ void test_large_payload() {
   require(received == payload, "large payload mismatch");
 }
 
-#ifndef _WIN32
-// The payload is a >2 GiB read-only MAP_NORESERVE mapping that is never
-// faulted in; Windows cannot hand out readable pages without charging
-// commit, so this case stays Unix-only.
 void test_payload_larger_than_flow_control_window() {
   h2_pair pair = make_pair();
   exchange_settings(&pair);
 
+  // Flow control counts compressed bytes. Cross the current server window
+  // with incompressible data; a multi-GiB zero mapping compresses below the
+  // window while still allowing gigabytes of decoded staging in the receiver.
   constexpr size_t payload_size =
-      static_cast<size_t>(INT32_MAX) + 64 * 1024 + 1;
-
-  void *payload = mmap(nullptr, payload_size, PROT_READ,
-                       MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
-  require(payload != MAP_FAILED, "flow-control payload mmap failed");
+      LUPINE_FF_STAGING_WINDOW_BYTES + 64 * 1024 + 1;
+  std::vector<unsigned char> payload(payload_size);
+  uint32_t seed = 53;
+  for (unsigned char &byte : payload) {
+    seed = seed * 1664525u + 1013904223u;
+    byte = static_cast<unsigned char>(seed >> 24);
+  }
 
   std::atomic<bool> read_failed{false};
   size_t received = 0;
@@ -1138,8 +1139,7 @@ void test_payload_larger_than_flow_control_window() {
         read_failed = true;
         break;
       }
-      if (!std::all_of(buffer.begin(), buffer.begin() + chunk,
-                       [](unsigned char value) { return value == 0; })) {
+      if (memcmp(buffer.data(), payload.data() + received, chunk) != 0) {
         read_failed = true;
         break;
       }
@@ -1155,7 +1155,7 @@ void test_payload_larger_than_flow_control_window() {
     (void)rpc_http2_read(&pair.client, &unused, sizeof(unused));
   });
 
-  int write_result = write_bytes(&pair.client, payload, payload_size);
+  int write_result = write_bytes(&pair.client, payload.data(), payload.size());
   if (write_result != 0) {
     shutdown(pair.client.connfd, LUPINE_TEST_SHUT_RDWR);
     shutdown(pair.server.connfd, LUPINE_TEST_SHUT_RDWR);
@@ -1163,13 +1163,11 @@ void test_payload_larger_than_flow_control_window() {
   server_reader.join();
   shutdown(pair.client.connfd, LUPINE_TEST_SHUT_RDWR);
   client_control_reader.join();
-  munmap(payload, payload_size);
 
   require(write_result == 0, "flow-controlled write failed before completion");
   require(!read_failed, "flow-controlled read failed");
   require(received == payload_size, "flow-controlled payload was truncated");
 }
-#endif
 
 // A server-side hold keeps received payload bytes uncredited until the staging
 // they landed in retires. Held bytes saturate at a cap so the reader filling
@@ -2001,8 +1999,8 @@ int main() {
   RUN_CASE(test_refillable_cursor_round_trip());
 #ifndef _WIN32
   RUN_CASE(test_refillable_cursor_across_flow_control_window());
-  RUN_CASE(test_payload_larger_than_flow_control_window());
 #endif
+  RUN_CASE(test_payload_larger_than_flow_control_window());
   RUN_CASE(test_server_window_hold_caps_and_releases());
   RUN_CASE(test_reset_wakes_flow_controlled_writer());
   std::cout << "h2_test: PASS" << std::endl;


### PR DESCRIPTION
The macOS Intel unit-test job in #699 timed out in `test_payload_larger_than_flow_control_window` ([failed job](https://github.com/lupinemachines/lupine/actions/runs/33990931733/job/101372920223?pr=699)). The case still sends over 2 GiB of zeros, sized for the old HTTP/2 window. The current server window is 64 MiB, and LZ4 compresses those zeros below it; the test can accumulate gigabytes of decoded staging without exhausting flow-control credit.

Size the payload from `LUPINE_FF_STAGING_WINDOW_BYTES` plus 64 KiB and one byte, fill it with deterministic incompressible data, and compare every received byte. The bounded vector also removes the test's mmap requirement.

Validation on Linux with CUDA/server builds disabled:

- All 7 CTest cases pass; `h2_test` passes 20 consecutive runs.
- Full `h2_test`: 4.84 s / 2,129,240 KiB peak RSS before, 1.92 s / 321,832 KiB after.
- Isolated negative control suppressing server WINDOW_UPDATE credit: the old case incorrectly passes; the revised case blocks until the probe's timeout, confirming that it exercises window exhaustion.

The HTTP/2 code and test were unchanged by #699; this fix is based directly on `main`.

CI validation: the [complete C++ unit-test matrix](https://github.com/lupinemachines/lupine/actions/runs/33991552954) passes, including macOS Intel and ARM. The [original failed job rerun](https://github.com/lupinemachines/lupine/actions/runs/33990931733/job/101374621389) also passes without changes to #699, confirming the intermittent failure.

Fixes #664.
