### PR TITLE
Remove LUPINE_DISABLE_LOCAL environment variable

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -651,7 +651,6 @@ jobs:
               export CCACHE_COMPILERCHECK=content
               export CCACHE_COMPRESS=true
               export LUPINE_LIB="$LUPINE_BUILD_DIR/libcuda.so.1"
-              export LUPINE_DISABLE_LOCAL=1
               export SERVER_LOCAL_BIN="$LUPINE_BUILD_DIR/lupine_driver_server"
               export SERVER_REMOTE_BIN="/tmp/lupine-driver-server-${MATRIX_LABEL}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
               export SSH_OPTS="-i /tmp/lupine-ssh/id_ed25519 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=15 -o ConnectionAttempts=1 -o ServerAliveInterval=15 -o ServerAliveCountMax=4"

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -762,21 +762,10 @@ extern "C" void lupine_remember_loaded_module_for_rpc(CUmodule module) {
   lupine_remember_loaded_module(module);
 }
 
-static bool lupine_env_enabled(const char *name) {
-  const char *value = getenv(name);
-  if (value == nullptr || strcmp(value, "0") == 0) {
-    return false;
-  }
-  return strcasecmp(value, "false") != 0 && strcasecmp(value, "no") != 0;
-}
-
 static void *lupine_local_libcuda_handle() {
   static std::once_flag once;
   static void *handle = nullptr;
   std::call_once(once, []() {
-    if (lupine_env_enabled("LUPINE_DISABLE_LOCAL")) {
-      return;
-    }
     const char *override_path = getenv("LUPINE_REAL_LIBCUDA");
 #if defined(_WIN32)
     if (override_path != nullptr && override_path[0] != '\0') {

--- a/python/README.md
+++ b/python/README.md
@@ -52,8 +52,6 @@ native HTTP/2 connection, so:
 - `LUPINE_LIBDIR` — load shims from a custom directory (e.g. a newer build).
 - `TRITON_LIBCUDA_PATH` — defaults to the selected shim directory so
   `torch.compile` can link Triton's launcher; an explicit value is preserved.
-- `LUPINE_DISABLE_LOCAL=0` — include local GPUs (when present) in the
-  topology ahead of the remote ones.
 
 The package depends on nothing but the standard library.
 
@@ -80,9 +78,8 @@ An explicit `LUPINE_SERVER` still wins. An externally managed
 `LUPINE_GPU_TYPE`, `LUPINE_GPU_COUNT`, and `LUPINE_REGION` to constrain automatic
 placement, and `LUPINE_AUTO=0` to disable the hook for one process.
 
-The hook does not change `LUPINE_DISABLE_LOCAL`. As with the explicit API,
-PyTorch must have a compiled CUDA backend; a CPU-only PyTorch build cannot
-gain one at runtime.
+As with the explicit API, PyTorch must have a compiled CUDA backend; a CPU-only
+PyTorch build cannot gain one at runtime.
 
 ## Authenticated cloud API
 

--- a/python/auto/tests/test_auto.py
+++ b/python/auto/tests/test_auto.py
@@ -9,7 +9,6 @@ import pytest
 def test_activate_uses_explicit_gateway_for_existing_session(monkeypatch):
     monkeypatch.delenv("LUPINE_AUTO", raising=False)
     monkeypatch.setenv("LUPINE_SERVER", "https://gw-east.lupine.sh:9443")
-    monkeypatch.delenv("LUPINE_DISABLE_LOCAL", raising=False)
     monkeypatch.setenv("LUPINE_SESSION", "lease-test")
     calls = []
     monkeypatch.setattr(
@@ -21,7 +20,6 @@ def test_activate_uses_explicit_gateway_for_existing_session(monkeypatch):
     assert lupine_auto.activate() == {"libcuda": "/shim"}
     assert lupine_auto.DEFAULT_SERVER == "https://api.lupine.sh"
     assert os.environ["LUPINE_SERVER"] == "https://gw-east.lupine.sh:9443"
-    assert "LUPINE_DISABLE_LOCAL" not in os.environ
     assert calls == [False]
 
 
@@ -89,21 +87,18 @@ def test_install_defers_activation_until_cuda_import(monkeypatch):
     assert calls == [True]
 
 
-def test_activate_respects_explicit_server_and_local_policy(monkeypatch):
+def test_activate_respects_explicit_server(monkeypatch):
     monkeypatch.delenv("LUPINE_AUTO", raising=False)
     monkeypatch.setenv("LUPINE_SERVER", "gpu.example:7443")
-    monkeypatch.setenv("LUPINE_DISABLE_LOCAL", "caller-value")
 
     def load_native(*, missing_ok):
         assert missing_ok is False
-        assert os.environ["LUPINE_DISABLE_LOCAL"] == "caller-value"
         return {}
 
     monkeypatch.setattr(lupine, "load_native", load_native)
     lupine_auto.activate()
 
     assert os.environ["LUPINE_SERVER"] == "gpu.example:7443"
-    assert os.environ["LUPINE_DISABLE_LOCAL"] == "caller-value"
 
 
 def test_activate_can_be_disabled(monkeypatch):

--- a/python/tests/test_lupine_adapter.py
+++ b/python/tests/test_lupine_adapter.py
@@ -121,26 +121,17 @@ def test_load_missing_ok_without_libs(monkeypatch, tmp_path):
         _native.load(missing_ok=False)
 
 
-def test_load_does_not_set_disable_local(monkeypatch, tmp_path):
+def test_loads_native_libraries(monkeypatch, tmp_path):
     libdir = tmp_path / "libs"
     libdir.mkdir()
     for name in _native._LIBS[sys.platform]:
         (libdir / name).write_bytes(b"")
 
-    seen_env = []
-
-    class FakeCDLL:
-        def __init__(self, path, mode=None):
-            seen_env.append(os.environ.get("LUPINE_DISABLE_LOCAL"))
-
     monkeypatch.setenv("LUPINE_LIBDIR", str(libdir))
-    monkeypatch.delenv("LUPINE_DISABLE_LOCAL", raising=False)
     monkeypatch.delenv("TRITON_LIBCUDA_PATH", raising=False)
-    monkeypatch.setattr(_native.ctypes, "CDLL", FakeCDLL)
+    monkeypatch.setattr(_native.ctypes, "CDLL", lambda path, mode=None: None)
     result = _native.load(missing_ok=False)
     assert len(result) == len(_native._LIBS[sys.platform])
-    assert seen_env == [None] * len(_native._LIBS[sys.platform])
-    assert "LUPINE_DISABLE_LOCAL" not in os.environ
     if sys.platform in ("linux", "darwin"):
         assert os.environ["TRITON_LIBCUDA_PATH"] == str(libdir)
     # Idempotent: second call loads nothing new.
@@ -150,24 +141,6 @@ def test_load_does_not_set_disable_local(monkeypatch, tmp_path):
         lambda *a, **k: pytest.fail("should not load again"),
     )
     assert _native.load() == result
-
-
-def test_load_respects_existing_disable_local(monkeypatch, tmp_path):
-    libdir = tmp_path / "libs"
-    libdir.mkdir()
-    for name in _native._LIBS[sys.platform]:
-        (libdir / name).write_bytes(b"")
-
-    class FakeCDLL:
-        def __init__(self, path, mode=None):
-            assert os.environ.get("LUPINE_DISABLE_LOCAL") == "0"
-
-    monkeypatch.setenv("LUPINE_LIBDIR", str(libdir))
-    monkeypatch.setenv("LUPINE_DISABLE_LOCAL", "0")
-    monkeypatch.setattr(_native.ctypes, "CDLL", FakeCDLL)
-    _native.load()
-    assert os.environ.get("LUPINE_DISABLE_LOCAL") == "0"
-
 
 def test_load_respects_existing_triton_libcuda_path(monkeypatch, tmp_path):
     libdir = tmp_path / "libs"


### PR DESCRIPTION
## Summary

- always attempt local CUDA driver discovery
- remove the obsolete environment variable from GPU integration CI and Python documentation
- drop Python tests that only verified preservation of the variable while retaining load and activation coverage

## Testing

- `cd python && uv run --all-extras pytest` (37 passed)
- `cmake --build build/client --parallel --target lupine_cuda_client`

## Notes

Use `CUDA_VISIBLE_DEVICES=` to restrict local GPU visibility instead.