### PR TITLE
Prefetch library loads from a per-application profile on a pipelined lane

### DIFF
--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -2,14 +2,18 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <cuda.h>
 #include <cuda_occupancy.h>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <new>
 #include <sstream>
@@ -59,6 +63,7 @@
 #include "rpc.h"
 #include "third_party/libcuckoo/libcuckoo/cuckoohash_map.hh"
 #include "transport.h"
+#include "xxhash.h"
 
 #ifdef cuMemPrefetchAsync
 #undef cuMemPrefetchAsync
@@ -5161,6 +5166,409 @@ static int lupine_read_library(conn_t *conn, CUlibrary library) {
   return 0;
 }
 
+// The image-following part of a library load request. Values travel by value;
+// an absent library value array is encoded as each option's complement so the
+// server can tell the two apart.
+struct lupine_library_load_request {
+  uint32_t kind = 0;
+  size_t image_size = 0;
+  const unsigned char *image = nullptr;
+  std::vector<unsigned char> options;
+};
+
+static std::vector<unsigned char> lupine_pack_library_load_options(
+    CUjit_option *jitOptions, void **jitOptionsValues,
+    unsigned int numJitOptions, CUlibraryOption *libraryOptions,
+    void **libraryOptionValues, unsigned int numLibraryOptions) {
+  std::vector<unsigned char> bytes;
+  auto append = [&](const void *data, size_t size) {
+    const auto *begin = static_cast<const unsigned char *>(data);
+    if (size != 0) {
+      bytes.insert(bytes.end(), begin, begin + size);
+    }
+  };
+  append(&numJitOptions, sizeof(numJitOptions));
+  append(jitOptions, numJitOptions * sizeof(*jitOptions));
+  append(jitOptionsValues, numJitOptions * sizeof(*jitOptionsValues));
+  append(&numLibraryOptions, sizeof(numLibraryOptions));
+  append(libraryOptions, numLibraryOptions * sizeof(*libraryOptions));
+  for (unsigned int i = 0; i < numLibraryOptions; ++i) {
+    uintptr_t value = libraryOptionValues != nullptr
+                          ? reinterpret_cast<uintptr_t>(libraryOptionValues[i])
+                          : ~static_cast<uintptr_t>(libraryOptions[i]);
+    append(&value, sizeof(value));
+  }
+  return bytes;
+}
+
+// The request references *load until the caller ends it. Callers prepare the
+// connection themselves: a prefetch lane must not interleave the host flush
+// that lupine_prepare_rpc may issue with its pipelined loads.
+static int
+lupine_write_library_load_request(conn_t *conn, int opcode,
+                                  const lupine_library_load_request &load) {
+  if (rpc_write_start_request(conn, opcode) < 0 ||
+      rpc_write(conn, &load.kind, sizeof(load.kind)) < 0 ||
+      rpc_write(conn, &load.image_size, sizeof(load.image_size)) < 0 ||
+      rpc_write(conn, load.image, load.image_size) < 0 ||
+      rpc_write(conn, load.options.data(), load.options.size()) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+// Applies the appended kernel snapshot on the reading thread, so a prefetch
+// lane must have the app's context current when it collects.
+static int lupine_read_library_load_response(
+    conn_t *conn, unsigned int numJitOptions, const CUjit_option *jitOptions,
+    void **jitOptionsValues, CUlibrary *library, CUresult *result) {
+  if (rpc_read(conn, library, sizeof(*library)) < 0 ||
+      lupine_read_jit_outputs(conn, numJitOptions, jitOptions,
+                              jitOptionsValues) < 0 ||
+      rpc_read(conn, result, sizeof(*result)) < 0 ||
+      (*result == CUDA_SUCCESS && lupine_read_library(conn, *library) < 0)) {
+    return -1;
+  }
+  return rpc_read_end(conn);
+}
+
+// A load issued from the previous run's profile before cudart asks for it.
+// Entries are claimed once, in send order, so every handle cudart receives is
+// distinct and unloads keep their native meaning.
+struct lupine_library_prefetch_entry {
+  uint64_t hash = 0;
+  lupine_library_load_request load;
+  std::vector<unsigned char> image;
+  bool arrived = false;
+  CUlibrary library = nullptr;
+  CUresult result = CUDA_ERROR_UNKNOWN;
+};
+
+struct lupine_library_prefetch_state {
+  std::mutex mutex;
+  std::condition_variable arrived;
+  bool started = false;
+  bool finished = false;
+  int route_id = -2;
+  std::vector<std::shared_ptr<lupine_library_prefetch_entry>> pending;
+  std::filesystem::path profile;
+  std::string lines;
+};
+
+static lupine_library_prefetch_state &lupine_library_prefetch() {
+  static auto *state = new lupine_library_prefetch_state();
+  return *state;
+}
+
+static std::string lupine_hex(const void *data, size_t size) {
+  static const char digits[] = "0123456789abcdef";
+  const auto *bytes = static_cast<const unsigned char *>(data);
+  std::string out;
+  for (size_t i = 0; i < size; ++i) {
+    out += digits[bytes[i] >> 4];
+    out += digits[bytes[i] & 15];
+  }
+  return out;
+}
+
+static bool lupine_unhex(const std::string &text,
+                         std::vector<unsigned char> *bytes) {
+  auto nibble = [](char c) {
+    return c >= '0' && c <= '9'   ? c - '0'
+           : c >= 'a' && c <= 'f' ? c - 'a' + 10
+                                  : -1;
+  };
+  bytes->resize(text.size() / 2);
+  for (size_t i = 0; i < bytes->size(); ++i) {
+    int high = nibble(text[2 * i]);
+    int low = nibble(text[2 * i + 1]);
+    if (high < 0 || low < 0) {
+      return false;
+    }
+    (*bytes)[i] = static_cast<unsigned char>(high << 4 | low);
+  }
+  return text.size() % 2 == 0;
+}
+
+static std::filesystem::path lupine_library_cache_dir() {
+  const char *cache = std::getenv("LUPINE_LIBRARY_CACHE");
+  if (cache != nullptr) {
+    return cache;
+  }
+  const char *xdg = std::getenv("XDG_CACHE_HOME");
+  const char *home = std::getenv("HOME");
+  if (xdg != nullptr && *xdg != '\0') {
+    return std::filesystem::path(xdg) / "lupine" / "libraries";
+  }
+  if (home != nullptr && *home != '\0') {
+    return std::filesystem::path(home) / ".cache" / "lupine" / "libraries";
+  }
+  return {};
+}
+
+// Profiles are keyed by the full command line, so `python train.py` and
+// `python eval.py` keep separate load orders while sharing image files.
+static std::filesystem::path
+lupine_library_profile_path(const std::filesystem::path &dir) {
+  const char *name = std::getenv("LUPINE_LIBRARY_PROFILE");
+  std::string key = name != nullptr ? name : "";
+  if (key.empty()) {
+    std::ifstream cmdline("/proc/self/cmdline", std::ios::binary);
+    std::string argv((std::istreambuf_iterator<char>(cmdline)),
+                     std::istreambuf_iterator<char>());
+    if (argv.empty()) {
+      return {};
+    }
+    uint64_t hash = XXH64(argv.data(), argv.size(), 0);
+    key = lupine_hex(&hash, sizeof(hash));
+  }
+  return dir / "profiles" / key;
+}
+
+static void lupine_write_file_atomically(const std::filesystem::path &path,
+                                         const void *data, size_t size) {
+  std::error_code ec;
+  std::filesystem::create_directories(path.parent_path(), ec);
+  std::filesystem::path temp = path;
+  temp += "." +
+          std::to_string(
+              std::chrono::steady_clock::now().time_since_epoch().count()) +
+          ".tmp";
+  std::ofstream out(temp, std::ios::binary);
+  out.write(static_cast<const char *>(data),
+            static_cast<std::streamsize>(size));
+  out.close();
+  if (!out) {
+    std::filesystem::remove(temp, ec);
+    return;
+  }
+  std::filesystem::rename(temp, path, ec);
+  if (ec) {
+    std::filesystem::remove(temp, ec);
+  }
+}
+
+static void lupine_trim_library_cache(const std::filesystem::path &images) {
+  const char *limit_env = std::getenv("LUPINE_LIBRARY_CACHE_BYTES");
+  uintmax_t limit = limit_env != nullptr ? std::strtoull(limit_env, nullptr, 10)
+                                         : UINTMAX_C(1) << 30;
+  std::vector<std::tuple<std::filesystem::file_time_type, uintmax_t,
+                         std::filesystem::path>>
+      files;
+  uintmax_t total = 0;
+  std::error_code ec;
+  for (const auto &entry : std::filesystem::directory_iterator(images, ec)) {
+    if (entry.is_regular_file(ec)) {
+      uintmax_t size = entry.file_size(ec);
+      total += size;
+      files.emplace_back(entry.last_write_time(ec), size, entry.path());
+    }
+  }
+  std::sort(files.begin(), files.end());
+  for (const auto &[time, size, path] : files) {
+    if (total <= limit) {
+      break;
+    }
+    total -= size;
+    std::filesystem::remove(path, ec);
+  }
+}
+
+// Only image files that hash to their own name are trusted, so a truncated or
+// hand-edited cache entry costs a normal load rather than a wrong library.
+static std::vector<std::shared_ptr<lupine_library_prefetch_entry>>
+lupine_read_library_profile(const std::filesystem::path &dir,
+                            const std::filesystem::path &profile) {
+  std::vector<std::shared_ptr<lupine_library_prefetch_entry>> entries;
+  std::ifstream in(profile);
+  std::string line;
+  while (std::getline(in, line) && entries.size() < 4096) {
+    std::istringstream fields(line);
+    std::string hash_hex;
+    std::string options_hex;
+    std::vector<unsigned char> hash_bytes;
+    auto entry = std::make_shared<lupine_library_prefetch_entry>();
+    if (!(fields >> hash_hex >> entry->load.kind >> options_hex) ||
+        !lupine_unhex(hash_hex, &hash_bytes) ||
+        hash_bytes.size() != sizeof(entry->hash) ||
+        !lupine_unhex(options_hex, &entry->load.options)) {
+      continue;
+    }
+    std::memcpy(&entry->hash, hash_bytes.data(), sizeof(entry->hash));
+    std::filesystem::path image_path = dir / "images" / hash_hex;
+    std::ifstream image(image_path, std::ios::binary);
+    entry->image.assign(std::istreambuf_iterator<char>(image),
+                        std::istreambuf_iterator<char>());
+    if (entry->image.empty() ||
+        XXH64(entry->image.data(), entry->image.size(), 0) != entry->hash) {
+      std::error_code ec;
+      std::filesystem::remove(image_path, ec);
+      continue;
+    }
+    entry->load.image = entry->image.data();
+    entry->load.image_size = entry->image.size();
+    entries.push_back(std::move(entry));
+  }
+  return entries;
+}
+
+// Runs on its own lane. The context switch and the loads go out back-to-back
+// and their responses are collected in the same order, so the whole profile
+// costs one round trip plus transfer instead of one round trip per library.
+// The in-flight window keeps early entries claimable while later ones are
+// still uploading, and bounds how far the burst queues ahead of the app's own
+// requests in the shared socket (at 150 ms RTT, 16 MB cost setup ~1.5 s).
+static constexpr size_t kLupineLibraryPrefetchWindowBytes = 4 * 1024 * 1024;
+
+static void lupine_library_prefetch_main(
+    lupine_route route, CUcontext context,
+    std::vector<std::shared_ptr<lupine_library_prefetch_entry>> entries) {
+  auto &state = lupine_library_prefetch();
+  conn_t *conn = lupine_route_remote_conn(route);
+  lupine_current_context = context;
+  auto start = std::chrono::steady_clock::now();
+  std::vector<int> ids;
+  int context_id = -1;
+  if (lupine_prepare_rpc(conn) >= 0 &&
+      rpc_write_start_request(conn, RPC_cuCtxSetCurrent) >= 0 &&
+      rpc_write(conn, &context, sizeof(context)) >= 0) {
+    context_id = rpc_write_end(conn);
+  }
+  CUresult context_result = CUDA_ERROR_UNKNOWN;
+  bool ok = context_id >= 0;
+  size_t collected = 0;
+  size_t in_flight = 0;
+  while (ok && collected < entries.size()) {
+    if (ids.size() < entries.size() &&
+        (ids.size() == collected ||
+         in_flight < kLupineLibraryPrefetchWindowBytes)) {
+      const auto &entry = entries[ids.size()];
+      int id = -1;
+      ok = lupine_write_library_load_request(conn, RPC_cuLibraryLoadData,
+                                             entry->load) >= 0 &&
+           (id = rpc_write_end(conn)) >= 0;
+      ids.push_back(id);
+      in_flight += entry->load.image_size;
+      continue;
+    }
+    if (collected == 0) {
+      ok = rpc_wait_for_pipelined_response(conn, context_id) >= 0 &&
+           rpc_read(conn, &context_result, sizeof(context_result)) >= 0 &&
+           rpc_read_end(conn) >= 0 && context_result == CUDA_SUCCESS;
+    }
+    auto &entry = entries[collected];
+    CUlibrary library = nullptr;
+    CUresult result = CUDA_ERROR_UNKNOWN;
+    if (!ok || rpc_wait_for_pipelined_response(conn, ids[collected]) < 0 ||
+        lupine_read_library_load_response(conn, 0, nullptr, nullptr, &library,
+                                          &result) < 0) {
+      break;
+    }
+    in_flight -= entry->load.image_size;
+    ++collected;
+    std::lock_guard<std::mutex> lock(state.mutex);
+    entry->library = library;
+    entry->result = result;
+    entry->arrived = true;
+    state.arrived.notify_all();
+  }
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    state.finished = true;
+    state.arrived.notify_all();
+  }
+  LUPINE_TRACE_LOG("LUPINE prefetched "
+                   << collected << "/" << entries.size() << " libraries in "
+                   << std::chrono::duration<double, std::milli>(
+                          std::chrono::steady_clock::now() - start)
+                          .count()
+                   << " ms");
+}
+
+static void lupine_library_prefetch_start(lupine_route route) {
+  auto &state = lupine_library_prefetch();
+  std::lock_guard<std::mutex> lock(state.mutex);
+  if (state.started) {
+    return;
+  }
+  state.started = true;
+  state.route_id = lupine_route_identity(route);
+  std::filesystem::path dir = lupine_library_cache_dir();
+  if (!dir.empty()) {
+    state.profile = lupine_library_profile_path(dir);
+  }
+  if (state.profile.empty()) {
+    return;
+  }
+  auto entries = lupine_read_library_profile(dir, state.profile);
+  if (entries.empty()) {
+    return;
+  }
+  state.pending = entries;
+  std::thread(lupine_library_prefetch_main, route, lupine_current_context,
+              std::move(entries))
+      .detach();
+}
+
+static bool
+lupine_library_prefetch_claim(lupine_route route, uint64_t hash,
+                              const lupine_library_load_request &load,
+                              CUlibrary *library) {
+  auto &state = lupine_library_prefetch();
+  std::unique_lock<std::mutex> lock(state.mutex);
+  if (lupine_route_identity(route) != state.route_id) {
+    return false;
+  }
+  auto it = std::find_if(
+      state.pending.begin(), state.pending.end(), [&](const auto &entry) {
+        return entry->hash == hash && entry->load.kind == load.kind &&
+               entry->load.options == load.options &&
+               entry->image.size() == load.image_size &&
+               std::memcmp(entry->image.data(), load.image, load.image_size) ==
+                   0;
+      });
+  if (it == state.pending.end()) {
+    return false;
+  }
+  auto entry = *it;
+  state.pending.erase(it);
+  state.arrived.wait(lock, [&] { return entry->arrived || state.finished; });
+  if (!entry->arrived || entry->result != CUDA_SUCCESS) {
+    return false;
+  }
+  *library = entry->library;
+  return true;
+}
+
+// Loads carrying JIT options are not recorded: their log buffers and wall-time
+// outputs belong to the call that passes them.
+static void
+lupine_library_profile_record(lupine_route route, uint64_t hash,
+                              const lupine_library_load_request &load) try {
+  auto &state = lupine_library_prefetch();
+  std::lock_guard<std::mutex> lock(state.mutex);
+  unsigned int jit_options = 0;
+  std::memcpy(&jit_options, load.options.data(), sizeof(jit_options));
+  if (state.profile.empty() || jit_options != 0 ||
+      lupine_route_identity(route) != state.route_id) {
+    return;
+  }
+  std::filesystem::path images =
+      state.profile.parent_path().parent_path() / "images";
+  std::string hash_hex = lupine_hex(&hash, sizeof(hash));
+  std::error_code ec;
+  if (!std::filesystem::exists(images / hash_hex, ec)) {
+    lupine_write_file_atomically(images / hash_hex, load.image,
+                                 load.image_size);
+    lupine_trim_library_cache(images);
+  }
+  state.lines += hash_hex + " " + std::to_string(load.kind) + " " +
+                 lupine_hex(load.options.data(), load.options.size()) + "\n";
+  lupine_write_file_atomically(state.profile, state.lines.data(),
+                               state.lines.size());
+} catch (...) {
+}
+
 extern "C" CUresult
 cuLibraryLoadData(CUlibrary *library, const void *code,
                   CUjit_option *jitOptions, void **jitOptionsValues,
@@ -5199,49 +5607,22 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  size_t image_size = image_bytes.size();
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
-      rpc_copy_alloc(conn, libraryOptionValues == nullptr
-                               ? numLibraryOptions * sizeof(uintptr_t)
-                               : 0) < 0 ||
-      rpc_write(conn, &kind, sizeof(kind)) < 0 ||
-      rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
-      rpc_write(conn, image_bytes.data(), image_size) < 0 ||
-      rpc_write(conn, &numJitOptions, sizeof(numJitOptions)) < 0 ||
-      rpc_write(conn, jitOptions, numJitOptions * sizeof(*jitOptions)) < 0 ||
-      rpc_write(conn, jitOptionsValues,
-                numJitOptions * sizeof(*jitOptionsValues)) < 0 ||
-      rpc_write(conn, &numLibraryOptions, sizeof(numLibraryOptions)) < 0 ||
-      rpc_write(conn, libraryOptions,
-                numLibraryOptions * sizeof(*libraryOptions)) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (libraryOptionValues != nullptr) {
-    if (rpc_write(conn, libraryOptionValues,
-                  numLibraryOptions * sizeof(*libraryOptionValues)) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-  } else {
-    auto *wire_values = static_cast<uintptr_t *>(rpc_write_buffer(
-        conn, numLibraryOptions * sizeof(uintptr_t), alignof(uintptr_t)));
-    for (unsigned int i = 0; i < numLibraryOptions; ++i) {
-      wire_values[i] = ~static_cast<uintptr_t>(libraryOptions[i]);
-    }
-  }
-  if (rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, library, sizeof(CUlibrary)) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (lupine_read_jit_outputs(conn, numJitOptions, jitOptions,
-                              jitOptionsValues) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      (return_value == CUDA_SUCCESS &&
-       lupine_read_library(conn, *library) < 0) ||
-      rpc_read_end(conn) < 0) {
+  lupine_library_load_request load = {
+      kind, image_bytes.size(), image_bytes.data(),
+      lupine_pack_library_load_options(jitOptions, jitOptionsValues,
+                                       numJitOptions, libraryOptions,
+                                       libraryOptionValues, numLibraryOptions)};
+  uint64_t hash = XXH64(load.image, load.image_size, 0);
+  lupine_library_prefetch_start(route);
+  CUresult return_value = CUDA_SUCCESS;
+  if (!lupine_library_prefetch_claim(route, hash, load, library) &&
+      (lupine_prepare_rpc(conn) < 0 ||
+       lupine_write_library_load_request(conn, RPC_cuLibraryLoadData, load) <
+           0 ||
+       rpc_wait_for_response(conn) < 0 ||
+       lupine_read_library_load_response(conn, numJitOptions, jitOptions,
+                                         jitOptionsValues, library,
+                                         &return_value) < 0)) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (return_value == CUDA_SUCCESS) {
@@ -5249,6 +5630,7 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
     lupine_record_library_image(*library, lupine_remote_route_for_conn(conn),
                                 kind, image_bytes.data(), image_bytes.size(),
                                 code);
+    lupine_library_profile_record(route, hash, load);
   }
   return return_value;
 }

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -823,6 +823,22 @@ int rpc_wait_for_response(conn_t *conn) {
   return 0;
 }
 
+int rpc_wait_for_pipelined_response(conn_t *conn, int write_id) {
+  if (conn == nullptr) {
+    return -1;
+  }
+  rpc_tls_io.response_conn = conn;
+  rpc_tls_io.response = {write_id,
+                         rpc_http2_lane_stream(conn, rpc_tls_lane.id)};
+  if (rpc_http2_flush(conn) < 0) {
+    return -1;
+  }
+  rpc_http2_response_wait_begin(conn);
+  int result = rpc_read_start(conn, write_id);
+  rpc_http2_response_wait_end(conn);
+  return result;
+}
+
 // rpc_write_start_request starts a new request builder on the given connection
 // index with a specific op code.
 //

--- a/rpc.h
+++ b/rpc.h
@@ -187,6 +187,11 @@ extern int rpc_drain(conn_t *conn, size_t size);
 extern int rpc_read_end(conn_t *conn);
 
 extern int rpc_wait_for_response(conn_t *conn);
+// Requests sent back-to-back on one lane are answered in send order. Waits for
+// the response to an earlier request by the id rpc_write_end returned; the
+// caller must collect every pipelined response, in order, before the lane
+// waits for any later request.
+extern int rpc_wait_for_pipelined_response(conn_t *conn, int write_id);
 
 // Owns connection validation for the request chain: a null conn (route with no
 // remote server) or a closed conn fails here, so callers surface their


### PR DESCRIPTION
## Summary

Since #747 every `cuLibraryLoadData` is one round trip, but cudart still issues them strictly serially (a kernel misses, its fatbin is loaded, the handle is awaited, the next miss loads the next library), so the gpt benchmark pays 59 × RTT plus 59 cold uploads (111 MB) at 150 ms. This takes those loads off the critical path:

- **Per-application profile.** The first remote load reads `~/.cache/lupine/libraries/profiles/<key>` (`$XDG_CACHE_HOME` honoured; `LUPINE_LIBRARY_CACHE` overrides the directory, empty disables), listing the images the previous run loaded in order, with a content-addressed copy of each image under `images/<xxh64>`. `<key>` is `LUPINE_LIBRARY_PROFILE` or the XXH64 of `/proc/self/cmdline`, so `python train.py` and `python eval.py` keep separate load orders while sharing image files. Every successful remote load rewrites the profile (atomic temp+rename) and stores its image if absent; the image directory is trimmed oldest-first above `LUPINE_LIBRARY_CACHE_BYTES` (default 1 GiB).
- **Pipelined prefetch on its own lane.** A detached thread opens its own HTTP/2 lane, sends `cuCtxSetCurrent` for the app's context and then every profiled load back-to-back (the plain `cuLibraryLoadData` op, whose response carries the kernel snapshot since #747), and collects the responses in send order with the same request writer and response reader as the normal path. The snapshot is applied by `lupine_read_library` on the reading thread, so the prefetch thread sets its thread-local context hint to the app's context before collecting. The whole profile costs one RTT plus transfer instead of one RTT per library. A 4 MB in-flight window makes early entries claimable while later ones upload and bounds how far the burst queues ahead of the app's own requests in the shared socket (measured below).
- **Claim by content.** `cuLibraryLoadData` hashes the packed image; a pending entry with the same hash, kind, option bytes and identical image bytes (full `memcmp`, so XXH64 needs no collision resistance) is claimed once, waiting for its response if it has not arrived, and the owner/image bookkeeping runs on the caller thread. Anything else — no profile, differing options, mismatching bytes, prefetch failure — is a normal load.

Transport extension: `rpc_wait_for_pipelined_response(conn, write_id)` flushes (like `rpc_wait_for_response`, so a burst shares one LZ4 block per #751) and waits for an earlier request's response on the calling thread's lane. Responses on a lane arrive in send order (the server handles each stream sequentially), so a pipelining caller must collect them in that order before the lane waits for anything else; the prefetch thread owns its lane, so nothing else ever waits on it. `lupine_prepare_rpc` is deliberately called once at thread start rather than per request: the host flush it may issue is a synchronous RPC and must not interleave with the pipelined loads.

Invariants kept: every handle cudart receives is distinct (entries are consumed once, so `cuLibraryUnload` keeps its native meaning); a prefetched library belongs to the route it was loaded on and is claimed only for loads on that route; loads carrying JIT options are never recorded (their log/wall-time outputs belong to the call that passes them); library options are matched by wire bytes, so pointer-valued options that change between runs fall back. Only image files that hash to their own name are trusted, and a file that fails the check is removed so the run's normal load rewrites it.

Why not the alternatives: dedupe alone does nothing here (cudart never loads the same image twice per process). Pipelining on the app's lane would have to drain every outstanding prefetch response before any unrelated RPC on that lane could wait, blocking setup for the whole upload; a separate lane keeps the app's lane clean and lets setup overlap the transfer.

Diff: +448/−43 in `cuda_client.cpp`, `rpc.cpp`, `rpc.h`. No server or wire changes.

## Measured

node-006 (GPU-less client, `CUDA_VISIBLE_DEVICES=""`) → node-008 (RTX 4090), `gpt_bench_steps.py`. Server built from this branch (server code is identical to main). "main" = a client shim built from `origin/main` (`8d7faa4e`); "cold" = this branch with no profile (its per-step path is main's plus hashing and recording); "warm" = the following run.

150 ms RTT (netem, port 15311), NSTEPS=200 (main/cold rows at NSTEPS=20 for the per-step medians):

| | main | cold (no profile) | warm |
|---|---|---|---|
| setup | 19.76 s | 19.82 s | **15.38 s** |
| step 0 | 13.98 s | 14.02 s | **12.09 s** |
| step 1 | 2.72 s | 2.73 s | 3.03 s |
| steps 2+ median | 1967 ms | 1970 ms | 2271 ms |
| prefetch burst | — | — | 59/59 libraries in 6.3 s (111 MB) |

Note the steady state: current main runs ~2 s per training step at 150 ms (it was 6 ms on the #747 branch tip this PR was first measured on — setup 20.9 s, step 0 13.4 s, steps 2+ 5.98 ms). The pure-main shim against the same server reproduces it exactly, so it is a regression already on main (post #746/#751), independent of this change; it also inflates every synchronous RPC in step 0/1, which is why the step-0 gain here (−1.9 s) is smaller than on the #747 tip (13.41 → 10.94 s, −2.5 s, with setup 20.92 → 16.57 s).

LAN (~0.3 ms, port 15321), NSTEPS=200:

| | main | cold | warm |
|---|---|---|---|
| setup | 2.46 s | 2.47 s | 2.45 s |
| step 0 | 745 ms | 794 ms | **321 ms** |
| steps 2+ median | 9.5 ms | 11.2 ms | 11.5 ms |

(On the #747 tip the same comparison was 481–487 ms → 84–91 ms for step 0 with steps 2+ at 5.6–6.3 ms on both sides.)

Synchronous RPC counts (`LUPINE_RPC_STATS`, LAN): main/cold issue 30 `cuLibraryLoadData` round trips in setup and 29 in step 0. Warm: 0 synchronous loads on the app thread in setup and step 0 — all 59 are claimed from the prefetch lane (the op count of 59 is the prefetch thread's sends, 0 ms blocked). A profile written by a setup-only run (30 libraries) prefetches those 30 and loads the other 29 normally. All other per-phase counts are unchanged.

Window sweep at 150 ms on the #747 tip (in-flight bytes → setup / burst): 2 MB → 16.35 s / 7.1 s; 4 MB → 16.50 s / 6.1 s; 16 MB → 17.91 s / 5.2 s; 64 MB → 18.54 s / 5.0 s. Larger windows finish the burst sooner but every app-thread RPC during the burst queues behind more prefetch bytes in the shared TCP socket; 4 MB is the knee.

## Validation

- `ctest`: 12/12 passed (3 skipped, no local GPU) on the rebased branch; `.claude/fmt-check.sh` clean against main.
- Stale/corrupt profile (on the #747 tip): hand-edited a bogus hash line, appended a junk line, truncated one cached image and overwrote another with garbage. The run prefetched the remaining 56/56, loaded the 3 others normally, completed, removed the two bad image files and rewrote a full 59-entry profile.
- Losses: the bench is unseeded, so trajectories vary run to run; final losses are within the run-to-run spread, and the no-profile run — which never touches the prefetch path — sits in the same band as the warm runs.

## Caveats

- Only the route of the first remote load is prefetched; other routes of a multi-GPU app load normally.
- Profiled libraries the app no longer loads stay loaded on the server for the life of the connection (bounded by the 4096-entry profile cap and the cache size limit); the next run's profile drops them.
- On non-Linux clients there is no `/proc/self/cmdline`, so the profile is disabled unless `LUPINE_LIBRARY_PROFILE` names one.
- The remaining gap to "loads are free" is the upload itself (111 MB at ~18–21 MB/s over the 150 ms path, wire-bound) and the head-of-line delay it imposes on app-thread RPCs during the burst. A dedicated bulk connection or `TCP_NOTSENT_LOWAT` on the shared socket would remove the latter; compression of the images beyond the stream's lz4 would shrink the former.
- The unit tests do not exercise the prefetch (it needs a live server); behaviour was validated end to end on node-006/node-008 as above.
