### PR TITLE
test: mark cuFFT 1d_mgpu_c2c as a known native failure

### DIFF
--- a/test/cuda-library-samples/known_failures.txt
+++ b/test/cuda-library-samples/known_failures.txt
@@ -20,3 +20,10 @@ cuBLASLt/LtHSHgemmGroupedSimple/sample_cublasLt_LtHSHgemmGroupedSimple
 cuSOLVER/gesv/cusolver_irs_expert
 cuSOLVER/gesv/cusolver_irs_lapack
 cuFFT/3d_mgpu_r2c_c2r/bin/3d_mgpu_r2c_c2r_example
+
+# Races natively: the sample runs a two-"GPU" plan on one device ({0, 0}) and
+# cufftXtMemcpy reads the result back on the plan's per-GPU streams without
+# waiting for the compute streams, so a busy GPU returns stale chunks (L2
+# error 0.12 / 0.88). Natively on an RTX 4090 with eight concurrent instances
+# it fails 65 of 310 runs; the shared CI L4 runs eight units at once.
+cuFFT/1d_mgpu_c2c/bin/1d_mgpu_c2c_example


### PR DESCRIPTION
## Summary

- add `cuFFT/1d_mgpu_c2c/bin/1d_mgpu_c2c_example` to the CUDALibrarySamples known failures

## Root cause

The CI failure (`FAILED with L2 error = 0.122098`, run 34428203100 on #721) is a race inside the sample, not in lupine. The sample builds a two-GPU plan on one device (`gpus = {0, 0}`), and `cufftXtMemcpy(DEVICE_TO_HOST)` issues its readback copies on the plan's per-GPU streams without waiting for the streams that ran the last FFT kernels. On a busy GPU the copy lands before those kernels finish and returns a stale chunk. Only the user stream is made to wait on the compute events, and the sample never synchronizes it before the readback.

Evidence:

- Native, no lupine, RTX 4090, eight concurrent instances of the sample: 65 of 310 runs fail, 64 of them with the exact CI value 0.122098 (single stale 16-element chunk); the remaining one at 0.948774.
- Through lupine under the same load: 2-4% of runs fail with the same values. RPC latency gives the kernels more time, so it is rarer than native.
- RPC traces of failing and passing runs through lupine are byte-identical (same ops, same order, same streams and events on the server), and the server-side value of the stale chunk matches what the client received: the device held untransformed data at copy time.
- Reproducing the exact 0.122098 with the sample's RNG: output chunk replaced by its own input data.
- Sequential runs pass 50 of 50 both natively and through lupine.

The CI L4 runs eight integration units in parallel, which is the same contention.

## Testing

- `LIBRARY_SAMPLES_DIR=... ./test/run_cuda_library_samples.sh cuFFT/1d_mgpu_c2c` reports `SKIP:known`