### PR TITLE
Support stream routing in forwarding codegen

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -33,6 +33,9 @@ the routing key is not the first matching parameter.
 Forwarding backends also accept `@routingkey EVENT <param>`. Their client must
 provide `connection_for_event(event)`, which selects the connection without
 changing the event handle sent to the server.
+Likewise, `@routingkey STREAM <param>` uses `connection_for_stream(stream)`.
+The backend helper handles default streams; the stream argument is sent
+unchanged.
 
 NVML wrappers use the same mechanism. A by-value `nvmlDevice_t` parameter
 infers `NVML_DEVICE` routing: the generated client resolves its owning server

--- a/codegen/emit.py
+++ b/codegen/emit.py
@@ -171,13 +171,18 @@ def write_client_wrapper(f, backend: Backend, function, operations, metadata):
             "  conn_t *conn = connection_for_device("
             f"&{metadata.routing_parameter.name});\n"
         )
-    elif metadata.routing_kind in ("EVENT", "STREAM"):
+    elif metadata.routing_kind == "EVENT":
         if metadata.routing_parameter is None:
-            raise RuntimeError(
-                f"{name}: {metadata.routing_kind} routing requires a parameter"
-            )
+            raise RuntimeError(f"{name}: EVENT routing requires a parameter")
         f.write(
-            f"  conn_t *conn = connection_for_{metadata.routing_kind.lower()}("
+            "  conn_t *conn = connection_for_event("
+            f"{metadata.routing_parameter.name});\n"
+        )
+    elif metadata.routing_kind == "STREAM":
+        if metadata.routing_parameter is None:
+            raise RuntimeError(f"{name}: STREAM routing requires a parameter")
+        f.write(
+            "  conn_t *conn = connection_for_stream("
             f"{metadata.routing_parameter.name});\n"
         )
     elif metadata.routing_kind is None:

--- a/codegen/emit.py
+++ b/codegen/emit.py
@@ -171,11 +171,13 @@ def write_client_wrapper(f, backend: Backend, function, operations, metadata):
             "  conn_t *conn = connection_for_device("
             f"&{metadata.routing_parameter.name});\n"
         )
-    elif metadata.routing_kind == "EVENT":
+    elif metadata.routing_kind in ("EVENT", "STREAM"):
         if metadata.routing_parameter is None:
-            raise RuntimeError(f"{name}: EVENT routing requires a parameter")
+            raise RuntimeError(
+                f"{name}: {metadata.routing_kind} routing requires a parameter"
+            )
         f.write(
-            "  conn_t *conn = connection_for_event("
+            f"  conn_t *conn = connection_for_{metadata.routing_kind.lower()}("
             f"{metadata.routing_parameter.name});\n"
         )
     elif metadata.routing_kind is None:


### PR DESCRIPTION
Stacks on #714.

## Summary
- Accept the existing @routingkey STREAM annotation in the forwarding client writer.
- Add a separate STREAM branch that calls connection_for_stream(stream), leaving EVENT handling and the stream argument unchanged.
- Leave default-stream selection to the backend helper and reject missing routing parameters.

No CUDART target, runtime implementation, new annotations, or test files are included.

## Validation
- Ran ./codegen/run.sh with the pinned SDK container; existing generated outputs are unchanged.
- Generated wrappers from real CUDA SDK declarations and compiled against CUDA/project headers: cudaStreamQuery, cudaStreamSynchronize, and cudaEventRecord routed by stream.
- Rechecked event destroy/query/elapsed-time emission and missing-parameter errors.
- These are code-generation/compiler checks, not GPU execution tests.