### PR TITLE
Export CUDA client RPC primitives for sibling shims

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ if(LUPINE_BUILD_CUDA)
     add_library(lupine_cuda_client SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/cuda_client.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/cuda_client_rpc.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/events.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/routing.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/cuda_client_memcpy.cpp

--- a/cuda_client.exports
+++ b/cuda_client.exports
@@ -3,6 +3,7 @@
     cu*;
     dlsym;
     lupine_checkpoint_*;
+    lupine_rpc_*;
   local:
     *;
 };

--- a/cuda_client_rpc.cpp
+++ b/cuda_client_rpc.cpp
@@ -1,0 +1,41 @@
+#include "cuda_client_rpc.h"
+#include "rpc.h"
+
+extern int rpc_open();
+extern int rpc_size();
+extern conn_t *rpc_client_get_connection(unsigned int index);
+
+extern "C" int lupine_rpc_open() { return rpc_open(); }
+
+extern "C" int lupine_rpc_size() { return rpc_size(); }
+
+extern "C" conn_t *lupine_rpc_client_get_connection(unsigned int index) {
+  return rpc_client_get_connection(index);
+}
+
+extern "C" int lupine_rpc_write_start_request(conn_t *conn, int op) {
+  return rpc_write_start_request(conn, op);
+}
+
+extern "C" int lupine_rpc_write_start_async_request(conn_t *conn, int op,
+                                                    uint64_t *sequence) {
+  return rpc_write_start_async_request(conn, op, sequence);
+}
+
+extern "C" int lupine_rpc_write(conn_t *conn, const void *data, size_t size) {
+  return rpc_write(conn, data, size);
+}
+
+extern "C" int lupine_rpc_write_end(conn_t *conn) {
+  return rpc_write_end(conn);
+}
+
+extern "C" int lupine_rpc_wait_for_response(conn_t *conn) {
+  return rpc_wait_for_response(conn);
+}
+
+extern "C" int lupine_rpc_read(conn_t *conn, void *data, size_t size) {
+  return rpc_read(conn, data, size);
+}
+
+extern "C" int lupine_rpc_read_end(conn_t *conn) { return rpc_read_end(conn); }

--- a/cuda_client_rpc.h
+++ b/cuda_client_rpc.h
@@ -1,0 +1,31 @@
+#ifndef LUPINE_CUDA_CLIENT_RPC_H
+#define LUPINE_CUDA_CLIENT_RPC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// C exports of the driver client's RPC functions for sibling shims. Each
+// wrapper has the same arguments and return value as its rpc_* counterpart.
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct conn_t conn_t;
+
+int lupine_rpc_open(void);
+int lupine_rpc_size(void);
+conn_t *lupine_rpc_client_get_connection(unsigned int index);
+int lupine_rpc_write_start_request(conn_t *conn, int op);
+int lupine_rpc_write_start_async_request(conn_t *conn, int op,
+                                         uint64_t *sequence);
+int lupine_rpc_write(conn_t *conn, const void *data, size_t size);
+int lupine_rpc_write_end(conn_t *conn);
+int lupine_rpc_wait_for_response(conn_t *conn);
+int lupine_rpc_read(conn_t *conn, void *data, size_t size);
+int lupine_rpc_read_end(conn_t *conn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Sibling shims need access to the CUDA driver's client RPC transport through `libcuda`. Add ten C exports in `cuda_client_rpc.cpp`, each forwarding its arguments and return value directly to the existing `rpc_*` function: open, size, connection lookup, request start, async request start, write, write end, response wait, read, and read end. Declare them in a C-compatible `cuda_client_rpc.h` and compile the source into `lupine_cuda_client`.

Expose `lupine_rpc_*` through the library's export map. This includes the eight existing `lupine_rpc_conn_for_*` routing helpers already present on main. The wrappers retain the existing RPC behavior and introduce no additional initialization or routing policy.

Based directly on main; independent of the event/stream routing and CUDART codegen PRs.

Validation:

- Configured with `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLUPINE_BUILD_SERVER=OFF -DLUPINE_BUILD_NVML=OFF -DLUPINE_BUILD_HIP=OFF -DBUILD_TESTING=OFF` and built `lupine_cuda_client` with `-j8`.
- `clang-format --dry-run --Werror`, `git diff --check`, and a C11 header syntax check passed.
- `nm -D --defined-only build/libcuda.so.1` confirmed all ten wrappers and the existing routing helpers are exported.
- A native caller linked against the new library used these exports to invoke `RPC_cuInit`, `RPC_cuDeviceGetCount`, and `RPC_cuDriverGetVersion` against the NVIDIA server on `inferable-node-008`: `PASS: RPC exports reached NVIDIA driver; connections=1 devices=1 version=13010`.

The GPU check exercised the synchronous request path. The async-start and standalone write-end exports were checked in the dynamic symbol table but were not invoked directly by that check.
