### PR TITLE
Flush LZ4 blocks from the HTTP/2 write thread so a burst of RPCs shares one block

### DIFF
--- a/h2.cpp
+++ b/h2.cpp
@@ -785,9 +785,8 @@ int h2_start_encoder_locked(h2_stream &stream) {
 }
 
 // Only the blocks the input completes come out; the remainder waits inside
-// LZ4F for a flush. LZ4F_compressBound assumes a block already nearly full,
-// so it is consulted only when a block will complete; otherwise the update
-// needs just the frame end it reserves.
+// LZ4F until a flush. LZ4F_compressBound reserves a whole worst-case block
+// even for tiny input, and `encoded` keeps that capacity across bursts.
 int h2_encode_locked(h2_stream &stream, const unsigned char *data,
                      size_t input) {
   const LZ4F_preferences_t preferences = h2_lz4_preferences();
@@ -805,7 +804,8 @@ int h2_encode_locked(h2_stream &stream, const unsigned char *data,
   return 0;
 }
 
-// Emits the block LZ4F is holding, or the frame end.
+// Emits the block LZ4F is holding (nothing when it holds none), or the frame
+// end.
 int h2_encode_terminal_locked(h2_stream &stream, bool finish) {
   size_t capacity = stream.buffered + 16;
   unsigned char *destination = h2_reserve_encoded(stream, capacity);
@@ -850,11 +850,10 @@ int h2_pump_stream_locked(h2_transport *transport, int32_t stream_id,
 }
 
 // Compresses the cursors in order. Whole blocks reach nghttp2 here; the tail
-// short of a block stays with the encoder for the write thread to flush,
-// unless the message is awaited: then nothing is gained by deferring, and the
-// flush would only drag the encoder and framing state onto the other core.
+// short of a block stays with the encoder for the write thread to flush, so
+// every message queued while one send is in flight shares a block.
 int h2_write_stream_locked(h2_transport *transport, int32_t stream_id,
-                           std::vector<rpc_write_cursor> &cursors, bool flush) {
+                           std::vector<rpc_write_cursor> &cursors) {
   h2_stream &stream = h2_get_stream(transport, stream_id);
   if (stream.closed || stream.encoder_finished ||
       (!stream.encoder_started && h2_start_encoder_locked(stream) < 0)) {
@@ -904,15 +903,6 @@ int h2_write_stream_locked(h2_transport *transport, int32_t stream_id,
         return -1;
       }
     }
-  }
-  if (stream.buffered == 0) {
-    return 0;
-  }
-  if (flush) {
-    return h2_encode_terminal_locked(stream, false) < 0 ||
-                   h2_pump_stream_locked(transport, stream_id, stream) < 0
-               ? -1
-               : 0;
   }
   if (!stream.flush_queued) {
     transport->flush_pending.push_back(stream_id);
@@ -1328,7 +1318,7 @@ int rpc_http2_read(conn_t *conn, void *data, size_t size) {
 }
 
 int rpc_http2_write_stream(conn_t *conn, int32_t stream_id,
-                           std::vector<rpc_write_cursor> &cursors, bool flush) {
+                           std::vector<rpc_write_cursor> &cursors) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
   if (std::all_of(
           cursors.begin(), cursors.end(),
@@ -1337,7 +1327,7 @@ int rpc_http2_write_stream(conn_t *conn, int32_t stream_id,
   }
 
   pthread_mutex_lock(&transport->session_mutex);
-  int result = h2_write_stream_locked(transport, stream_id, cursors, flush);
+  int result = h2_write_stream_locked(transport, stream_id, cursors);
   pthread_mutex_unlock(&transport->session_mutex);
   // Signalled after the unlock so the write thread never wakes into a mutex
   // its producer still holds.
@@ -1348,8 +1338,7 @@ int rpc_http2_write_stream(conn_t *conn, int32_t stream_id,
 
 int rpc_http2_write(conn_t *conn, std::vector<rpc_write_cursor> &cursors) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
-  return rpc_http2_write_stream(conn, transport->dispatch_stream_id, cursors,
-                                false);
+  return rpc_http2_write_stream(conn, transport->dispatch_stream_id, cursors);
 }
 
 int32_t rpc_http2_dispatch_stream(conn_t *conn) {
@@ -1421,12 +1410,18 @@ int h2_end_stream_locked(h2_transport *transport, int32_t stream_id) {
 
 } // namespace
 
+// Emits the encoder tails on the caller instead of the write thread: for a
+// message the caller is about to wait on, nothing is gained by deferring, and
+// the flush would only drag the encoder and framing state onto the other core.
 int rpc_http2_flush(conn_t *conn) {
   if (conn == nullptr || conn->http2 == nullptr) {
     return -1;
   }
   auto *transport = static_cast<h2_transport *>(conn->http2);
   pthread_mutex_lock(&transport->session_mutex);
+  if (h2_flush_pending_locked(transport) < 0) {
+    transport->write_failed = true;
+  }
   h2_drain_output_locked(transport);
   int result = transport->write_failed ? -1 : 0;
   pthread_mutex_unlock(&transport->session_mutex);

--- a/h2.cpp
+++ b/h2.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <climits>
 #include <deque>
@@ -34,14 +35,22 @@ constexpr uint32_t kH2ServerWindow =
 constexpr uint64_t kH2MaxHeldBytes = LUPINE_FF_STAGING_WINDOW_BYTES / 2;
 constexpr uint32_t kH2MaxFrame = (16 * 1024 * 1024) - 1;
 constexpr size_t kH2FrameHeaderLen = 9;
-constexpr size_t kH2EncodeChunkBytes = 4 * 1024 * 1024;
-constexpr size_t kH2ProviderMinFrameBytes = 16 * 1024;
-constexpr size_t kH2ProviderMaxFrameBytes = 1024 * 1024;
+// LZ4F_max4MB, the encoder's block size. Input short of a block stays inside
+// LZ4F until a flush, and each compression step feeds exactly one block so a
+// very compressible body cannot delay its first byte until all of it has been
+// compressed.
+constexpr size_t kH2Lz4BlockBytes = 4 * 1024 * 1024;
+constexpr size_t kH2MaxDataFrameBytes = 1024 * 1024;
 constexpr size_t kH2DecodeBufferBytes = 64 * 1024;
 // Retained capacity for drained staging buffers, a few frames' worth.
 constexpr size_t kH2StagingPoolBytes = 4 * 1024 * 1024;
 // Output nghttp2 may produce ahead of the socket before request writers block.
 constexpr size_t kH2OutboundLimitBytes = 8 * 1024 * 1024;
+// How long the client write thread polls for more output before it parks.
+// Parked, every message costs its producer a futex wake and the two then
+// contend for session_mutex; polling covers the gap between back-to-back RPCs.
+// The server hosts one write thread per connection and does not poll.
+constexpr auto kH2WriterPoll = std::chrono::microseconds(200);
 constexpr std::array<uint8_t, 8> kH2ShutdownPing = {'l', 'u', 'p', 'i',
                                                     'n', 'e', 0,   1};
 // Linux restarts slow start after an idle period of one retransmission
@@ -67,7 +76,18 @@ struct h2_stream {
   bool encoder_started = false;
   bool encoder_finished = false;
   bool decoder_finished = false;
-  size_t provider_frame_bytes = kH2ProviderMinFrameBytes;
+  // One DATA item carries the stream's whole body. It defers whenever
+  // `encoded` runs dry and is resumed when more output lands.
+  bool provider_submitted = false;
+  bool provider_deferred = false;
+  bool flush_queued = false;
+  // Input LZ4F holds back for its next block; only a flush emits it.
+  size_t buffered = 0;
+  // Compressed output nghttp2 has not framed yet: valid up to encoded_size,
+  // consumed up to encoded_offset. Capacity is retained across bursts.
+  std::vector<unsigned char> encoded;
+  size_t encoded_size = 0;
+  size_t encoded_offset = 0;
   LZ4F_compressionContext_t encoder = nullptr;
   LZ4F_decompressionContext_t decoder = nullptr;
   int response_status = 0;
@@ -98,14 +118,17 @@ struct h2_transport {
   // far more than it will ever need again.
   std::vector<h2_buffer> buffer_pool;
   size_t buffer_pool_bytes = 0;
-  // LZ4F_compressBound includes a full worst-case block even for tiny input.
-  // Writes are serialized, so retain one connection-wide workspace and track
-  // its valid prefix separately instead of resizing/zeroing it per RPC.
-  std::vector<unsigned char> encoder_output;
   // Wire bytes nghttp2 has produced that the socket has not taken yet. Only
   // the write thread sends, so a producer never blocks in the socket and
   // everything queued while one send is in flight leaves in the next one.
   std::vector<unsigned char> outbound;
+  // Streams whose encoder holds input short of a block. The write thread
+  // flushes them before each send, so every message queued while one send is
+  // in flight shares a block instead of paying a block and a flush each.
+  std::vector<int32_t> flush_pending;
+  // Bumped whenever outbound or flush_pending grows, so the write thread can
+  // poll for work without touching session_mutex.
+  std::atomic<uint64_t> output_generation{0};
   pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_cond_t session_progress = PTHREAD_COND_INITIALIZER;
   pthread_cond_t heartbeat_progress = PTHREAD_COND_INITIALIZER;
@@ -161,19 +184,6 @@ void h2_release_codecs(h2_stream &stream) {
   }
 }
 
-struct h2_write_source {
-  std::vector<rpc_write_cursor> *cursors = nullptr;
-  rpc_write_cursor *refill_cursor = nullptr;
-  size_t index = 0;
-  uint64_t progress = 0;
-  std::vector<unsigned char> pending;
-  size_t pending_size = 0;
-  size_t pending_offset = 0;
-  bool terminal_generated = false;
-  bool finish_stream = false;
-  bool complete = false;
-};
-
 void receive_bytes(h2_transport *transport, int32_t stream_id,
                    const unsigned char *data, size_t len) {
   if (len == 0) {
@@ -216,6 +226,7 @@ void h2_queue_output(h2_transport *transport, const struct iovec *iov,
     transport->outbound.insert(transport->outbound.end(), data,
                                data + iov[i].iov_len);
   }
+  transport->output_generation.fetch_add(1, std::memory_order_release);
   pthread_cond_broadcast(&transport->outbound_progress);
 }
 
@@ -256,40 +267,6 @@ int h2_write_socket(h2_transport *transport, const unsigned char *data,
   return 0;
 }
 
-void *h2_write_main(void *arg) {
-  auto *transport = static_cast<h2_transport *>(arg);
-  std::vector<unsigned char> chunk;
-  pthread_mutex_lock(&transport->session_mutex);
-  // transport_failed alone does not stop the drain: a rejected handshake
-  // sets it while the GOAWAY and shutdown PING are still queued.
-  for (;;) {
-    while (transport->outbound.empty() && !transport->write_stop) {
-      pthread_cond_wait(&transport->outbound_progress,
-                        &transport->session_mutex);
-    }
-    if (transport->write_stop) {
-      break;
-    }
-    chunk.clear();
-    chunk.swap(transport->outbound);
-    transport->write_busy = true;
-    pthread_mutex_unlock(&transport->session_mutex);
-    int result = h2_write_socket(transport, chunk.data(), chunk.size());
-    pthread_mutex_lock(&transport->session_mutex);
-    transport->write_busy = false;
-    if (result < 0) {
-      transport->write_failed = true;
-      transport->transport_failed = true;
-      pthread_cond_broadcast(&transport->session_progress);
-      break;
-    }
-    pthread_cond_broadcast(&transport->outbound_progress);
-  }
-  pthread_cond_broadcast(&transport->outbound_progress);
-  pthread_mutex_unlock(&transport->session_mutex);
-  return nullptr;
-}
-
 ssize_t h2_send_callback(nghttp2_session *, const uint8_t *data, size_t length,
                          int, void *user_data) {
   auto *transport = static_cast<h2_transport *>(user_data);
@@ -306,161 +283,30 @@ LZ4F_preferences_t h2_lz4_preferences() {
   return preferences;
 }
 
-void h2_update_provider_frame_size(h2_stream &stream, size_t encoded) {
-  if (encoded != 0) {
-    // Match nghttp2's next provider buffer to actual compressed output: large
-    // blocks amortize DATA framing, while high-ratio blocks avoid repeatedly
-    // reserving a mostly empty maximum-size buffer.
-    stream.provider_frame_bytes =
-        std::clamp(encoded, kH2ProviderMinFrameBytes, kH2ProviderMaxFrameBytes);
-  }
-}
-
-unsigned char *h2_append_pending(h2_write_source &source, size_t capacity) {
-  size_t required = source.pending_size + capacity;
-  if (source.pending.size() < required) {
-    source.pending.resize(required);
-  }
-  return source.pending.data() + source.pending_size;
-}
-
-void h2_commit_pending(h2_write_source &source, size_t produced) {
-  source.pending_size += produced;
-}
-
 ssize_t h2_data_source_read_callback(nghttp2_session *, int32_t stream_id,
                                      uint8_t *, size_t length,
                                      uint32_t *data_flags,
-                                     nghttp2_data_source *source,
-                                     void *user_data) {
+                                     nghttp2_data_source *, void *user_data) {
   auto *transport = static_cast<h2_transport *>(user_data);
-  auto *write_source = static_cast<h2_write_source *>(source->ptr);
   h2_stream &stream = h2_get_stream(transport, stream_id);
-  if (length == 0 || write_source->complete || stream.encoder_finished) {
-    return NGHTTP2_ERR_CALLBACK_FAILURE;
+  size_t available = stream.encoded_size - stream.encoded_offset;
+  if (available == 0) {
+    stream.provider_deferred = true;
+    return NGHTTP2_ERR_DEFERRED;
   }
-
-  const LZ4F_preferences_t preferences = h2_lz4_preferences();
-  size_t input_budget = kH2EncodeChunkBytes;
-  while (write_source->pending_size < length && !write_source->complete) {
-
-    if (!stream.encoder_started) {
-      if (LZ4F_isError(
-              LZ4F_createCompressionContext(&stream.encoder, LZ4F_VERSION))) {
-        return NGHTTP2_ERR_CALLBACK_FAILURE;
-      }
-      size_t capacity = LZ4F_HEADER_SIZE_MAX;
-      unsigned char *destination = h2_append_pending(*write_source, capacity);
-      size_t header = LZ4F_compressBegin(stream.encoder, destination, capacity,
-                                         &preferences);
-      if (LZ4F_isError(header)) {
-        return NGHTTP2_ERR_CALLBACK_FAILURE;
-      }
-      h2_commit_pending(*write_source, header);
-      stream.encoder_started = true;
-      continue;
-    }
-
-    rpc_write_cursor *cursor = nullptr;
-    if (write_source->cursors != nullptr) {
-      auto &cursors = *write_source->cursors;
-      while (write_source->index < cursors.size()) {
-        auto &candidate = cursors[write_source->index];
-        if (candidate.remaining() != 0) {
-          cursor = &candidate;
-          break;
-        }
-        if (candidate.refill != nullptr) {
-          write_source->refill_cursor = &candidate;
-          return NGHTTP2_ERR_DEFERRED;
-        }
-        ++write_source->index;
-      }
-    }
-
-    if (cursor == nullptr) {
-      if (!write_source->terminal_generated) {
-        size_t capacity = LZ4F_compressBound(0, &preferences);
-        unsigned char *destination = h2_append_pending(*write_source, capacity);
-        size_t terminal;
-        if (write_source->finish_stream) {
-          terminal =
-              LZ4F_compressEnd(stream.encoder, destination, capacity, nullptr);
-        } else {
-          terminal = LZ4F_flush(stream.encoder, destination, capacity, nullptr);
-        }
-        if (LZ4F_isError(terminal)) {
-          return NGHTTP2_ERR_CALLBACK_FAILURE;
-        }
-        h2_update_provider_frame_size(stream, terminal);
-        h2_commit_pending(*write_source, terminal);
-        write_source->terminal_generated = true;
-        continue;
-      }
-      if (write_source->finish_stream) {
-        stream.encoder_finished = true;
-        *data_flags |= NGHTTP2_DATA_FLAG_EOF;
-      } else {
-        *data_flags |= NGHTTP2_DATA_FLAG_EOF | NGHTTP2_DATA_FLAG_NO_END_STREAM;
-      }
-      write_source->complete = true;
-      break;
-    }
-
-    // Bound work by logical input as well as encoded output. Otherwise a very
-    // compressible body can consume gigabytes while trying to fill one large
-    // HTTP/2 DATA frame, delaying the first byte until the entire body has
-    // been compressed.
-    if (input_budget == 0) {
-      break;
-    }
-
-    size_t input = std::min(cursor->size, input_budget);
-    size_t capacity = LZ4F_compressBound(input, &preferences);
-    unsigned char *destination = h2_append_pending(*write_source, capacity);
-    size_t encoded = LZ4F_compressUpdate(stream.encoder, destination, capacity,
-                                         cursor->data, input, nullptr);
-    if (LZ4F_isError(encoded)) {
-      return NGHTTP2_ERR_CALLBACK_FAILURE;
-    }
-    h2_update_provider_frame_size(stream, encoded);
-    h2_commit_pending(*write_source, encoded);
-    cursor->data += input;
-    cursor->size -= input;
-    input_budget -= input;
-    write_source->progress += input;
-    if (cursor->size == 0 && cursor->refill == nullptr) {
-      ++write_source->index;
-    }
-  }
-
-  size_t available = write_source->pending_size - write_source->pending_offset;
   size_t produced = std::min(available, length);
-  if (produced == 0) {
-    return write_source->complete ? 0 : NGHTTP2_ERR_CALLBACK_FAILURE;
-  }
   *data_flags |= NGHTTP2_DATA_FLAG_NO_COPY;
-  if (produced == available && write_source->terminal_generated) {
-    if (write_source->finish_stream) {
-      stream.encoder_finished = true;
-      *data_flags |= NGHTTP2_DATA_FLAG_EOF;
-    } else {
-      *data_flags |= NGHTTP2_DATA_FLAG_EOF | NGHTTP2_DATA_FLAG_NO_END_STREAM;
-    }
-    write_source->complete = true;
+  if (produced == available && stream.encoder_finished) {
+    *data_flags |= NGHTTP2_DATA_FLAG_EOF;
   }
   return static_cast<ssize_t>(produced);
 }
 
 int h2_send_data_callback(nghttp2_session *, nghttp2_frame *frame,
                           const uint8_t *framehd, size_t length,
-                          nghttp2_data_source *source, void *user_data) {
+                          nghttp2_data_source *, void *user_data) {
   auto *transport = static_cast<h2_transport *>(user_data);
-  auto *write_source = static_cast<h2_write_source *>(source->ptr);
-  size_t available = write_source->pending_size - write_source->pending_offset;
-  if (length > available) {
-    return NGHTTP2_ERR_CALLBACK_FAILURE;
-  }
+  h2_stream &stream = h2_get_stream(transport, frame->hd.stream_id);
 
   std::array<struct iovec, 4> iov = {};
   int iov_count = 0;
@@ -471,8 +317,7 @@ int h2_send_data_callback(nghttp2_session *, nghttp2_frame *frame,
     padlen = static_cast<unsigned char>(frame->data.padlen - 1);
     iov[iov_count++] = {&padlen, 1};
   }
-  iov[iov_count++] = {
-      write_source->pending.data() + write_source->pending_offset, length};
+  iov[iov_count++] = {stream.encoded.data() + stream.encoded_offset, length};
 
   unsigned char padding[256] = {};
   if (frame->data.padlen > 1) {
@@ -480,11 +325,10 @@ int h2_send_data_callback(nghttp2_session *, nghttp2_frame *frame,
   }
   h2_queue_output(transport, iov.data(), iov_count);
 
-  write_source->pending_offset += length;
-  write_source->progress += length;
-  if (write_source->pending_offset == write_source->pending_size) {
-    write_source->pending_size = 0;
-    write_source->pending_offset = 0;
+  stream.encoded_offset += length;
+  if (stream.encoded_offset == stream.encoded_size) {
+    stream.encoded_size = 0;
+    stream.encoded_offset = 0;
   }
   return 0;
 }
@@ -501,9 +345,10 @@ ssize_t h2_data_source_read_length_callback(nghttp2_session *, uint8_t,
   if (window <= 0) {
     return NGHTTP2_ERR_CALLBACK_FAILURE;
   }
-  size_t max_len = std::min<size_t>(kH2MaxFrame, remote_max_frame_size);
-  max_len = std::min(max_len,
-                     h2_get_stream(transport, stream_id).provider_frame_bytes);
+  h2_stream &stream = h2_get_stream(transport, stream_id);
+  size_t max_len =
+      std::min<size_t>(kH2MaxDataFrameBytes, remote_max_frame_size);
+  max_len = std::min(max_len, stream.encoded_size - stream.encoded_offset);
   max_len = std::min<size_t>(max_len, static_cast<size_t>(window));
   return static_cast<ssize_t>(std::max<size_t>(1, max_len));
 }
@@ -914,66 +759,238 @@ int h2_flush_session_locked(h2_transport *transport) {
   return result == 0 ? 0 : -1;
 }
 
-int h2_send_source_locked(h2_transport *transport, int32_t stream_id,
-                          h2_write_source *source) {
-  source->pending.swap(transport->encoder_output);
-  nghttp2_data_provider provider = {};
-  provider.source.ptr = source;
-  provider.read_callback = h2_data_source_read_callback;
-  int result = nghttp2_submit_data(transport->session, NGHTTP2_FLAG_NONE,
-                                   stream_id, &provider);
-  // nghttp2 retains provider.source.ptr until the provider reaches EOF. Keep
-  // the stack-backed source alive while flow control pauses the stream, and
-  // release the mutex while the read thread applies WINDOW_UPDATE frames.
-  while (result == 0 && !source->complete) {
-    while (transport->outbound.size() > kH2OutboundLimitBytes &&
-           !transport->write_failed) {
-      pthread_cond_wait(&transport->outbound_progress,
-                        &transport->session_mutex);
+unsigned char *h2_reserve_encoded(h2_stream &stream, size_t capacity) {
+  size_t required = stream.encoded_size + capacity;
+  if (stream.encoded.size() < required) {
+    stream.encoded.resize(required);
+  }
+  return stream.encoded.data() + stream.encoded_size;
+}
+
+int h2_start_encoder_locked(h2_stream &stream) {
+  if (LZ4F_isError(
+          LZ4F_createCompressionContext(&stream.encoder, LZ4F_VERSION))) {
+    return -1;
+  }
+  const LZ4F_preferences_t preferences = h2_lz4_preferences();
+  unsigned char *destination = h2_reserve_encoded(stream, LZ4F_HEADER_SIZE_MAX);
+  size_t header = LZ4F_compressBegin(stream.encoder, destination,
+                                     LZ4F_HEADER_SIZE_MAX, &preferences);
+  if (LZ4F_isError(header)) {
+    return -1;
+  }
+  stream.encoded_size += header;
+  stream.encoder_started = true;
+  return 0;
+}
+
+// Only the blocks the input completes come out; the remainder waits inside
+// LZ4F for a flush. LZ4F_compressBound assumes a block already nearly full,
+// so it is consulted only when a block will complete; otherwise the update
+// needs just the frame end it reserves.
+int h2_encode_locked(h2_stream &stream, const unsigned char *data,
+                     size_t input) {
+  const LZ4F_preferences_t preferences = h2_lz4_preferences();
+  size_t capacity = stream.buffered + input < kH2Lz4BlockBytes
+                        ? 8
+                        : LZ4F_compressBound(input, &preferences);
+  unsigned char *destination = h2_reserve_encoded(stream, capacity);
+  size_t encoded = LZ4F_compressUpdate(stream.encoder, destination, capacity,
+                                       data, input, nullptr);
+  if (LZ4F_isError(encoded)) {
+    return -1;
+  }
+  stream.encoded_size += encoded;
+  stream.buffered = (stream.buffered + input) % kH2Lz4BlockBytes;
+  return 0;
+}
+
+// Emits the block LZ4F is holding, or the frame end.
+int h2_encode_terminal_locked(h2_stream &stream, bool finish) {
+  size_t capacity = stream.buffered + 16;
+  unsigned char *destination = h2_reserve_encoded(stream, capacity);
+  size_t terminal =
+      finish ? LZ4F_compressEnd(stream.encoder, destination, capacity, nullptr)
+             : LZ4F_flush(stream.encoder, destination, capacity, nullptr);
+  if (LZ4F_isError(terminal)) {
+    return -1;
+  }
+  stream.encoded_size += terminal;
+  stream.buffered = 0;
+  if (finish) {
+    stream.encoder_finished = true;
+  }
+  return 0;
+}
+
+// Hands the stream's encoded bytes to nghttp2. The stream's DATA item is
+// submitted on first use and resumed from its deferral after that; whatever
+// the peer's window does not cover stays encoded until the read thread pumps
+// the session after the next WINDOW_UPDATE.
+int h2_pump_stream_locked(h2_transport *transport, int32_t stream_id,
+                          h2_stream &stream) {
+  if (stream.encoded_offset == stream.encoded_size) {
+    return 0;
+  }
+  if (!stream.provider_submitted) {
+    nghttp2_data_provider provider = {};
+    provider.read_callback = h2_data_source_read_callback;
+    if (nghttp2_submit_data(transport->session, NGHTTP2_FLAG_NONE, stream_id,
+                            &provider) != 0) {
+      return -1;
     }
-    uint64_t progress = source->progress;
-    if (h2_flush_session_locked(transport) < 0) {
-      result = -1;
-      break;
+    stream.provider_submitted = true;
+  } else if (stream.provider_deferred) {
+    if (nghttp2_session_resume_data(transport->session, stream_id) != 0) {
+      return -1;
     }
-    if (source->complete) {
-      break;
-    }
-    if (transport->transport_failed) {
-      result = -1;
-      break;
-    }
-    if (source->refill_cursor != nullptr) {
-      rpc_write_cursor *cursor = source->refill_cursor;
-      pthread_mutex_unlock(&transport->session_mutex);
-      int refill = cursor->refill(cursor->refill_context, cursor);
-      pthread_mutex_lock(&transport->session_mutex);
-      source->refill_cursor = nullptr;
-      if (transport->transport_failed || refill < 0 ||
-          (refill == 0 && cursor->remaining() != 0) ||
-          (refill > 0 &&
-           (cursor->data == nullptr || cursor->remaining() == 0))) {
-        result = -1;
-        break;
+    stream.provider_deferred = false;
+  }
+  return h2_flush_session_locked(transport);
+}
+
+// Compresses the cursors in order. Whole blocks reach nghttp2 here; the tail
+// short of a block stays with the encoder for the write thread to flush,
+// unless the message is awaited: then nothing is gained by deferring, and the
+// flush would only drag the encoder and framing state onto the other core.
+int h2_write_stream_locked(h2_transport *transport, int32_t stream_id,
+                           std::vector<rpc_write_cursor> &cursors, bool flush) {
+  h2_stream &stream = h2_get_stream(transport, stream_id);
+  if (stream.closed || stream.encoder_finished ||
+      (!stream.encoder_started && h2_start_encoder_locked(stream) < 0)) {
+    return -1;
+  }
+  for (rpc_write_cursor &cursor : cursors) {
+    for (;;) {
+      if (cursor.size == 0) {
+        if (cursor.refill == nullptr) {
+          break;
+        }
+        pthread_mutex_unlock(&transport->session_mutex);
+        int refill = cursor.refill(cursor.refill_context, &cursor);
+        pthread_mutex_lock(&transport->session_mutex);
+        if (transport->transport_failed || stream.closed || refill < 0 ||
+            (refill == 0 && cursor.remaining() != 0) ||
+            (refill > 0 &&
+             (cursor.data == nullptr || cursor.remaining() == 0))) {
+          return -1;
+        }
+        if (refill == 0) {
+          cursor.refill = nullptr;
+        }
+        continue;
       }
-      if (refill == 0) {
-        cursor->refill = nullptr;
+      size_t input = std::min(cursor.size, kH2Lz4BlockBytes);
+      size_t encoded_before = stream.encoded_size;
+      if (h2_encode_locked(stream, cursor.data, input) < 0 ||
+          (stream.encoded_size != encoded_before &&
+           h2_pump_stream_locked(transport, stream_id, stream) < 0)) {
+        return -1;
       }
-      if (nghttp2_session_resume_data(transport->session, stream_id) != 0) {
-        result = -1;
-        break;
-      }
-      continue;
-    }
-    if (source->progress == progress &&
+      cursor.data += input;
+      cursor.size -= input;
+      while (!transport->transport_failed && !stream.closed &&
+             stream.encoded_size - stream.encoded_offset >
+                 kH2OutboundLimitBytes) {
         pthread_cond_wait(&transport->session_progress,
-                          &transport->session_mutex) != 0) {
-      result = -1;
-      break;
+                          &transport->session_mutex);
+      }
+      while (!transport->write_failed &&
+             transport->outbound.size() > kH2OutboundLimitBytes) {
+        pthread_cond_wait(&transport->outbound_progress,
+                          &transport->session_mutex);
+      }
+      if (transport->transport_failed || stream.closed) {
+        return -1;
+      }
     }
   }
-  source->pending.swap(transport->encoder_output);
-  return result == 0 ? 0 : -1;
+  if (stream.buffered == 0) {
+    return 0;
+  }
+  if (flush) {
+    return h2_encode_terminal_locked(stream, false) < 0 ||
+                   h2_pump_stream_locked(transport, stream_id, stream) < 0
+               ? -1
+               : 0;
+  }
+  if (!stream.flush_queued) {
+    transport->flush_pending.push_back(stream_id);
+    stream.flush_queued = true;
+  }
+  return 0;
+}
+
+int h2_flush_pending_locked(h2_transport *transport) {
+  int result = 0;
+  for (int32_t stream_id : transport->flush_pending) {
+    h2_stream &stream = h2_get_stream(transport, stream_id);
+    stream.flush_queued = false;
+    if (stream.closed || stream.encoder_finished) {
+      continue;
+    }
+    if (h2_encode_terminal_locked(stream, false) < 0 ||
+        h2_pump_stream_locked(transport, stream_id, stream) < 0) {
+      result = -1;
+    }
+  }
+  transport->flush_pending.clear();
+  return result;
+}
+
+void h2_await_output_locked(h2_transport *transport) {
+  if (!transport->server) {
+    uint64_t seen =
+        transport->output_generation.load(std::memory_order_relaxed);
+    pthread_mutex_unlock(&transport->session_mutex);
+    auto deadline = std::chrono::steady_clock::now() + kH2WriterPoll;
+    while (transport->output_generation.load(std::memory_order_acquire) ==
+               seen &&
+           std::chrono::steady_clock::now() < deadline) {
+    }
+    pthread_mutex_lock(&transport->session_mutex);
+  }
+  if (transport->outbound.empty() && transport->flush_pending.empty() &&
+      !transport->write_stop) {
+    pthread_cond_wait(&transport->outbound_progress, &transport->session_mutex);
+  }
+}
+
+void *h2_write_main(void *arg) {
+  auto *transport = static_cast<h2_transport *>(arg);
+  std::vector<unsigned char> chunk;
+  pthread_mutex_lock(&transport->session_mutex);
+  // transport_failed alone does not stop the drain: a rejected handshake
+  // sets it while the GOAWAY and shutdown PING are still queued.
+  for (;;) {
+    while (transport->outbound.empty() && transport->flush_pending.empty() &&
+           !transport->write_stop) {
+      h2_await_output_locked(transport);
+    }
+    if (transport->write_stop) {
+      break;
+    }
+    int result = h2_flush_pending_locked(transport);
+    if (result == 0 && !transport->outbound.empty()) {
+      chunk.clear();
+      chunk.swap(transport->outbound);
+      transport->write_busy = true;
+      pthread_mutex_unlock(&transport->session_mutex);
+      result = h2_write_socket(transport, chunk.data(), chunk.size());
+      pthread_mutex_lock(&transport->session_mutex);
+      transport->write_busy = false;
+    }
+    if (result < 0) {
+      transport->write_failed = true;
+      transport->transport_failed = true;
+      pthread_cond_broadcast(&transport->session_progress);
+      break;
+    }
+    pthread_cond_broadcast(&transport->outbound_progress);
+  }
+  pthread_cond_broadcast(&transport->outbound_progress);
+  pthread_mutex_unlock(&transport->session_mutex);
+  return nullptr;
 }
 
 void *h2_heartbeat_main(void *arg) {
@@ -1120,10 +1137,10 @@ int32_t h2_submit_client_handshake(h2_transport *transport, conn_t *conn,
 }
 
 void h2_drain_output_locked(h2_transport *transport) {
-  while ((!transport->outbound.empty() || transport->write_busy) &&
+  while ((!transport->outbound.empty() || !transport->flush_pending.empty() ||
+          transport->write_busy) &&
          !transport->write_failed) {
-    pthread_cond_wait(&transport->outbound_progress,
-                      &transport->session_mutex);
+    pthread_cond_wait(&transport->outbound_progress, &transport->session_mutex);
   }
 }
 
@@ -1311,7 +1328,7 @@ int rpc_http2_read(conn_t *conn, void *data, size_t size) {
 }
 
 int rpc_http2_write_stream(conn_t *conn, int32_t stream_id,
-                           std::vector<rpc_write_cursor> &cursors) {
+                           std::vector<rpc_write_cursor> &cursors, bool flush) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
   if (std::all_of(
           cursors.begin(), cursors.end(),
@@ -1319,17 +1336,20 @@ int rpc_http2_write_stream(conn_t *conn, int32_t stream_id,
     return 0;
   }
 
-  h2_write_source source;
-  source.cursors = &cursors;
   pthread_mutex_lock(&transport->session_mutex);
-  int result = h2_send_source_locked(transport, stream_id, &source);
+  int result = h2_write_stream_locked(transport, stream_id, cursors, flush);
   pthread_mutex_unlock(&transport->session_mutex);
+  // Signalled after the unlock so the write thread never wakes into a mutex
+  // its producer still holds.
+  transport->output_generation.fetch_add(1, std::memory_order_release);
+  pthread_cond_broadcast(&transport->outbound_progress);
   return result;
 }
 
 int rpc_http2_write(conn_t *conn, std::vector<rpc_write_cursor> &cursors) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
-  return rpc_http2_write_stream(conn, transport->dispatch_stream_id, cursors);
+  return rpc_http2_write_stream(conn, transport->dispatch_stream_id, cursors,
+                                false);
 }
 
 int32_t rpc_http2_dispatch_stream(conn_t *conn) {
@@ -1390,9 +1410,13 @@ int32_t rpc_http2_lane_stream(conn_t *conn, uint64_t lane_id) {
 namespace {
 
 int h2_end_stream_locked(h2_transport *transport, int32_t stream_id) {
-  h2_write_source source;
-  source.finish_stream = true;
-  return h2_send_source_locked(transport, stream_id, &source);
+  h2_stream &stream = h2_get_stream(transport, stream_id);
+  if (stream.closed || stream.encoder_finished ||
+      (!stream.encoder_started && h2_start_encoder_locked(stream) < 0) ||
+      h2_encode_terminal_locked(stream, true) < 0) {
+    return -1;
+  }
+  return h2_pump_stream_locked(transport, stream_id, stream);
 }
 
 } // namespace

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -130,7 +130,7 @@ int write_bytes(conn_t *conn, const void *data, size_t size) {
 int write_stream_bytes(conn_t *conn, int32_t stream_id, const void *data,
                        size_t size) {
   std::vector<rpc_write_cursor> cursors = {rpc_write_cursor(data, size)};
-  return rpc_http2_write_stream(conn, stream_id, cursors, false);
+  return rpc_http2_write_stream(conn, stream_id, cursors);
 }
 
 std::string read_string(conn_t *conn, size_t size) {

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -130,7 +130,7 @@ int write_bytes(conn_t *conn, const void *data, size_t size) {
 int write_stream_bytes(conn_t *conn, int32_t stream_id, const void *data,
                        size_t size) {
   std::vector<rpc_write_cursor> cursors = {rpc_write_cursor(data, size)};
-  return rpc_http2_write_stream(conn, stream_id, cursors);
+  return rpc_http2_write_stream(conn, stream_id, cursors, false);
 }
 
 std::string read_string(conn_t *conn, size_t size) {
@@ -322,7 +322,7 @@ void test_data_provider_frame_sizing() {
   });
   size_t max_data_frame_size = 0;
   int data_frame_count = 0;
-  for (int frame_count = 0; frame_count < 8 && data_frame_count < 2;
+  for (int frame_count = 0; frame_count < 8 && data_frame_count < 1;
        ++frame_count) {
     std::array<unsigned char, 9> header = {};
     require(raw_read_frame(pair.server.connfd, &header),
@@ -1274,8 +1274,8 @@ void test_reset_wakes_flow_controlled_writer() {
   h2_pair pair;
   init_raw_server_peer(&pair);
 
-  // Shrink the peer's stream window so the writer pauses after 64 KiB rather
-  // than requiring another multi-gigabyte test payload.
+  // Shrink the peer's stream window so the writer pauses once 8 MiB of output
+  // sit behind it, rather than requiring a multi-gigabyte test payload.
   std::array<unsigned char, 15> settings = {};
   settings[2] = 6;
   settings[3] = NGHTTP2_SETTINGS;
@@ -1326,7 +1326,7 @@ void test_reset_wakes_flow_controlled_writer() {
     }
   });
 
-  std::string payload(128 * 1024, '\0');
+  std::string payload(12 * 1024 * 1024, '\0');
   uint32_t seed = 29;
   for (char &byte : payload) {
     seed = seed * 1664525u + 1013904223u;

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -488,6 +488,7 @@ struct rpc_thread_io {
   conn_t *response_conn = nullptr;
   rpc_response_route response;
   conn_t *held_call_lock = nullptr;
+  bool await_response = false;
 };
 
 static thread_local rpc_thread_io rpc_tls_io;
@@ -807,6 +808,7 @@ int rpc_wait_for_response(conn_t *conn) {
   int op = conn->write_op;
   uint64_t start =
       lupine_rpc_stats_path() != nullptr ? lupine_rpc_stats_now_ns() : 0;
+  rpc_tls_io.await_response = true;
   int write_id = rpc_write_end(conn);
   if (write_id < 0) {
     return -1;
@@ -1021,11 +1023,14 @@ int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
 // the request lock is released after the request is sent and the function
 // returns the request id which can be used to wait for a response.
 int rpc_write_end(conn_t *conn) {
+  bool awaited = rpc_tls_io.await_response;
+  rpc_tls_io.await_response = false;
   if (conn == nullptr || rpc_tls_io.write_conn != conn) {
     return -1;
   }
   bool request = conn->write_op != -1;
   bool request_nested_in_response = rpc_tls_io.nested_write.conn == conn;
+  awaited = awaited || !request;
   if (conn->closed) {
     rpc_release_write_builder(conn, request_nested_in_response);
     if (request) {
@@ -1041,7 +1046,8 @@ int rpc_write_end(conn_t *conn) {
         rpc_write_cursor(&conn->write_id, sizeof(conn->write_id));
     conn->write_queue[1] =
         rpc_write_cursor(&conn->write_op, sizeof(conn->write_op));
-    result = rpc_http2_write_stream(conn, write_stream_id, conn->write_queue);
+    result = rpc_http2_write_stream(conn, write_stream_id, conn->write_queue,
+                                    awaited);
   }
   rpc_release_write_builder(conn, request_nested_in_response);
   if (request) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -488,7 +488,6 @@ struct rpc_thread_io {
   conn_t *response_conn = nullptr;
   rpc_response_route response;
   conn_t *held_call_lock = nullptr;
-  bool await_response = false;
 };
 
 static thread_local rpc_thread_io rpc_tls_io;
@@ -808,9 +807,8 @@ int rpc_wait_for_response(conn_t *conn) {
   int op = conn->write_op;
   uint64_t start =
       lupine_rpc_stats_path() != nullptr ? lupine_rpc_stats_now_ns() : 0;
-  rpc_tls_io.await_response = true;
   int write_id = rpc_write_end(conn);
-  if (write_id < 0) {
+  if (write_id < 0 || rpc_http2_flush(conn) < 0) {
     return -1;
   }
   rpc_http2_response_wait_begin(conn);
@@ -1023,14 +1021,11 @@ int rpc_write_cursors(conn_t *conn, const rpc_write_cursor *cursors,
 // the request lock is released after the request is sent and the function
 // returns the request id which can be used to wait for a response.
 int rpc_write_end(conn_t *conn) {
-  bool awaited = rpc_tls_io.await_response;
-  rpc_tls_io.await_response = false;
   if (conn == nullptr || rpc_tls_io.write_conn != conn) {
     return -1;
   }
   bool request = conn->write_op != -1;
   bool request_nested_in_response = rpc_tls_io.nested_write.conn == conn;
-  awaited = awaited || !request;
   if (conn->closed) {
     rpc_release_write_builder(conn, request_nested_in_response);
     if (request) {
@@ -1046,8 +1041,7 @@ int rpc_write_end(conn_t *conn) {
         rpc_write_cursor(&conn->write_id, sizeof(conn->write_id));
     conn->write_queue[1] =
         rpc_write_cursor(&conn->write_op, sizeof(conn->write_op));
-    result = rpc_http2_write_stream(conn, write_stream_id, conn->write_queue,
-                                    awaited);
+    result = rpc_http2_write_stream(conn, write_stream_id, conn->write_queue);
   }
   rpc_release_write_builder(conn, request_nested_in_response);
   if (request) {

--- a/rpc.h
+++ b/rpc.h
@@ -256,8 +256,11 @@ extern int rpc_http2_read_stream(conn_t *conn, int32_t stream_id, void *data,
                                  size_t size);
 extern int rpc_http2_write(conn_t *conn,
                            std::vector<rpc_write_cursor> &cursors);
+// flush: the message is awaited, so its block is emitted and framed before
+// the write thread is signalled instead of with that thread's next drain.
 extern int rpc_http2_write_stream(conn_t *conn, int32_t stream_id,
-                                  std::vector<rpc_write_cursor> &cursors);
+                                  std::vector<rpc_write_cursor> &cursors,
+                                  bool flush);
 extern int32_t rpc_http2_dispatch_stream(conn_t *conn);
 extern int32_t rpc_http2_lane_stream(conn_t *conn, uint64_t lane_id);
 extern int rpc_http2_end_stream(conn_t *conn, int32_t stream_id);

--- a/rpc.h
+++ b/rpc.h
@@ -256,11 +256,8 @@ extern int rpc_http2_read_stream(conn_t *conn, int32_t stream_id, void *data,
                                  size_t size);
 extern int rpc_http2_write(conn_t *conn,
                            std::vector<rpc_write_cursor> &cursors);
-// flush: the message is awaited, so its block is emitted and framed before
-// the write thread is signalled instead of with that thread's next drain.
 extern int rpc_http2_write_stream(conn_t *conn, int32_t stream_id,
-                                  std::vector<rpc_write_cursor> &cursors,
-                                  bool flush);
+                                  std::vector<rpc_write_cursor> &cursors);
 extern int32_t rpc_http2_dispatch_stream(conn_t *conn);
 extern int32_t rpc_http2_lane_stream(conn_t *conn, uint64_t lane_id);
 extern int rpc_http2_end_stream(conn_t *conn, int32_t stream_id);


### PR DESCRIPTION
## Summary

Follows #746 (now merged). With the socket write already on a per-connection write thread, this moves the rest of the per-RPC transport work off the calling thread for fire-and-forget messages and stops the thread hand-off from costing a futex round trip per RPC.

What changes in `h2.cpp`:

- **One LZ4 block per burst.** The caller runs `LZ4F_compressUpdate` (a memcpy into the encoder's block buffer for anything short of 4 MiB) and marks the stream flush-pending. The write thread calls `LZ4F_flush` for every pending stream right before each socket write, so every message queued while one send was in flight shares a single block and a single DATA frame instead of paying a block, a flush marker and a frame each. Only completed 4 MiB blocks are framed on the caller's thread (bulk copies), which keeps the first-byte behaviour for very compressible bodies.
- **Persistent per-stream DATA provider.** Each stream submits one nghttp2 DATA item that returns `NGHTTP2_ERR_DEFERRED` when its `encoded` buffer is empty and is resumed when output lands, so there is no `nghttp2_submit_data` (and its allocation) per message, and the stack-owned `h2_write_source` + connection-wide `encoder_output` workspace go away. Refill cursors are now driven directly by the caller instead of through callback deferral.
- **Awaited messages flush inline.** A response, or a request whose caller is about to wait (`rpc_wait_for_response` sets a thread-local hint consumed by `rpc_write_end`), emits its block and frames it before signalling the write thread: deferring it gains nothing and would only drag the encoder and nghttp2 state onto the other core. Measured as required to keep sync-RPC latency flat.
- **Writer wake-up.** The caller signals after releasing `session_mutex`, and the client's write thread polls a generation counter for up to 200 µs before parking on the condvar. Parked, every RPC cost the producer a futex wake plus a contended-mutex sleep/wake; polling covers the gap between back-to-back RPCs so neither side enters the kernel. The server's write thread does not poll (one per connection).

Invariants: bytes on a stream still leave in order (one encoder, one append-only `encoded` buffer, all under `session_mutex`); LZ4 block boundaries are transparent to the receiver's streaming `LZ4F_decompress`, so a block spanning messages (or a message spanning blocks) decodes identically; no data is held on a timer — the only deferral is until the write thread's next drain, which happens as soon as it is signalled; back-pressure moves from "blocked on the peer window" to "more than 8 MiB of encoded output behind the window", matching the existing outbound limit; `rpc_http2_flush` also drains flush-pending streams.

## Measured

`gpt_bench_steps.py` (tiny GPT, ~324 RPCs/step), `NOITEM=1`, server on node-008 (RTX 4090). "main" = 340f7821, "base" = #746, "this" = this PR at 200 µs poll.

**WSL2 client (Ryzen 3900X, no GPU, ~0.3 ms RTT to node-008), NSTEPS=300, CPU-bound** — the target case:

| client shim | steps2+ median (ms) | main-thread CPU user / sys | process vol. ctx switches | total user / sys |
|---|---|---|---|---|
| main | 14.5 / 16.8 / 16.4 | 4.67 s / 1.12 s | 3.3 k | 9.2 s / 1.6–2.0 s |
| base (#746) | 20.6 / 20.8 / 21.4 | 5.07 s / 1.35 s | 77–81 k | 10.4 s / 3.8–4.0 s |
| this, poll 0 | 18.8 / 18.9 | — | 73 k | 9.7–10.1 s / 3.4–3.8 s |
| this, poll 50 µs | 11.9 / 12.1 / 14.0 | — | 17–20 k | 10.5–11.2 s / 1.6–2.0 s |
| **this, poll 200 µs** | **11.1 / 11.5** (both ends patched: 11.3 / 11.8) | **4.27 s / 0.70 s** | **7.6–7.7 k** | 11.0–11.3 s / 1.3–1.5 s |

The total `user` column includes the write thread's polling (~2.8 s here, on a separate core); the main-thread column is what gates step time. #746 alone regresses this box because the per-RPC wake and mutex contention cost more than the inline `sendmsg` it removed; the writer-side flush is worth ~2 ms/step on its own and the poll recovers the rest.

**node-006 client (Ryzen 7950X, GPU-less), LAN, NSTEPS=200:** steps2+ median main 6.1–6.3 ms, base 4.56 ms, this 4.06–4.30 ms (native on the node ≈4.2 ms); context switches 2.6 k / 55 k / 6–8 k.

**node-006, 150 ms RTT, NSTEPS=100:** setup 76.7 → 76.9 s, step0 21.83 → 21.88 s, step1 0.76 → 0.76 s (all RTT-bound sync counts, untouched); steps2+ median 6.06 → 3.81 ms, mean 13.55 → 3.90 ms, max 112.9 → 6.1 ms.

**Sync RPC latency, node-006 LAN, `/tmp/latbench 3000`, 3 alternating runs each (cuMemGetInfo p50):** main 174.6 / 179.0 / 189.5 µs, base 181.3 / 181.8 / 182.0 µs, this 180.9 / 181.7 / 183.6 µs — within the link's noise. (Before the inline-flush hint, this was ~5 µs slower than main.)

**Cloud TLS path** (`lupine run --gpu rtx-pro-6000`, HTTPS via gw-east, NSTEPS=100): runs cleanly, steps2+ median 11.34 ms, mean 11.75 ms.

## Validation

- `ctest` 12/12 (h2_test, dispatch, events, ipc, checkpoint, nvml exports; sigterm/smemcpy skipped as usual) on the final build.
- `h2_test` changes: `test_data_provider_frame_sizing` now reads the first DATA frame (a 256 KiB write becomes one frame rather than a 16 KiB frame plus the remainder); `test_reset_wakes_flow_controlled_writer` writes 12 MiB instead of 128 KiB, because a sub-block write is now accepted immediately and the caller only blocks once 8 MiB of encoded output sit behind the peer's window — the RST still wakes it and fails the write.
- Bench runs above on WSL, node-006 (LAN and 150 ms), and the cloud TLS gateway; client-only, and client+server both patched.

## Caveats

- The client write thread burns up to 200 µs of one core after each send while it polls; during a training loop that is most of a core (≈2.8 s user over a 4 s run here). It is bounded, it costs nothing when the client is idle beyond one 200 µs spin, and the server never polls. If that is unwelcome on small clients, `kH2WriterPoll` is the single knob.
- A fire-and-forget write now returns before its bytes are framed; a stream reset that lands after the write returns surfaces on the stream's next operation rather than from that write. Awaited messages are unaffected.
- Compressed-output capacity for sub-block updates relies on `LZ4F_compressBound_internal` reserving only the frame end when no block completes (vendored lz4 1.10.0); LZ4F checks capacity before writing, so a mismatch fails the write rather than corrupting memory.
