### PR TITLE
Fix CUDA 12 runtime kernels across device routes

### DIFF
--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -1263,6 +1263,10 @@ extern "C" CUresult cuModuleGetFunction(CUfunction *function, CUmodule module,
   return result;
 }
 
+static CUresult lupine_load_recorded_library_on_route(CUlibrary source_library,
+                                                      lupine_route route,
+                                                      CUlibrary *library);
+
 static CUresult lupine_load_recorded_module_on_route(CUmodule source_module,
                                                      lupine_route route,
                                                      CUmodule *module) {
@@ -1276,27 +1280,49 @@ static CUresult lupine_load_recorded_module_on_route(CUmodule source_module,
   }
 
   lupine_module_image_record record;
+  CUlibrary parent_library = nullptr;
   {
     std::lock_guard<std::mutex> lock(lupine_library_kernel_mutex());
     auto it = lupine_module_images().find(source_module);
     if (it == lupine_module_images().end()) {
-      // No recorded image, so the module cannot be replicated elsewhere. It is
-      // still valid on the route that already owns it (cuModuleLoad, for one,
-      // never records an image), so hand that handle back untouched and only
-      // fail when a genuinely different route is asked for.
       if (lupine_route_identity(lupine_route_for_module(source_module)) ==
           route_id) {
         *module = source_module;
         return CUDA_SUCCESS;
       }
-      return CUDA_ERROR_NOT_FOUND;
+      auto library = lupine_library_modules().find(source_module);
+      if (library == lupine_library_modules().end()) {
+        // No recorded image or parent library means the module cannot be
+        // reconstructed on another route (cuModuleLoad, for one, records
+        // neither).
+        return CUDA_ERROR_NOT_FOUND;
+      }
+      parent_library = library->second;
+    } else {
+      auto cached = it->second.modules_by_route.find(route_id);
+      if (cached != it->second.modules_by_route.end()) {
+        *module = cached->second;
+        return CUDA_SUCCESS;
+      }
+      record = it->second;
     }
-    auto cached = it->second.modules_by_route.find(route_id);
-    if (cached != it->second.modules_by_route.end()) {
-      *module = cached->second;
-      return CUDA_SUCCESS;
+  }
+
+  if (parent_library != nullptr) {
+    CUlibrary library = nullptr;
+    CUresult result =
+        lupine_load_recorded_library_on_route(parent_library, route, &library);
+    if (result != CUDA_SUCCESS || library == nullptr) {
+      return result;
     }
-    record = it->second;
+
+    CUmodule loaded = nullptr;
+    result = cuLibraryGetModule(&loaded, library);
+    if (result != CUDA_SUCCESS || loaded == nullptr) {
+      return result;
+    }
+    *module = loaded;
+    return CUDA_SUCCESS;
   }
 
   CUmodule loaded = nullptr;
@@ -5077,9 +5103,15 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
 
   lupine_route route = lupine_route_for_current_context();
   if (lupine_route_is_local(route)) {
-    return lupine_call_real_cuda_fn(
+    CUresult result = lupine_call_real_cuda_fn(
         "cuLibraryLoadData", library, code, jitOptions, jitOptionsValues,
         numJitOptions, libraryOptions, libraryOptionValues, numLibraryOptions);
+    if (result == CUDA_SUCCESS) {
+      lupine_note_library_owner_route(*library, route);
+      lupine_record_library_image(*library, route, kind, image_bytes.data(),
+                                  image_bytes.size(), code);
+    }
+    return result;
   }
 
   conn_t *conn = lupine_route_remote_conn(route);

--- a/cuda_compat.h
+++ b/cuda_compat.h
@@ -56,6 +56,7 @@ CUresult cuFuncGetParamInfo(CUfunction, size_t, size_t *, size_t *);
 CUresult cuKernelGetAttribute(int *, CUfunction_attribute, CUkernel, CUdevice);
 CUresult cuKernelGetFunction(CUfunction *, CUkernel);
 CUresult cuLibraryGetKernel(CUkernel *, CUlibrary, const char *);
+CUresult cuLibraryGetModule(CUmodule *, CUlibrary);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Closes #733.

Summary:
- record local cuLibraryLoadData ownership and replayable images, matching the remote path
- recreate CUmodules obtained from CUlibraries by replaying the parent library on the launch route
- preserve the existing raw-module replay path for modules loaded directly from images

Reproduction:
Using the CUDA 12.4.1 upstream sample binaries with the main-branch client and GPU servers on inferable-node-006 and inferable-node-008:
- two remote routes: simpleMultiGPU and MonteCarloMultiGPU failed with CUDA error 500
- one local plus one remote route: both samples failed with CUDA error 46

Validation:
- two remote routes: simpleMultiGPU and MonteCarloMultiGPU pass
- one local plus one remote route: simpleMultiGPU and MonteCarloMultiGPU pass
- full CMake build passes
- ctest: 13/13 passed, including 3 expected environment-dependent skips
- clang-format dry-run and git diff checks pass