### PR TITLE
Keep capture-info queries local and preserve native versioned ABIs

### DIFF
--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -6954,6 +6954,19 @@ static bool lupine_is_writable_user_pointer(const void *ptr, size_t size) {
 #endif
 }
 
+// Include admitted capture starts, not just completed BeginCapture calls: a
+// different thread may query after the server starts capture but before the
+// initiating thread receives its reply.
+std::atomic<int> lupine_active_stream_captures{0};
+
+static bool lupine_stream_handle_is_known(CUstream hStream) {
+  if (hStream == nullptr || hStream == CU_STREAM_LEGACY ||
+      hStream == CU_STREAM_PER_THREAD) {
+    return true;
+  }
+  return lupine_route_for_known_stream(hStream).kind != LUPINE_ROUTE_INVALID;
+}
+
 static CUresult lupine_cuStreamGetCaptureInfo(
     CUstream stream, CUstreamCaptureStatus *captureStatus_out,
     cuuint64_t *id_out, CUgraph *graph_out,
@@ -6993,6 +7006,17 @@ static CUresult lupine_cuStreamGetCaptureInfo(
     }
   }
 #endif
+
+  // Like cuStreamIsCapturing, this query needs no server state when no capture
+  // is outstanding. Optional outputs are only defined during active capture.
+  // Keep unknown streams and uninitialized/detached contexts on the RPC path.
+  if (captureStatus_out != nullptr && lupine_cuda_is_initialized() &&
+      lupine_current_context != nullptr &&
+      lupine_active_stream_captures.load() == 0 &&
+      lupine_stream_handle_is_known(stream)) {
+    *captureStatus_out = CU_STREAM_CAPTURE_STATUS_NONE;
+    return CUDA_SUCCESS;
+  }
 
   CUstreamCaptureStatus status = CU_STREAM_CAPTURE_STATUS_NONE;
   cuuint64_t id = 0;
@@ -7080,19 +7104,15 @@ static CUresult lupine_cuStreamGetCaptureInfo(
   return return_value;
 }
 
-// Stream captures started by this client and not yet terminated. A stream can
-// only be capturing if we started the capture, so cuStreamIsCapturing can
-// answer NONE locally while this is zero.
-std::atomic<int> lupine_active_stream_captures{0};
-
 extern "C" void lupine_stream_capture_begin() {
   lupine_checkpoint::capture_begin();
+  lupine_active_stream_captures.fetch_add(1);
 }
 
 extern "C" void lupine_stream_capture_begin_complete(bool started) {
   lupine_checkpoint::capture_begin_complete(started);
-  if (started) {
-    lupine_active_stream_captures.fetch_add(1);
+  if (!started) {
+    lupine_active_stream_captures.fetch_sub(1);
   }
 }
 
@@ -7107,14 +7127,6 @@ extern "C" CUresult lupine_complete_stream_end_capture(CUresult result) {
     lupine_active_stream_captures.fetch_sub(1);
   }
   return result;
-}
-
-static bool lupine_stream_handle_is_known(CUstream hStream) {
-  if (hStream == nullptr || hStream == CU_STREAM_LEGACY ||
-      hStream == CU_STREAM_PER_THREAD) {
-    return true;
-  }
-  return lupine_route_for_known_stream(hStream).kind != LUPINE_ROUTE_INVALID;
 }
 
 extern "C" CUresult cuStreamIsCapturing(CUstream hStream,

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -31,10 +31,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#if defined(__APPLE__)
-#include <mach/mach.h>
-#include <mach/mach_vm.h>
-#elif !defined(__GLIBC__)
+#if !defined(__APPLE__) && !defined(__GLIBC__)
 #error "Lupine CUDA client requires glibc, macOS, or Windows"
 #endif
 #endif
@@ -6897,63 +6894,6 @@ static void lupine_complete_pending_log_callbacks(conn_t *, int32_t) {}
 static void lupine_discard_pending_log_callbacks(conn_t *) {}
 #endif
 
-static bool lupine_is_writable_user_pointer(const void *ptr, size_t size) {
-  if (ptr == nullptr || size == 0) {
-    return false;
-  }
-  uintptr_t start = reinterpret_cast<uintptr_t>(ptr);
-  uintptr_t end = start + size;
-  if (end < start) {
-    return false;
-  }
-
-#if defined(_WIN32)
-  MEMORY_BASIC_INFORMATION info = {};
-  if (VirtualQuery(ptr, &info, sizeof(info)) == 0 || info.State != MEM_COMMIT) {
-    return false;
-  }
-  uintptr_t region_start = reinterpret_cast<uintptr_t>(info.BaseAddress);
-  uintptr_t region_end = region_start + info.RegionSize;
-  DWORD protection = info.Protect & 0xff;
-  bool writable = protection == PAGE_READWRITE ||
-                  protection == PAGE_WRITECOPY ||
-                  protection == PAGE_EXECUTE_READWRITE ||
-                  protection == PAGE_EXECUTE_WRITECOPY;
-  return start >= region_start && end <= region_end && writable &&
-         (info.Protect & PAGE_GUARD) == 0;
-#elif defined(__APPLE__)
-  mach_vm_address_t region = static_cast<mach_vm_address_t>(start);
-  mach_vm_size_t region_size = 0;
-  vm_region_basic_info_data_64_t info = {};
-  mach_msg_type_number_t info_count = VM_REGION_BASIC_INFO_COUNT_64;
-  mach_port_t object_name = MACH_PORT_NULL;
-  kern_return_t result = mach_vm_region(
-      mach_task_self(), &region, &region_size, VM_REGION_BASIC_INFO_64,
-      reinterpret_cast<vm_region_info_t>(&info), &info_count, &object_name);
-  if (object_name != MACH_PORT_NULL) {
-    mach_port_deallocate(mach_task_self(), object_name);
-  }
-  return result == KERN_SUCCESS && region <= start &&
-         end <= region + region_size && (info.protection & VM_PROT_WRITE) != 0;
-#else
-  std::ifstream maps("/proc/self/maps");
-  std::string line;
-  while (std::getline(maps, line)) {
-    uintptr_t region_start = 0;
-    uintptr_t region_end = 0;
-    char perms[5] = {};
-    if (sscanf(line.c_str(), "%lx-%lx %4s", &region_start, &region_end,
-               perms) != 3) {
-      continue;
-    }
-    if (start >= region_start && end <= region_end && perms[1] == 'w') {
-      return true;
-    }
-  }
-  return false;
-#endif
-}
-
 // Include admitted capture starts, not just completed BeginCapture calls: a
 // different thread may query after the server starts capture but before the
 // initiating thread receives its reply.
@@ -7054,25 +6994,6 @@ static CUresult lupine_cuStreamGetCaptureInfo(
   if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-
-  bool num_dependencies_writable =
-      numDependencies_out != nullptr &&
-      lupine_is_writable_user_pointer(numDependencies_out,
-                                      sizeof(*numDependencies_out));
-  if (edgeData_out != nullptr &&
-      (numDependencies_out == nullptr || !num_dependencies_writable)) {
-    numDependencies_out = reinterpret_cast<size_t *>(edgeData_out);
-    edgeData_out = nullptr;
-    num_dependencies_writable = lupine_is_writable_user_pointer(
-        numDependencies_out, sizeof(*numDependencies_out));
-  }
-  if (numDependencies_out != nullptr && !num_dependencies_writable) {
-    numDependencies_out = nullptr;
-  }
-  if (edgeData_out != nullptr &&
-      !lupine_is_writable_user_pointer(edgeData_out, sizeof(*edgeData_out))) {
-    edgeData_out = nullptr;
   }
 
   if (captureStatus_out != nullptr) {
@@ -7266,17 +7187,6 @@ extern "C" CUresult cuStreamGetCaptureInfo_v2(
 #ifdef cuStreamGetCaptureInfo
 #undef cuStreamGetCaptureInfo
 #endif
-#if CUDA_VERSION >= 12000
-extern "C" CUresult cuStreamGetCaptureInfo(
-    CUstream stream, CUstreamCaptureStatus *captureStatus_out,
-    cuuint64_t *id_out, CUgraph *graph_out,
-    const CUgraphNode **dependencies_out, const CUgraphEdgeData **edgeData_out,
-    size_t *numDependencies_out) {
-  return lupine_cuStreamGetCaptureInfo(stream, captureStatus_out, id_out,
-                                       graph_out, dependencies_out,
-                                       edgeData_out, numDependencies_out);
-}
-#else
 extern "C" CUresult
 cuStreamGetCaptureInfo(CUstream stream,
                        CUstreamCaptureStatus *captureStatus_out,
@@ -7284,7 +7194,6 @@ cuStreamGetCaptureInfo(CUstream stream,
   return lupine_cuStreamGetCaptureInfo(stream, captureStatus_out, id_out,
                                        nullptr, nullptr, nullptr, nullptr);
 }
-#endif
 
 extern "C" CUresult
 cuStreamBeginCaptureToGraph(CUstream hStream, CUgraph hGraph,
@@ -8646,6 +8555,20 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
   // Most wrappers route purely by symbol name. A few CUDA APIs changed ABI
   // without changing the name and must also use the requested API version.
   (void)flags;
+
+  if (strcmp(symbol, "cuStreamGetCaptureInfo") == 0) {
+    if (cudaVersion >= 12030) {
+      *pfn = reinterpret_cast<void *>(&cuStreamGetCaptureInfo_v3);
+    } else if (cudaVersion >= 11030) {
+      *pfn = reinterpret_cast<void *>(&cuStreamGetCaptureInfo_v2);
+    } else {
+      *pfn = reinterpret_cast<void *>(&cuStreamGetCaptureInfo);
+    }
+    if (symbolStatus != nullptr) {
+      *symbolStatus = CU_GET_PROC_ADDRESS_SUCCESS;
+    }
+    return CUDA_SUCCESS;
+  }
 
   auto resolve_graph_query = [&](const char *candidate, void *legacy,
                                  void *edge_data) {

--- a/test/test_stream_capture_info.cu
+++ b/test/test_stream_capture_info.cu
@@ -5,6 +5,17 @@
 #include <cstdlib>
 #include <thread>
 
+#ifdef cuGetProcAddress
+#undef cuGetProcAddress
+#endif
+extern "C" CUresult cuGetProcAddress(const char *, void **, int, cuuint64_t);
+
+#ifdef cuStreamGetCaptureInfo
+#undef cuStreamGetCaptureInfo
+#endif
+extern "C" CUresult cuStreamGetCaptureInfo(CUstream, CUstreamCaptureStatus *,
+                                           cuuint64_t *);
+
 extern "C" CUresult cuStreamGetCaptureInfo_v2(CUstream, CUstreamCaptureStatus *,
                                               cuuint64_t *, CUgraph *,
                                               const CUgraphNode **, size_t *);
@@ -22,6 +33,9 @@ static void check_status(CUstream stream, CUstreamCaptureStatus expected) {
   CUgraph graph = nullptr;
   const CUgraphNode *dependencies = nullptr;
   size_t count = 0;
+  require(cuStreamGetCaptureInfo(stream, &status, &id) == CUDA_SUCCESS &&
+              status == expected,
+          "legacy capture status is incorrect");
   require(cuStreamGetCaptureInfo_v2(stream, &status, &id, &graph, &dependencies,
                                     &count) == CUDA_SUCCESS &&
               status == expected,
@@ -31,12 +45,49 @@ static void check_status(CUstream stream, CUstreamCaptureStatus expected) {
     require(count != 0 && dependencies != nullptr,
             "captured dependency metadata is missing");
   }
+  using CaptureInfoV1 =
+      CUresult (*)(CUstream, CUstreamCaptureStatus *, cuuint64_t *);
+  using CaptureInfoV2 =
+      CUresult (*)(CUstream, CUstreamCaptureStatus *, cuuint64_t *, CUgraph *,
+                   const CUgraphNode **, size_t *);
+  void *function = nullptr;
+  require(cuGetProcAddress("cuStreamGetCaptureInfo", &function, 10010, 0) ==
+              CUDA_SUCCESS,
+          "v1 lookup failed");
+  require(reinterpret_cast<CaptureInfoV1>(function)(stream, &status, &id) ==
+                  CUDA_SUCCESS &&
+              status == expected,
+          "versioned v1 capture query failed");
+  require(cuGetProcAddress("cuStreamGetCaptureInfo", &function, 11030, 0) ==
+              CUDA_SUCCESS,
+          "v2 lookup failed");
+  count = 0;
+  require(reinterpret_cast<CaptureInfoV2>(function)(stream, &status, &id,
+                                                    &graph, &dependencies,
+                                                    &count) == CUDA_SUCCESS &&
+              status == expected,
+          "versioned v2 capture query failed");
+  if (expected == CU_STREAM_CAPTURE_STATUS_ACTIVE) {
+    require(count != 0 && dependencies != nullptr,
+            "versioned v2 lost capture dependencies");
+  }
 #if CUDA_VERSION >= 12030
   const CUgraphEdgeData *edges = nullptr;
   require(cuStreamGetCaptureInfo_v3(stream, &status, &id, &graph, &dependencies,
                                     &edges, &count) == CUDA_SUCCESS &&
               status == expected,
           "v3 capture status is incorrect");
+  using CaptureInfoV3 =
+      CUresult (*)(CUstream, CUstreamCaptureStatus *, cuuint64_t *, CUgraph *,
+                   const CUgraphNode **, const CUgraphEdgeData **, size_t *);
+  require(cuGetProcAddress("cuStreamGetCaptureInfo", &function, 12030, 0) ==
+              CUDA_SUCCESS,
+          "v3 lookup failed");
+  require(reinterpret_cast<CaptureInfoV3>(function)(
+              stream, &status, &id, &graph, &dependencies, &edges, &count) ==
+                  CUDA_SUCCESS &&
+              status == expected,
+          "versioned v3 capture query failed");
 #endif
 }
 

--- a/test/test_stream_capture_info.cu
+++ b/test/test_stream_capture_info.cu
@@ -1,0 +1,123 @@
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+extern "C" CUresult cuStreamGetCaptureInfo_v2(CUstream, CUstreamCaptureStatus *,
+                                              cuuint64_t *, CUgraph *,
+                                              const CUgraphNode **, size_t *);
+
+static void require(bool condition, const char *message) {
+  if (!condition) {
+    std::fprintf(stderr, "%s\n", message);
+    std::exit(1);
+  }
+}
+
+static void check_status(CUstream stream, CUstreamCaptureStatus expected) {
+  CUstreamCaptureStatus status = CU_STREAM_CAPTURE_STATUS_NONE;
+  cuuint64_t id = 0;
+  CUgraph graph = nullptr;
+  const CUgraphNode *dependencies = nullptr;
+  size_t count = 0;
+  require(cuStreamGetCaptureInfo_v2(stream, &status, &id, &graph, &dependencies,
+                                    &count) == CUDA_SUCCESS &&
+              status == expected,
+          "v2 capture status is incorrect");
+  if (expected == CU_STREAM_CAPTURE_STATUS_ACTIVE) {
+    require(graph != nullptr && id != 0, "active capture metadata is missing");
+    require(count != 0 && dependencies != nullptr,
+            "captured dependency metadata is missing");
+  }
+#if CUDA_VERSION >= 12030
+  const CUgraphEdgeData *edges = nullptr;
+  require(cuStreamGetCaptureInfo_v3(stream, &status, &id, &graph, &dependencies,
+                                    &edges, &count) == CUDA_SUCCESS &&
+              status == expected,
+          "v3 capture status is incorrect");
+#endif
+}
+
+int main() {
+  require(cuInit(0) == CUDA_SUCCESS, "cuInit failed");
+  CUdevice device;
+  CUcontext context;
+  require(cuDeviceGet(&device, 0) == CUDA_SUCCESS &&
+              cuDevicePrimaryCtxRetain(&context, device) == CUDA_SUCCESS &&
+              cuCtxSetCurrent(context) == CUDA_SUCCESS,
+          "context setup failed");
+  CUstream stream = nullptr, idle = nullptr;
+  require(cuStreamCreate(&stream, CU_STREAM_DEFAULT) == CUDA_SUCCESS &&
+              cuStreamCreate(&idle, CU_STREAM_NON_BLOCKING) == CUDA_SUCCESS,
+          "stream creation failed");
+  CUdeviceptr memory;
+  require(cuMemAlloc(&memory, 64) == CUDA_SUCCESS, "allocation failed");
+  for (int i = 0; i < 100; ++i) {
+    check_status(stream, CU_STREAM_CAPTURE_STATUS_NONE);
+    check_status(nullptr, CU_STREAM_CAPTURE_STATUS_NONE);
+  }
+  require(cuStreamBeginCapture(stream, static_cast<CUstreamCaptureMode>(999)) ==
+              CUDA_ERROR_INVALID_VALUE,
+          "invalid begin did not fail");
+  check_status(stream, CU_STREAM_CAPTURE_STATUS_NONE);
+
+  require(cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_GLOBAL) ==
+              CUDA_SUCCESS,
+          "begin capture failed");
+  require(cuMemsetD8Async(memory, 7, 64, stream) == CUDA_SUCCESS,
+          "captured memset failed");
+  check_status(stream, CU_STREAM_CAPTURE_STATUS_ACTIVE);
+  check_status(idle, CU_STREAM_CAPTURE_STATUS_NONE);
+  CUstreamCaptureStatus status;
+  require(cuStreamGetCaptureInfo_v2(nullptr, &status, nullptr, nullptr, nullptr,
+                                    nullptr) ==
+              CUDA_ERROR_STREAM_CAPTURE_IMPLICIT,
+          "legacy stream did not report implicit capture");
+  std::thread other([&] {
+    require(cuCtxSetCurrent(context) == CUDA_SUCCESS, "thread context failed");
+    check_status(stream, CU_STREAM_CAPTURE_STATUS_ACTIVE);
+  });
+  other.join();
+  CUgraph graph = nullptr;
+  require(cuStreamEndCapture(stream, &graph) == CUDA_SUCCESS &&
+              graph != nullptr,
+          "end capture failed");
+  require(cuGraphDestroy(graph) == CUDA_SUCCESS, "graph destroy failed");
+  check_status(stream, CU_STREAM_CAPTURE_STATUS_NONE);
+
+  require(cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_GLOBAL) ==
+              CUDA_SUCCESS,
+          "second begin failed");
+  require(cuStreamSynchronize(stream) == CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED,
+          "capture was not invalidated by synchronization");
+  check_status(stream, CU_STREAM_CAPTURE_STATUS_INVALIDATED);
+  require(cuStreamEndCapture(stream, &graph) ==
+              CUDA_ERROR_STREAM_CAPTURE_INVALIDATED,
+          "invalidated capture did not terminate");
+  for (int i = 0; i < 100; ++i) {
+    check_status(stream, CU_STREAM_CAPTURE_STATUS_NONE);
+  }
+  // The runtime and driver share capture bookkeeping on the same streams.
+  require(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal) ==
+                  cudaSuccess &&
+              cudaMemsetAsync(reinterpret_cast<void *>(memory), 9, 64,
+                              stream) == cudaSuccess,
+          "runtime capture failed");
+  check_status(stream, CU_STREAM_CAPTURE_STATUS_ACTIVE);
+  cudaGraph_t runtime_graph = nullptr;
+  require(cudaStreamEndCapture(stream, &runtime_graph) == cudaSuccess &&
+              cudaGraphDestroy(runtime_graph) == cudaSuccess,
+          "runtime end capture failed");
+  check_status(stream, CU_STREAM_CAPTURE_STATUS_NONE);
+  require(cuStreamDestroy(stream) == CUDA_SUCCESS &&
+              cuStreamDestroy(idle) == CUDA_SUCCESS &&
+              cuMemFree(memory) == CUDA_SUCCESS,
+          "cleanup failed");
+  require(cuCtxSetCurrent(nullptr) == CUDA_SUCCESS &&
+              cuDevicePrimaryCtxRelease(device) == CUDA_SUCCESS,
+          "context cleanup failed");
+  std::puts("capture info preserves inactive, active, implicit, invalidated, "
+            "and cross-thread capture state");
+}


### PR DESCRIPTION
## Summary

Extend the existing `cuStreamIsCapturing` no-capture fast path to `cuStreamGetCaptureInfo*`. This is a driver-only optimization, independent of the CUDART-only changes in #743. No RPC-core or protocol changes.

The GPT benchmark's CUDA 13 runtime issues two capture-info queries per generated token. Main forwards every query synchronously even when this client has no capture underway. A full GPU-initialized benchmark with 500 training steps and both 120-token samples made **551 queries, spending 82.72 seconds waiting for their replies at 150 ms RTT**.

For a known remote stream, initialized/current context, and no admitted or active capture, return `CU_STREAM_CAPTURE_STATUS_NONE` locally. Optional metadata is only defined for active capture per [NVIDIA's API contract](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__STREAM.html). Unknown streams, missing contexts, active captures, and local-GPU routes keep their existing paths.

Also count admitted/in-flight `BeginCapture` calls, not only successful replies. Otherwise another thread could incorrectly return NONE after the server starts capture but before the initiating client thread receives the reply. Failed begins release their count, and successful/terminal-error ends retain the existing decrement behavior.

## Mirror the native versioned ABIs

The public symbols now have their exact native signatures: legacy `cuStreamGetCaptureInfo` has three arguments, `_v2` has six, and `_v3` has seven. `cuGetProcAddress*` selects the matching wrapper for CUDA API versions 10010, 11030, and 12030. This removes the mixed seven-argument legacy export and all writable-pointer guessing/reinterpretation (including the platform-specific pointer-probing helper). Internal serialization remains shared; public ABIs do not.

Explicit tests call every supported version both directly and through versioned lookup. The old mixed-wrapper implementation crashes on the new legacy/versioned-ABI test; native CUDA and the corrected wrappers pass.

## Measured result

RTX 4090 on `inferable-node-006`, PyTorch 2.13.0+cu130, native NVIDIA libcudart plus Lupine libcuda. Same GPU-initialized GPT script on both sides, all 500 training steps, original 120-token samples before and after training. Explicit phase-boundary synchronization is identical. `tc netem delay 150ms limit 100000` applies only to client-container egress (150 ms added RTT, no bandwidth cap, no drops).

| Phase | Main | This PR |
| --- | ---: | ---: |
| Import/device setup | 4.77 s | 4.56 s |
| GPU model initialization | 13.12 s | 2.64 s |
| First 120-token sample, including cold kernel loading | 57.79 s | 21.80 s |
| Optimizer construction | 0.80 s | 0.78 s |
| 500 training steps, including first-step loading and loss logs | 34.21 s | 34.19 s |
| Final 120-token sample | 36.67 s | 0.82 s |
| **Total through final synchronized sample** | **147.36 s** | **64.79 s** |

Capture-info RPC count falls from **551 to zero** in this full benchmark. The workload and sampling algorithm are unchanged; both runs finish with finite losses.

This is a long-standing missing fast path, not proof of a recent driver-only source regression. `cuStreamIsCapturing` was optimized in #399, but this separate entry point was not. Earlier matched driver-only comparisons also did not reproduce a slowdown relative to August 16. Different CUDA/PyTorch versions can expose different polling paths.

## Validation

- New CUDA regression test passes natively and through Lupine at 150 ms RTT. Covers repeated inactive v2/v3 queries, active capture metadata/dependencies, idle streams during another capture, implicit legacy-stream capture errors, cross-thread queries, invalid begin rollback, invalidated/end capture, and captures started/ended through CUDART.
- Driver-only and paired-runtime checks; C++14 compilation with CUDA 13.3.
- Three consecutive native-CUDART/driver-only mixed-API runs pass at 150 ms RTT with profiling disabled.
- All 12 CTest targets pass.
- Full benchmark described above passes.
- Changed-line clang-format and `git diff --check` pass.

Worktree: `/tmp/lupine-driver-capture-worktree`. Remote profiling/build artifacts: `/tmp/lupine-latency-followup-RRei2V`. Original user worktree changes are untouched.

### Separate profiling-only teardown issue

Enabling `LUPINE_RPC_STATS` on the native-CUDART mixed-API test exposes an existing shutdown crash, reproduced on unmodified main too. A signal-handler backtrace places it in `lupine_rpc_stats_record` called by `cuDevicePrimaryCtxRelease_v2` from native CUDART's `__cxa_finalize` teardown, consistent with the global statistics map already having been destroyed. Ordinary runs pass without the statistics option; paired-runtime profiling and the full PyTorch profiles also complete. This RPC-core lifetime issue is documented but intentionally not changed in this PR.
