### PR TITLE
Infer forwarding return types from annotated declarations

### DIFF
--- a/codegen/emit.py
+++ b/codegen/emit.py
@@ -66,7 +66,7 @@ def signed_length_arrays(operations) -> list[ArrayOperation]:
     ]
 
 
-def write_client_validation(f, backend: Backend, operations):
+def write_client_validation(f, backend: Backend, function, operations):
     checks = [
         f"{operation.length.name} < 0"
         for operation in signed_length_arrays(operations)
@@ -83,7 +83,13 @@ def write_client_validation(f, backend: Backend, operations):
             )
     if checks:
         f.write("  if (" + " ||\n      ".join(checks) + ") {\n")
-        f.write(f"    return {backend.invalid_argument};\n")
+        result = function.return_type.format()
+        if result == backend.result:
+            f.write(f"    return {backend.invalid_argument};\n")
+        elif result == "void":
+            f.write("    return;\n")
+        else:
+            f.write("    return {};\n")
         f.write("  }\n")
 
 
@@ -95,12 +101,15 @@ def write_cleared_fields(f, metadata, indent, reference):
 
 def write_client_rpc(f, backend: Backend, function, operations, metadata):
     name = function.name.format()
+    result = function.return_type.format()
     params = ", ".join(format_function_params(function))
-    f.write(f"static {backend.result} lupine_rpc_{name}(conn_t *conn")
+    f.write(f"static {result} lupine_rpc_{name}(conn_t *conn")
     if params:
         f.write(f", {params}")
     f.write(") {\n")
-    f.write(f"  {backend.result} return_value = rpc_error();\n")
+    if result != "void":
+        initial_value = "rpc_error()" if result == backend.result else "{}"
+        f.write(f"  {result} return_value = {initial_value};\n")
     for operation in operations:
         if isinstance(operation, NullTerminatedOperation):
             f.write(
@@ -118,13 +127,20 @@ def write_client_rpc(f, backend: Backend, function, operations, metadata):
     f.write("      rpc_wait_for_response(conn) < 0 ||\n")
     for operation in operations:
         operation.client_rpc_read(f)
-    f.write("      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||\n")
+    if result != "void":
+        f.write("      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||\n")
     f.write("      rpc_read_end(conn) < 0) {\n")
     write_cleared_fields(f, metadata, "    ", "->")
-    f.write("    return rpc_error();\n")
+    if result == backend.result:
+        f.write("    return rpc_error();\n")
+    elif result == "void":
+        f.write("    return;\n")
+    else:
+        f.write("    return {};\n")
     f.write("  }\n")
     write_cleared_fields(f, metadata, "  ", "->")
-    f.write("  return return_value;\n")
+    if result != "void":
+        f.write("  return return_value;\n")
     f.write("}\n\n")
 
 
@@ -133,9 +149,10 @@ def write_client_wrapper(f, backend: Backend, function, operations, metadata):
         return
 
     name = function.name.format()
+    result = function.return_type.format()
     params = ", ".join(format_function_params(function))
-    f.write(f'extern "C" {backend.result} {name}({params}) {{\n')
-    write_client_validation(f, backend, operations)
+    f.write(f'extern "C" {result} {name}({params}) {{\n')
+    write_client_validation(f, backend, function, operations)
 
     call_args = format_call_args(function)
     if metadata.routing_kind == "ALL" and backend.lookup_on_all_connections:
@@ -211,10 +228,8 @@ def write_server_handler(f, backend: Backend, function, operations, metadata):
     if metadata.async_fire_forget:
         f.write("  uint64_t async_sequence = 0;\n")
     f.write("  int request_id;\n")
-    if not metadata.async_fire_forget:
-        # A void call has no result to send, but the wire still carries the
-        # field, so the handler needs storage of some type to point at.
-        f.write(f"  {'void *' if result == 'void' else result} return_value;\n")
+    if not metadata.async_fire_forget and result != "void":
+        f.write(f"  {result} return_value;\n")
     if backend.symbol_lookup:
         fn_params = ", ".join(
             parameter.type.format() for parameter in function.parameters
@@ -259,10 +274,18 @@ def write_server_handler(f, backend: Backend, function, operations, metadata):
     args = ", ".join(call_args)
     if backend.symbol_lookup:
         f.write(f'  fn = {backend.symbol_lookup}<fn_t>("{name}");\n')
-        f.write(
-            "  return_value = fn == nullptr ? function_not_found()\n"
-            f"                               : fn({args});\n\n"
-        )
+        if result == backend.result and not metadata.async_fire_forget:
+            f.write(
+                "  return_value = fn == nullptr ? function_not_found()\n"
+                f"                               : fn({args});\n\n"
+            )
+        else:
+            f.write("  if (fn == nullptr)\n")
+            f.write("    goto ERROR_0;\n")
+            if result == "void" or metadata.async_fire_forget:
+                f.write(f"  fn({args});\n\n")
+            else:
+                f.write(f"  return_value = fn({args});\n\n")
     elif metadata.async_fire_forget or result == "void":
         f.write(f"  {entry}({args});\n\n")
     else:
@@ -277,7 +300,8 @@ def write_server_handler(f, backend: Backend, function, operations, metadata):
         f.write("  if (rpc_write_start_response(conn, request_id) < 0 ||\n")
         for operation in operations:
             operation.server_rpc_write(f)
-        f.write(f"      rpc_write(conn, &return_value, sizeof({result})) < 0 ||\n")
+        if result != "void":
+            f.write(f"      rpc_write(conn, &return_value, sizeof({result})) < 0 ||\n")
         f.write("      rpc_write_end(conn) < 0)\n")
         f.write("    goto ERROR_0;\n")
     write_server_buffer_cleanup(f, owned_buffers, "  ")


### PR DESCRIPTION
## Summary

Use the return type in each annotated C++ declaration for forwarding RPC helpers and public wrappers, rather than forcing the backend's status type. No new annotations or backend options.

- Serialize the declared non-void type at its actual width, including `char`, pointers, and structs.
- Void calls have no return-value storage or payload, and server calls are not assigned to a status variable.
- Preserve existing backend status/error behavior for status-returning APIs. For other return types, the current client failure fallback is value-initialization (or a bare return for void); missing server symbols fail the handler rather than being converted into an unrelated status value.

This is a standalone prerequisite against `main`; it does not contain the CUDART target, annotations, routing changes, or runtime shim.

## Validation

- `./codegen/run.sh` using pinned CUDA 13.3.1: passed; all checked-in generated artifacts remain unchanged.
- Generated client, dynamically resolved server, and directly called server for seven real CUDA SDK declarations. All passed `g++ -std=c++17 -Wall -Wextra -Werror -pedantic-errors -fsyntax-only`: `cudaCreateChannelDesc` (struct), `__cudaPushCallConfiguration` (unsigned), `__cudaInitModule` (char), `__cudaRegisterFatBinaryEnd` and `__cudaUnregisterFatBinary` (void), `__cudaRegisterFatBinary` (pointer), and `cudaRuntimeGetVersion` (status).
- Executed generated client/server code over Lupine's actual TCP/HTTP2 RPC transport against NVIDIA `libcudart.so.13.3.29`. Checked all struct fields, the unsigned push result and server-side native pop configuration, void registration-end/unregister calls using a real nvcc-built fatbinary, and runtime-version status/output (`13030`). A subsequent successful call on the same stream checks void responses leave no phantom return bytes. No CUDA or transport mocks.
- Char and pointer-returning registration APIs were compile-checked, not runtime-executed. The runtime check is host-side and does not claim GPU/kernel coverage.
- `git diff --check`: passed.
