### PR TITLE
Order synchronous RPCs behind earlier async submissions across lanes

### DIFF
--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1467,7 +1467,7 @@ void test_rpc_write_queue_grows() {
     require(rpc_write(&pair.client, &values[i], sizeof(values[i])) == 0,
             "large queue rpc_write failed");
   }
-  require(pair.client.write_queue.size() == kCount + 2,
+  require(pair.client.write_queue.size() == kCount + 3,
           "large queue count mismatch");
   require(rpc_write_end(&pair.client) > 0, "large queue write_end failed");
   reader.join();

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -363,6 +363,24 @@ fail:
   return -1;
 }
 
+static int rpc_async_fence_wait(conn_t *conn, uint64_t fence) {
+  if (fence == 0 || !conn->async_sync_initialized) {
+    return 0;
+  }
+  if (pthread_mutex_lock(&conn->async_mutex) != 0) {
+    return -1;
+  }
+  while (!conn->closed && conn->serving_async_sequence < fence) {
+    if (pthread_cond_wait(&conn->async_cond, &conn->async_mutex) != 0) {
+      pthread_mutex_unlock(&conn->async_mutex);
+      return -1;
+    }
+  }
+  int closed = conn->closed;
+  pthread_mutex_unlock(&conn->async_mutex);
+  return closed ? -1 : 0;
+}
+
 int rpc_async_sequence_begin(conn_t *conn, uint64_t sequence) {
   if (pthread_mutex_lock(&conn->async_mutex) != 0) {
     return -1;
@@ -460,6 +478,7 @@ struct rpc_read_frame {
   int32_t stream_id = -1;
   int request_id = 0;
   int op = 0;
+  uint64_t fence = 0;
 };
 
 struct rpc_response_route {
@@ -590,8 +609,16 @@ int rpc_dispatch(conn_t *conn, int parity) {
     }
     return -1;
   }
+  uint64_t fence = 0;
+  read_result = rpc_http2_read_stream(conn, stream_id, &fence, sizeof(fence));
+  if (read_result != sizeof(fence)) {
+    if (read_result != LUPINE_RPC_HTTP2_STREAM_END) {
+      rpc_mark_connection_closed(conn);
+    }
+    return -1;
+  }
   rpc_tls_io.read_conn = conn;
-  rpc_tls_io.read = {stream_id, request_id, op};
+  rpc_tls_io.read = {stream_id, request_id, op, fence};
   return op;
 }
 
@@ -729,6 +756,7 @@ int rpc_read_end(conn_t *conn) {
     int read_id = rpc_tls_io.read.request_id;
     int32_t stream_id = rpc_tls_io.read.stream_id;
     bool completed_response = rpc_tls_io.read.op == -1;
+    uint64_t fence = rpc_tls_io.read.fence;
     rpc_tls_io.read_conn = nullptr;
     rpc_tls_io.read = {};
     rpc_release_held_call_lock(conn);
@@ -737,6 +765,8 @@ int rpc_read_end(conn_t *conn) {
       if (hook != nullptr) {
         hook(conn, stream_id);
       }
+    } else if (rpc_async_fence_wait(conn, fence) < 0) {
+      return -1;
     }
     return read_id;
   }
@@ -867,7 +897,7 @@ int rpc_write_start_request(conn_t *conn, const int op) {
     rpc_tls_io.write_conn = conn;
   }
 
-  if (rpc_write_queue_reset(conn, 2) < 0) {
+  if (rpc_write_queue_reset(conn, 3) < 0) {
     rpc_release_write_builder(conn, request_nested_in_response);
     pthread_mutex_unlock(&conn->call_mutex);
     return -1;
@@ -875,6 +905,7 @@ int rpc_write_start_request(conn_t *conn, const int op) {
   conn->request_id = conn->request_id + 2; // leave the last bit the same
   conn->write_id = conn->request_id;
   conn->write_op = op;
+  conn->write_fence = conn->issued_async_sequence;
   conn->write_stream_id = rpc_http2_lane_stream(conn, rpc_tls_lane.id);
   if (conn->write_stream_id < 0) {
     rpc_release_write_builder(conn, request_nested_in_response);
@@ -1036,11 +1067,15 @@ int rpc_write_end(conn_t *conn) {
   int write_id = conn->write_id;
   int32_t write_stream_id = conn->write_stream_id;
   int result = -1;
-  if (conn->write_queue.size() >= 2) {
+  if (conn->write_queue.size() >= (request ? 3u : 2u)) {
     conn->write_queue[0] =
         rpc_write_cursor(&conn->write_id, sizeof(conn->write_id));
     conn->write_queue[1] =
         rpc_write_cursor(&conn->write_op, sizeof(conn->write_op));
+    if (request) {
+      conn->write_queue[2] =
+          rpc_write_cursor(&conn->write_fence, sizeof(conn->write_fence));
+    }
     result = rpc_http2_write_stream(conn, write_stream_id, conn->write_queue);
   }
   rpc_release_write_builder(conn, request_nested_in_response);

--- a/rpc.h
+++ b/rpc.h
@@ -113,6 +113,7 @@ struct conn_t {
   int request_id;
   int write_id;
   int write_op;
+  uint64_t write_fence;
   int32_t write_stream_id;
 
   pthread_t read_thread;
@@ -192,7 +193,10 @@ extern int rpc_wait_for_response(conn_t *conn);
 extern int rpc_write_start_request(conn_t *conn, const int op);
 // Starts a request and allocates its async-submission ticket while the normal
 // request lock is held. The caller writes the ticket into the request payload;
-// this adds no server acknowledgement or round trip.
+// this adds no server acknowledgement or round trip. Every request header also
+// carries the number of tickets issued before it, and the server serves none of
+// it until those submissions have reached the driver: a synchronous call on one
+// lane must observe fire-and-forget work another lane issued earlier.
 extern int rpc_write_start_async_request(conn_t *conn, const int op,
                                          uint64_t *sequence);
 extern int rpc_write_start_response(conn_t *conn, const int read_id);

--- a/test/test_cross_lane_launch_order.cu
+++ b/test/test_cross_lane_launch_order.cu
@@ -128,6 +128,50 @@ void test_cross_type_order(int *value, int *failures) {
   require_no_failures(failures, "async memsets overtook kernel launches");
 }
 
+// A synchronous request carries no ticket of its own, yet it must not reach
+// the driver before fire-and-forget work another lane issued earlier.
+void test_sync_readback_order(int *value) {
+  check(cudaMemset(value, 0xff, sizeof(*value)), "cudaMemset value");
+
+  std::atomic<int> phase{0};
+  std::atomic<int> stale{0};
+  std::thread producer([&] {
+    check(cudaSetDevice(0), "producer cudaSetDevice");
+    large_payload payload = {};
+    for (int round = 0; round < kRounds; ++round) {
+      wait_for(phase, round * 2);
+      payload.value = round;
+      publish<<<1, 1>>>(payload, value);
+      check(cudaGetLastError(), "publish launch");
+      phase.store(round * 2 + 1, std::memory_order_release);
+    }
+  });
+
+  std::thread consumer([&] {
+    check(cudaSetDevice(0), "consumer cudaSetDevice");
+    for (int round = 0; round < kRounds; ++round) {
+      wait_for(phase, round * 2 + 1);
+      int observed = -1;
+      check(cudaMemcpy(&observed, value, sizeof(observed),
+                       cudaMemcpyDeviceToHost),
+            "cudaMemcpy value");
+      if (observed != round) {
+        stale.fetch_add(1, std::memory_order_relaxed);
+      }
+      phase.store(round * 2 + 2, std::memory_order_release);
+    }
+  });
+
+  producer.join();
+  consumer.join();
+  int observed = stale.load(std::memory_order_relaxed);
+  if (observed != 0) {
+    std::fprintf(stderr, "FAIL: %d of %d synchronous readbacks overtook\n",
+                 observed, kRounds);
+    std::exit(EXIT_FAILURE);
+  }
+}
+
 } // namespace
 
 int main() {
@@ -146,6 +190,7 @@ int main() {
 
   test_kernel_launch_order(value, failures);
   test_cross_type_order(value, failures);
+  test_sync_readback_order(value);
 
   check(cudaFree(failures), "cudaFree failures");
   check(cudaFree(value), "cudaFree value");


### PR DESCRIPTION
## Summary

- every request header now carries a fence: the number of fire-and-forget tickets the client had issued before it
- the server finishes reading a request's payload, then waits until every earlier ticket has reached the driver before running the handler
- extend `test_cross_lane_launch_order` with a synchronous readback case

## Root cause

#701 sequenced fire-and-forget requests (kernel launches, event records, async memsets and DtoH copies) against each other with tickets, but a request that waits for a response carries no ticket. A host thread that issues a synchronous call on its own HTTP/2 lane after another thread's fire-and-forget call returned can reach the driver first, because the earlier request may still be decoding on the other lane. Natively the driver sees the calls in issue order. Through lupine a `cudaMemcpy` readback, `cuStreamWaitEvent`, or `cuCtxSynchronize` on a second thread can observe the device before the first thread's launch or event record is submitted.

The fence is captured under the request lock, so it is exactly the issue order. The wait sits in `rpc_read_end` so the lane has already consumed its payload and holds no HTTP/2 credits while waiting; fire-and-forget handlers still take their own ticket afterwards. Requests the server originates carry fence 0.

Found while chasing the cuFFT `1d_mgpu_c2c` CI failure, which turned out to be an upstream race in the sample (#729); this is a separate real ordering hole.

## Testing

- new `test_sync_readback_order` on unpatched main (RTX 4090): `FAIL: 1 of 512 synchronous readbacks overtook` in 3 of 4 runs; with this change 4 of 4 runs pass
- `ctest --test-dir build` 13 of 13
- `./test/run_sanitizer_tests.sh thread` passed
- clang-format on changed lines, `git diff --check`