### PR TITLE
Fix local pinned async DtoH dispatch

### DIFF
--- a/cuda_client_memcpy.cpp
+++ b/cuda_client_memcpy.cpp
@@ -3295,6 +3295,7 @@ extern "C" CUresult cuMemcpyAtoH(void *dstHost, CUarray srcArray,
 
 extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
+  lupine_route route = lupine_route_for_deviceptr(srcDevice);
   // "API synchronization behavior" lets the driver make this copy synchronous
   // when the destination is pageable, and every driver does. Callers rely on it
   // instead of synchronizing: cuSPARSE reads its scalar results (nnz counts,
@@ -3306,7 +3307,6 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
   if (ByteCount != 0 && !lupine_host_ptr_is_page_locked(dstHost) &&
       lupine_active_stream_captures.load(std::memory_order_relaxed) == 0) {
 
-    lupine_route route = lupine_route_for_deviceptr(srcDevice);
     CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (lupine_route_is_local(route)) {
       return lupine_call_real_cuda_fn("cuMemcpyDtoH_v2", dstHost, srcDevice,
@@ -3352,7 +3352,11 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
     return return_value;
   }
 
-  conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
+  if (lupine_route_is_local(route)) {
+    return lupine_call_real_cuda_fn("cuMemcpyDtoHAsync_v2", dstHost, srcDevice,
+                                    ByteCount, hStream);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
   uint64_t async_sequence = 0;
   if (lupine_prepare_rpc(conn) < 0 ||
       rpc_write_start_async_request(conn, RPC_cuMemcpyDtoHAsync_v2,

--- a/test/test_pinned_async_dtoh.cu
+++ b/test/test_pinned_async_dtoh.cu
@@ -1,0 +1,89 @@
+// Verify that a DtoH copy into pinned memory remains asynchronous and obeys a
+// cross-stream event dependency. In mixed local/remote mode this also covers
+// native dispatch while the Lupine shim is enabled.
+#include <cuda.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+constexpr size_t kElements = 16384;
+
+bool check(CUresult result, const char *operation) {
+  if (result == CUDA_SUCCESS) {
+    return true;
+  }
+  const char *name = nullptr;
+  cuGetErrorName(result, &name);
+  std::fprintf(stderr, "FAIL: %s returned CUDA error %d (%s)\n", operation,
+               static_cast<int>(result), name == nullptr ? "unknown" : name);
+  return false;
+}
+
+} // namespace
+
+int main() {
+  if (!check(cuInit(0), "cuInit")) {
+    return 1;
+  }
+
+  CUdevice device = 0;
+  CUcontext context = nullptr;
+  CUdeviceptr allocation = 0;
+  CUstream producer = nullptr;
+  CUstream consumer = nullptr;
+  CUevent ready = nullptr;
+  unsigned int *pinned = nullptr;
+  const size_t bytes = kElements * sizeof(*pinned);
+
+  if (!check(cuDeviceGet(&device, 0), "cuDeviceGet") ||
+      !check(cuDevicePrimaryCtxRetain(&context, device),
+             "cuDevicePrimaryCtxRetain") ||
+      !check(cuCtxSetCurrent(context), "cuCtxSetCurrent") ||
+      !check(cuMemAllocHost(reinterpret_cast<void **>(&pinned), 2 * bytes),
+             "cuMemAllocHost") ||
+      !check(cuMemAlloc(&allocation, bytes), "cuMemAlloc") ||
+      !check(cuStreamCreate(&producer, CU_STREAM_NON_BLOCKING),
+             "cuStreamCreate(producer)") ||
+      !check(cuStreamCreate(&consumer, CU_STREAM_NON_BLOCKING),
+             "cuStreamCreate(consumer)") ||
+      !check(cuEventCreate(&ready, CU_EVENT_DISABLE_TIMING), "cuEventCreate")) {
+    return 1;
+  }
+
+  std::vector<unsigned int> expected(kElements);
+  for (size_t i = 0; i < expected.size(); ++i) {
+    expected[i] = static_cast<unsigned int>(i * 2654435761U) ^ 0x725U;
+  }
+  std::copy(expected.begin(), expected.end(), pinned);
+  std::fill(pinned + kElements, pinned + 2 * kElements, 0);
+
+  if (!check(cuMemcpyHtoDAsync(allocation, pinned, bytes, producer),
+             "cuMemcpyHtoDAsync") ||
+      !check(cuEventRecord(ready, producer), "cuEventRecord") ||
+      !check(cuStreamWaitEvent(consumer, ready, 0), "cuStreamWaitEvent") ||
+      !check(cuMemcpyDtoHAsync(pinned + kElements, allocation, bytes, consumer),
+             "cuMemcpyDtoHAsync") ||
+      !check(cuStreamSynchronize(consumer), "cuStreamSynchronize")) {
+    return 1;
+  }
+
+  if (!std::equal(expected.begin(), expected.end(), pinned + kElements)) {
+    std::fprintf(stderr, "FAIL: pinned async DtoH output mismatch\n");
+    return 1;
+  }
+
+  if (!check(cuEventDestroy(ready), "cuEventDestroy") ||
+      !check(cuStreamDestroy(consumer), "cuStreamDestroy(consumer)") ||
+      !check(cuStreamDestroy(producer), "cuStreamDestroy(producer)") ||
+      !check(cuMemFree(allocation), "cuMemFree") ||
+      !check(cuMemFreeHost(pinned), "cuMemFreeHost") ||
+      !check(cuDevicePrimaryCtxRelease(device), "cuDevicePrimaryCtxRelease")) {
+    return 1;
+  }
+
+  std::printf("PASS: pinned async DtoH preserves stream ordering and bytes\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

- route pinned `cuMemcpyDtoHAsync_v2` calls for local device allocations through the native CUDA driver
- preserve the existing synchronous behavior for pageable local destinations
- add a focused pinned-memory stream/event workload that validates output bytes after synchronization

## Validation

- reproduced the pre-fix error 46 with node 008 as the local client and node 006 as the remote server
- passed `mixed-local-remote.streams` equivalent across nodes 008/006
- passed `mixed-local-remote-same-host.streams` equivalent using separate GPUs/processes on node 008
- passed the focused test with the shim-enabled local route, remote-only Lupine, and native CUDA
- passed all 12 registered unit checks (9 passed, 3 skipped by platform configuration)

Fixes #725