### PR TITLE
Use existing client declarations and bodies in forwarding codegen

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -962,6 +962,7 @@ def collect_backend_functions(
     names=None,
     server_bindings: dict[str, ServerBinding] = {},
     string_length_type: str = None,
+    client_call_templates: dict[str, ClientCallTemplate] = None,
 ):
     """Calls in the order named, or every call the annotation file declares."""
     by_name = {
@@ -976,6 +977,8 @@ def collect_backend_functions(
         if function is None:
             raise RuntimeError(f"Annotation for {name} not found")
         metadata = parse_annotation(function.doxygen, function.parameters)
+        if client_call_templates is not None:
+            attach_client_call_template(function, metadata, client_call_templates)
         if string_length_type is not None:
             for operation in metadata.operations:
                 if isinstance(operation, NullTerminatedOperation):
@@ -1564,14 +1567,18 @@ def main():
             ]
         )
     )
-    definition_return_types = {
-        function.name.format(): function.return_type.format()
-        for function in cuda_annotations.namespace.functions
-        if function.has_body
+    client_call_templates_by_target = {
+        target: collect_client_call_templates(
+            ANNOTATION_FILES[target],
+            {
+                function.name.format(): function.return_type.format()
+                for function in parsed.namespace.functions
+                if function.has_body
+            },
+        )
+        for target, parsed in annotations_by_target.items()
     }
-    client_call_templates = collect_client_call_templates(
-        ANNOTATION_FILES["cuda"], definition_return_types
-    )
+    client_call_templates = client_call_templates_by_target["cuda"]
     server_bindings = {}
     # A handler belongs to the backend whose annotation file declares it.
     for target, path in ANNOTATION_FILES.items():
@@ -1698,9 +1705,11 @@ def main():
         server_bindings,
         # NVML's protocol predates the size_t string lengths CUDA RPC uses.
         string_length_type="unsigned int",
+        client_call_templates=client_call_templates_by_target["nvml"],
     )
     hip_functions_with_annotations = collect_backend_functions(
-        annotations_by_target["hip"]
+        annotations_by_target["hip"],
+        client_call_templates=client_call_templates_by_target["hip"],
     )
 
     annotated_names = sorted(

--- a/codegen/emit.py
+++ b/codegen/emit.py
@@ -6,12 +6,15 @@ nothing here asks which one it is writing.
 """
 
 from dataclasses import dataclass
+import textwrap
 
 from cxxheaderparser.types import Function, Parameter, Pointer
 
 from ops import (
     ArrayOperation,
     DereferenceOperation,
+    InOutCountOperation,
+    NullableArrayOperation,
     NullableOperation,
     NullTerminatedOperation,
 )
@@ -111,7 +114,9 @@ def write_client_rpc(f, backend: Backend, function, operations, metadata):
         initial_value = "rpc_error()" if result == backend.result else "{}"
         f.write(f"  {result} return_value = {initial_value};\n")
     for operation in operations:
-        if isinstance(operation, NullTerminatedOperation):
+        if isinstance(operation, (InOutCountOperation, NullableArrayOperation)):
+            f.write(operation.client_declaration())
+        elif isinstance(operation, NullTerminatedOperation):
             f.write(
                 f"  {operation.length_type} {operation.parameter.name}_len = static_cast<{operation.length_type}>(std::strlen({operation.parameter.name}) + 1);\n"
             )
@@ -155,6 +160,8 @@ def write_client_wrapper(f, backend: Backend, function, operations, metadata):
     write_client_validation(f, backend, function, operations)
 
     call_args = format_call_args(function)
+    suffix = f", {', '.join(call_args)}" if call_args else ""
+    call = f"lupine_rpc_{name}(conn{suffix})"
     if metadata.routing_kind == "ALL" and backend.lookup_on_all_connections:
         owners = [
             owner
@@ -170,16 +177,13 @@ def write_client_wrapper(f, backend: Backend, function, operations, metadata):
         lambda_args = [
             "remote_device" if arg == output_name else arg for arg in call_args
         ]
-        f.write(
-            f"  return lookup_device_on_all_connections({output_name},\n"
+        call = (
+            f"lookup_device_on_all_connections({output_name},\n"
             "      [&](conn_t *conn, nvmlDevice_t *remote_device) {\n"
             f"        return lupine_rpc_{name}(conn, {', '.join(lambda_args)});\n"
-            "      });\n"
+            "      })"
         )
-        f.write("}\n\n")
-        return
-
-    if metadata.routing_kind == backend.device_routing_kind:
+    elif metadata.routing_kind == backend.device_routing_kind:
         if metadata.routing_parameter is None:
             raise RuntimeError(
                 f"{name}: {metadata.routing_kind} routing requires a parameter"
@@ -206,8 +210,14 @@ def write_client_wrapper(f, backend: Backend, function, operations, metadata):
         f.write("  conn_t *conn = connection();\n")
     else:
         raise RuntimeError(f"{name}: unsupported routing key {metadata.routing_kind}")
-    suffix = f", {', '.join(call_args)}" if call_args else ""
-    f.write(f"  return lupine_rpc_{name}(conn{suffix});\n")
+    template = metadata.client_call_template
+    if template is not None:
+        f.write(textwrap.indent(template.before_call, "  "))
+        f.write(f"  {result} return_value = {call};\n")
+        f.write(textwrap.indent(template.after_call, "  "))
+        f.write("  return return_value;\n")
+    else:
+        f.write(f"  return {call};\n")
     f.write("}\n\n")
 
 


### PR DESCRIPTION
## Summary

Connect the forwarding emitter to the existing nullable-array/count declarations and annotated client-body handling already used by the CUDA driver generator.

- Invoke `InOutCountOperation.client_declaration()` and `NullableArrayOperation.client_declaration()` before serializing a request. This supplies locals such as `numNodes_requested` and `nodes_null`.
- Collect and attach existing `LUPINE_GENERATED_CALL()` function-body templates per target, using the existing parser and validation.
- Emit the existing before/after sections around the generated call. Calls without a body template retain their current output, including the existing NVML all-connections lookup path.

No new annotation syntax, operation classes, memory-retention behavior, or CUDA-specific argument marshalling. The generated RPC still calls the same vendor API. CUDART target wiring and annotations remain in #717, which will be rebased onto this PR.

## Validation

- Pinned `./codegen/run.sh` (CUDA 13.3.1): passed; all checked-in generated artifacts unchanged.
- Strict C++17 compilation against the real CUDA 13.3.1 SDK and project RPC headers passed for generated clients/servers for all six affected nullable-array APIs: `cudaLogsDumpToMemory`, `cudaGraphGetEdges`, `cudaGraphGetNodes`, `cudaGraphGetRootNodes`, `cudaGraphNodeGetDependencies`, and `cudaGraphNodeGetDependentNodes`.
- Parsed and attached real-SDK API body examples through `collect_client_call_templates()` and `collect_backend_functions(..., client_call_templates=...)`: status-returning `cudaRuntimeGetVersion` with input staging/output copy-back, and struct-returning `cudaCreateChannelDesc` with before/after sections. Both compile with `-Wall -Wextra -Werror -pedantic-errors`.
- Real NVIDIA runtime tests passed on an RTX 4090 with CUDA 13.1 using generated client/server code over Lupine's actual TCP/HTTP2 RPC transport. Graph creation plus three nodes exercised null count queries, capacity-one output with bounds checks against native CUDA, and full-capacity output. Collected/attached status and struct body templates also executed their before/after sections correctly, including runtime-version staging and copy-back.
- The original isolated `cudaGraphGetNodes` compiler reproduction now passes unchanged with this emitter.
- No CUDA or transport mocks or new mock tests. The other five nullable-array APIs have compiler coverage, not runtime-execution coverage in this check.
- `git diff --check`: passed.
