### PR TITLE
test: carry the upstream cuFFT multi-GPU stream sync fix in the library sample runner

### DIFF
--- a/test/run_cuda_library_samples.sh
+++ b/test/run_cuda_library_samples.sh
@@ -85,6 +85,70 @@ if [[ "$BUILD_SAMPLES" != "0" ]]; then
     git -C "$LIBRARY_SAMPLES_DIR" fetch --quiet origin
     git -C "$LIBRARY_SAMPLES_DIR" checkout --quiet "$LIBRARY_SAMPLES_REF"
   fi
+  # The multi-GPU cuFFT samples read the result back before the plan's stream
+  # has finished, which returns stale chunks on a busy GPU. Fix proposed in
+  # NVIDIA/CUDALibrarySamples#367; drop this once LIBRARY_SAMPLES_REF includes it.
+  patch_file="$(mktemp)"
+  cat >"$patch_file" <<'PATCH'
+--- a/cuFFT/1d_mgpu_c2c/1d_mgpu_c2c_example.cpp
++++ b/cuFFT/1d_mgpu_c2c/1d_mgpu_c2c_example.cpp
+@@ -105,6 +105,11 @@
+     // Execute the plan
+     CUFFT_CALL(cufftXtExecDescriptor(plan, indesc, indesc, CUFFT_FORWARD));
+ 
++#if CUFFT_VERSION >= 10400
++    // The transform runs on the plan's stream; wait for it before reading back
++    CUDA_RT_CALL(cudaStreamSynchronize(stream));
++#endif
++
+     // Copy output data to CPU
+     CUFFT_CALL(cufftXtMemcpy(plan, reinterpret_cast<void *>(h_data_out.data()),
+                              reinterpret_cast<void *>(indesc), CUFFT_COPY_DEVICE_TO_HOST));
+--- a/cuFFT/3d_mgpu_c2c/3d_mgpu_c2c_example.cpp
++++ b/cuFFT/3d_mgpu_c2c/3d_mgpu_c2c_example.cpp
+@@ -105,6 +105,11 @@
+     // Execute the plan
+     CUFFT_CALL(cufftXtExecDescriptor(plan, indesc, indesc, CUFFT_FORWARD));
+ 
++#if CUFFT_VERSION >= 10400
++    // The transform runs on the plan's stream; wait for it before reading back
++    CUDA_RT_CALL(cudaStreamSynchronize(stream));
++#endif
++
+     // Copy output data to CPU
+     CUFFT_CALL(cufftXtMemcpy(plan, reinterpret_cast<void *>(h_data_out.data()),
+                              reinterpret_cast<void *>(indesc), CUFFT_COPY_DEVICE_TO_HOST));
+--- a/cuFFT/3d_mgpu_r2c_c2r/3d_mgpu_r2c_c2r_example.cpp
++++ b/cuFFT/3d_mgpu_r2c_c2r/3d_mgpu_r2c_c2r_example.cpp
+@@ -155,6 +155,11 @@
+     // Execute the plan_r2c
+     CUFFT_CALL(cufftXtExecDescriptor(plan_r2c, indesc, indesc, CUFFT_FORWARD));
+ 
++#if CUFFT_VERSION >= 10400
++    // The transform runs on the plan's stream; wait for it before reading back
++    CUDA_RT_CALL(cudaStreamSynchronize(stream));
++#endif
++
+     // Scale complex results
+     float scale{2.f};
+     scaleComplex(indesc, scale, h_data_out.size(), gpus.size());
+@@ -162,6 +167,11 @@
+     // Execute the plan_c2r
+     CUFFT_CALL(cufftXtExecDescriptor(plan_c2r, indesc, indesc, CUFFT_INVERSE));
+ 
++#if CUFFT_VERSION >= 10400
++    // The transform runs on the plan's stream; wait for it before reading back
++    CUDA_RT_CALL(cudaStreamSynchronize(stream));
++#endif
++
+     // Copy output data to CPU
+     CUFFT_CALL(cufftXtMemcpy(plan_c2r, (void *)h_data_out.data(), (void *)indesc,
+                              CUFFT_COPY_DEVICE_TO_HOST));
+PATCH
+  if ! git -C "$LIBRARY_SAMPLES_DIR" apply --reverse --check "$patch_file" 2>/dev/null; then
+    git -C "$LIBRARY_SAMPLES_DIR" apply "$patch_file"
+  fi
+  rm -f "$patch_file"
 fi
 
 # A sample is a directory with a CMakeLists.txt and no CMake project beneath


### PR DESCRIPTION
## Summary

- apply the fix proposed in NVIDIA/CUDALibrarySamples#367 to the CUDALibrarySamples checkout after the pinned ref is checked out
- drop it once `LIBRARY_SAMPLES_REF` moves past that merge

## Root cause of the CI flake

`cuda-library.cuFFT/1d_mgpu_c2c` failing with `L2 error = 0.122098` (run 34428203100 on #721) is a race in the sample, not in lupine. The sample sets a stream on a two-"GPU" plan on one device and calls `cufftXtMemcpy(DEVICE_TO_HOST)` straight after `cufftXtExecDescriptor`. The readback runs on the plan's per-GPU streams, which do not wait for the streams that ran the last kernels, so on a busy GPU it returns a stale chunk. RPC traces of passing and failing runs through lupine are identical, and the server read the same stale bytes from the device that the client received.

Native on an RTX 4090 with eight concurrent instances, no lupine: 66 of 320 runs fail, 65 of them with exactly 0.122098. With the stream synchronized after the transform: 320 of 320 pass. Through lupine the failure is rarer (2 to 4 percent) because RPC latency gives the kernels time; the CI L4 runs eight units at once.

The patch is embedded in the runner rather than shipped as a file because the CI image copies only the runner script into the build stage and keys the sample binary cache on its content, so this also rebuilds the cached binaries.

## Testing

- `./test/run_cuda_library_samples.sh cuFFT/1d_mgpu_c2c` against a fresh clone: patch applied, unit passes; second run skips the already-applied patch and passes