### PR TITLE
Create the torch stream pool with the primary context and hand streams out of it

### DIFF
--- a/codegen/annotations_cuda.h
+++ b/codegen/annotations_cuda.h
@@ -1479,6 +1479,7 @@ CUresult cuPointerGetAttributes(unsigned int numAttributes,
                                 CUpointer_attribute *attributes, void **data,
                                 CUdeviceptr ptr);
 /**
+ * @disabled client - manual client hands out pooled streams
  * @routingkey CURRENT_CONTEXT
  * @recordowner STREAM phStream
  * @param phStream SEND_RECV
@@ -1486,6 +1487,7 @@ CUresult cuPointerGetAttributes(unsigned int numAttributes,
  */
 CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags);
 /**
+ * @disabled client - manual client hands out pooled streams
  * @routingkey CURRENT_CONTEXT
  * @recordowner STREAM phStream
  * @param phStream SEND_RECV
@@ -3324,6 +3326,8 @@ void cuGraphConditionalHandleCreate();
 void cuGraphAddNode_v2();
 /** @disabled */
 void lupineEventQueryBatch();
+/** @disabled */
+void lupineStreamPoolInit();
 /** @disabled */
 void cuStreamBeginCaptureToGraph();
 /** @disabled handle_cuStreamUpdateCaptureDependencies */

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -229,6 +229,7 @@ PRIVATE_RPC_FUNCTIONS = [
     "lupineFunctionAttributeSnapshot",
     "lupineFunctionParamLayoutSnapshot",
     "lupineManagedHostFlush",
+    "lupineStreamPoolInit",
 ]
 
 REGISTRY_CPP_TEMPLATE = Template(

--- a/codegen/gen_cuda_client.cpp
+++ b/codegen/gen_cuda_client.cpp
@@ -2620,61 +2620,6 @@ CUresult cuMemRangeGetAttribute(void *data, size_t dataSize,
   return return_value;
 }
 
-CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
-  lupine_route route = lupine_route_for_current_context();
-  CUresult return_value;
-  if (lupine_route_is_local(route)) {
-    return_value = lupine_call_real_cuda_fn("cuStreamCreate", phStream, Flags);
-    if (return_value == CUDA_SUCCESS && phStream != nullptr) {
-      lupine_note_stream_owner_route(*phStream, route);
-    }
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuStreamCreate) < 0 ||
-      rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
-      rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, phStream, sizeof(CUstream)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS && phStream != nullptr) {
-    lupine_note_stream_owner_route(*phStream, route);
-  }
-  return return_value;
-}
-
-CUresult cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags,
-                                    int priority) {
-  lupine_route route = lupine_route_for_current_context();
-  CUresult return_value;
-  if (lupine_route_is_local(route)) {
-    return_value = lupine_call_real_cuda_fn("cuStreamCreateWithPriority",
-                                            phStream, flags, priority);
-    if (return_value == CUDA_SUCCESS && phStream != nullptr) {
-      lupine_note_stream_owner_route(*phStream, route);
-    }
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (lupine_prepare_rpc(conn) < 0 ||
-      rpc_write_start_request(conn, RPC_cuStreamCreateWithPriority) < 0 ||
-      rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
-      rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
-      rpc_write(conn, &priority, sizeof(int)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, phStream, sizeof(CUstream)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS && phStream != nullptr) {
-    lupine_note_stream_owner_route(*phStream, route);
-  }
-  return return_value;
-}
-
 CUresult cuStreamGetPriority(CUstream hStream, int *priority) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());

--- a/codegen/gen_rpc_ids.h
+++ b/codegen/gen_rpc_ids.h
@@ -822,3 +822,4 @@
 #define LUPINE_RPC_lupineFunctionAttributeSnapshot 115640665
 #define LUPINE_RPC_lupineFunctionParamLayoutSnapshot 1930405904
 #define LUPINE_RPC_lupineManagedHostFlush 1450411892
+#define LUPINE_RPC_lupineStreamPoolInit 394532239

--- a/codegen/registry.cpp
+++ b/codegen/registry.cpp
@@ -101,6 +101,7 @@
   HANDLER(LUPINE_RPC_cuGraphConditionalHandleCreate, handle_cuGraphConditionalHandleCreate, rpc_backend::cuda) \
   HANDLER(RPC_cuGraphAddNode_v2, handle_cuGraphAddNode, rpc_backend::cuda) \
   HANDLER(LUPINE_RPC_lupineEventQueryBatch, handle_lupineEventQueryBatch, rpc_backend::cuda) \
+  HANDLER(LUPINE_RPC_lupineStreamPoolInit, handle_lupineStreamPoolInit, rpc_backend::cuda) \
   HANDLER(LUPINE_RPC_cuStreamBeginCaptureToGraph, handle_cuStreamBeginCaptureToGraph, rpc_backend::cuda) \
   HANDLER(RPC_cuStreamUpdateCaptureDependencies_v2, handle_cuStreamUpdateCaptureDependencies, rpc_backend::cuda) \
   HANDLER(LUPINE_RPC_cuStreamGetCaptureInfo_v3, handle_cuStreamGetCaptureInfo, rpc_backend::cuda) \

--- a/cuda_client.cpp
+++ b/cuda_client.cpp
@@ -2146,6 +2146,11 @@ extern "C" CUresult cuDeviceTotalMem(size_t *bytes, CUdevice dev) {
   return cuDeviceTotalMem_v2(bytes, dev);
 }
 
+static void lupine_stream_pool_init(lupine_route route, CUdevice dev,
+                                    CUcontext ctx);
+static void lupine_stream_pool_discard(int route_id, CUdevice dev,
+                                       CUcontext ctx);
+
 extern "C" CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
   CUdevice remote_dev = dev;
   lupine_route route = lupine_route_for_device(&remote_dev);
@@ -2174,6 +2179,7 @@ extern "C" CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
   }
   if (return_value == CUDA_SUCCESS && pctx != nullptr) {
     lupine_note_context_owner_route(*pctx, route);
+    lupine_stream_pool_init(route, dev, *pctx);
   }
   return return_value;
 }
@@ -2185,6 +2191,7 @@ extern "C" CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev) {
     return CUDA_ERROR_INVALID_DEVICE;
   }
   lupine_invalidate_primary_ctx_state(dev);
+  lupine_stream_pool_discard(lupine_route_identity(route), dev, nullptr);
   CUresult return_value;
   if (lupine_route_is_local(route)) {
     return_value =
@@ -2282,6 +2289,7 @@ extern "C" CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
     return CUDA_ERROR_INVALID_DEVICE;
   }
   lupine_invalidate_primary_ctx_state(dev);
+  lupine_stream_pool_discard(lupine_route_identity(route), dev, nullptr);
   CUresult return_value;
   if (lupine_route_is_local(route)) {
     return_value =
@@ -3497,6 +3505,146 @@ extern "C" CUresult cuProfilerStop(void) {
                                       : CUDA_ERROR_NOT_INITIALIZED;
 }
 
+// torch's c10 stream pool creates 32 streams at each of up to 4 priorities on
+// its first side-stream use, one round trip each. When a primary context is
+// first retained on a remote route the client instead has the server create
+// that whole pool under it with one lupineStreamPoolInit round trip, so
+// stream requests with a matching (flags, priority) are answered locally;
+// any other request is created singly. A stream belongs to the context
+// current when it was created, so pools are keyed by (route, context) and
+// dropped when that context goes away; pooled streams never handed out are
+// freed with the server context.
+static constexpr uint32_t kLupineStreamPoolMax = 4 * 32;
+
+struct lupine_stream_pool {
+  CUdevice dev;
+  std::map<std::pair<unsigned int, int>, std::vector<CUstream>> streams;
+};
+
+static std::mutex &lupine_stream_pool_mutex() {
+  static auto *mutex = new std::mutex();
+  return *mutex;
+}
+
+static std::map<std::pair<int, CUcontext>, lupine_stream_pool> &
+lupine_stream_pools() {
+  static auto *pools =
+      new std::map<std::pair<int, CUcontext>, lupine_stream_pool>();
+  return *pools;
+}
+
+// The handles arrive in creation order (stream-major, priority-minor); they
+// are pushed in reverse so hand-out pops them in that order.
+static void lupine_stream_pool_init(lupine_route route, CUdevice dev,
+                                    CUcontext ctx) {
+  std::lock_guard<std::mutex> lock(lupine_stream_pool_mutex());
+  auto &pools = lupine_stream_pools();
+  auto key = std::make_pair(lupine_route_identity(route), ctx);
+  if (pools.find(key) != pools.end()) {
+    return;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  uint32_t created = 0;
+  uint32_t priorities = 0;
+  int least = 0;
+  CUstream streams[kLupineStreamPoolMax];
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, LUPINE_RPC_lupineStreamPoolInit) < 0 ||
+      rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &created, sizeof(created)) < 0 ||
+      rpc_read(conn, &priorities, sizeof(priorities)) < 0 ||
+      rpc_read(conn, &least, sizeof(least)) < 0 ||
+      created > kLupineStreamPoolMax || (created != 0 && priorities == 0) ||
+      rpc_read(conn, streams, created * sizeof(*streams)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return;
+  }
+  auto &pool = pools[key];
+  pool.dev = dev;
+  for (uint32_t i = created; i-- > 0;) {
+    int priority = least - static_cast<int>(i % priorities);
+    pool.streams[{CU_STREAM_NON_BLOCKING, priority}].push_back(streams[i]);
+  }
+}
+
+static void lupine_stream_pool_discard(int route_id, CUdevice dev,
+                                       CUcontext ctx) {
+  std::lock_guard<std::mutex> lock(lupine_stream_pool_mutex());
+  auto &pools = lupine_stream_pools();
+  for (auto it = pools.begin(); it != pools.end();) {
+    bool matches = ctx != nullptr
+                       ? it->first.second == ctx
+                       : it->first.first == route_id && it->second.dev == dev;
+    it = matches ? pools.erase(it) : std::next(it);
+  }
+}
+
+static CUresult lupine_stream_create_remote(lupine_route route,
+                                            CUstream *phStream,
+                                            unsigned int flags, int priority) {
+  CUcontext ctx = lupine_current_context_hint();
+  if (ctx != nullptr) {
+    std::lock_guard<std::mutex> lock(lupine_stream_pool_mutex());
+    auto &pools = lupine_stream_pools();
+    auto pool = pools.find({lupine_route_identity(route), ctx});
+    if (pool != pools.end()) {
+      auto bucket = pool->second.streams.find({flags, priority});
+      if (bucket != pool->second.streams.end() && !bucket->second.empty()) {
+        *phStream = bucket->second.back();
+        bucket->second.pop_back();
+        lupine_note_stream_owner_route(*phStream, route);
+        return CUDA_SUCCESS;
+      }
+    }
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult return_value;
+  if (lupine_prepare_rpc(conn) < 0 ||
+      rpc_write_start_request(conn, RPC_cuStreamCreateWithPriority) < 0 ||
+      rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
+      rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
+      rpc_write(conn, &priority, sizeof(int)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, phStream, sizeof(CUstream)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS && phStream != nullptr) {
+    lupine_note_stream_owner_route(*phStream, route);
+  }
+  return return_value;
+}
+
+extern "C" CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
+  lupine_route route = lupine_route_for_current_context();
+  if (!lupine_route_is_local(route)) {
+    return lupine_stream_create_remote(route, phStream, Flags, 0);
+  }
+  CUresult return_value =
+      lupine_call_real_cuda_fn("cuStreamCreate", phStream, Flags);
+  if (return_value == CUDA_SUCCESS && phStream != nullptr) {
+    lupine_note_stream_owner_route(*phStream, route);
+  }
+  return return_value;
+}
+
+extern "C" CUresult cuStreamCreateWithPriority(CUstream *phStream,
+                                               unsigned int flags,
+                                               int priority) {
+  lupine_route route = lupine_route_for_current_context();
+  if (!lupine_route_is_local(route)) {
+    return lupine_stream_create_remote(route, phStream, flags, priority);
+  }
+  CUresult return_value = lupine_call_real_cuda_fn("cuStreamCreateWithPriority",
+                                                   phStream, flags, priority);
+  if (return_value == CUDA_SUCCESS && phStream != nullptr) {
+    lupine_note_stream_owner_route(*phStream, route);
+  }
+  return return_value;
+}
+
 CUresult cuStreamDestroy_v2(CUstream hStream);
 extern "C" CUresult cuEventDestroy_v2(CUevent hEvent) {
   std::unique_lock<std::shared_mutex> event_lifecycle_lock(
@@ -3660,6 +3808,7 @@ extern "C" void lupine_forget_destroyed_context(CUcontext ctx) {
     return;
   }
   lupine_forget_context_owner(ctx);
+  lupine_stream_pool_discard(-1, -1, ctx);
   if (lupine_current_context == ctx) {
     lupine_current_context = nullptr;
   }

--- a/cuda_server.cpp
+++ b/cuda_server.cpp
@@ -4605,6 +4605,57 @@ int handle_cuCtxCreate_v2(conn_t *conn) {
   return 0;
 }
 
+// Creates the client's stream pool under the context it names in one round
+// trip: kStreamPoolPerPriority streams at each usable priority from the least
+// downward, capped at kStreamPoolMaxPriorities, in torch's c10 creation order
+// (stream-major, priority-minor), all CU_STREAM_NON_BLOCKING. Creation stops
+// at the first failure; the streams already created are still returned.
+int handle_lupineStreamPoolInit(conn_t *conn) {
+  constexpr uint32_t kStreamPoolPerPriority = 32;
+  constexpr uint32_t kStreamPoolMaxPriorities = 4;
+  CUcontext context = nullptr;
+  if (rpc_read(conn, &context, sizeof(context)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  CUstream streams[kStreamPoolPerPriority * kStreamPoolMaxPriorities];
+  uint32_t created = 0;
+  uint32_t priorities = 0;
+  int least = 0;
+  int greatest = 0;
+  if (cuCtxPushCurrent(context) == CUDA_SUCCESS) {
+    priorities = 1;
+    if (cuCtxGetStreamPriorityRange(&least, &greatest) == CUDA_SUCCESS) {
+      priorities =
+          std::min<uint32_t>(kStreamPoolMaxPriorities,
+                             static_cast<uint32_t>(least - greatest) + 1);
+    }
+    for (; created < kStreamPoolPerPriority * priorities; ++created) {
+      int priority = least - static_cast<int>(created % priorities);
+      if (cuStreamCreateWithPriority(&streams[created], CU_STREAM_NON_BLOCKING,
+                                     priority) != CUDA_SUCCESS) {
+        break;
+      }
+    }
+    CUcontext popped = nullptr;
+    cuCtxPopCurrent(&popped);
+  }
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &created, sizeof(created)) < 0 ||
+      rpc_write(conn, &priorities, sizeof(priorities)) < 0 ||
+      rpc_write(conn, &least, sizeof(least)) < 0 ||
+      rpc_write(conn, streams, created * sizeof(*streams)) < 0 ||
+      rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
 int handle_cuDevicePrimaryCtxRetain(conn_t *conn) {
   CUdevice device = 0;
   if (rpc_read(conn, &device, sizeof(device)) < 0) {

--- a/cuda_server.h
+++ b/cuda_server.h
@@ -64,6 +64,7 @@ int handle_cuEventRecord(conn_t *conn);
 int handle_cuEventRecordWithFlags(conn_t *conn);
 int handle_cuEventQuery(conn_t *conn);
 int handle_lupineEventQueryBatch(conn_t *conn);
+int handle_lupineStreamPoolInit(conn_t *conn);
 int handle_cuStreamWaitEvent(conn_t *conn);
 int handle_cuStreamBeginCaptureToGraph(conn_t *conn);
 int handle_cuStreamUpdateCaptureDependencies(conn_t *conn);


### PR DESCRIPTION
## Summary

PyTorch's c10 stream pool (`initDeviceStreamState`) creates 32 streams for each of up to 4 priorities (0, -1, -2, -3, `cudaStreamNonBlocking`) the first time a program touches a side stream: `torch.cuda.Stream()`, graph capture, a pinned-memory DataLoader, DDP. Through Lupine that was 128 synchronous `cuStreamCreateWithPriority` round trips, 19.3 s at 150 ms RTT, in every such program.

A private op, `lupineStreamPoolInit(ctx)`, creates that whole pool in one round trip: the server pushes the named context, creates `32 x min(4, least - greatest + 1)` `CU_STREAM_NON_BLOCKING` streams in torch's creation order (stream-major, priority-minor), pops, and returns `created`, `priorities`, `least` and the handles. Creation stops at the first failure and the streams already created are still returned. The client issues it synchronously right after the first successful `cuDevicePrimaryCtxRetain` on a remote route for a context that has no pool yet (one call site in the retain wrapper, after the retain completes; the retain RPC itself is untouched). One extra round trip per process.

`cuStreamCreate` / `cuStreamCreateWithPriority` are now manual on the client: a request whose `(flags, priority)` has a pooled stream under the current context is answered locally; anything else (other flags, a priority outside the pooled range, a context without a pool, or a bucket that ran out) is created remotely as before. `cuStreamCreate` uses priority 0, which the driver defines it as.

Invariants:
- A stream belongs to the context current when it was created, so pools are keyed by (route, context) and hold the device they were retained for; a pool is dropped on `cuDevicePrimaryCtxRelease`/`Reset` for that route+device and when the context is destroyed (`lupine_forget_destroyed_context`). Pooled streams never handed out are freed with the server context.
- Ownership is recorded at hand-out exactly as the generated `@recordowner STREAM` client did, so routing of every later call on the stream is unchanged. `cuStreamDestroy` is forwarded unchanged.
- The pool RPC names the context explicitly rather than using the lane's current context: right after a retain the context is not yet current on the lane, and this keeps the op independent of what the lane happens to have current.

Why a separate op, and why eager: the pool is a Lupine transport optimization, not a CUDA semantic, so it does not ride on the retain reply (an earlier revision did that; it saved one round trip but tied the retain wire format to torch's pool sizing). It is issued at retain rather than on the first stream request so the pool is ready before any stream is asked for; the cost is that every app that retains a primary context on a remote route gets 128 non-blocking streams created for it (~1.6 ms server side, freed with the context) whether or not it ever asks for one. Contexts from `cuCtxCreate*` and contexts the runtime shim creates implicitly get no pool and keep creating streams one round trip each.

## Measured

node-006 (client, `CUDA_VISIBLE_DEVICES=""`) -> node-008 (RTX 4090), netem 150 ms RTT on the WAN port, LAN ~0.3 ms. main = d8789b17.

Synchronous RPCs, `gpt_bench_warm.py` (`WARMUP=3 SIDE=1`, whole run, LAN):

| op | main | this PR |
|---|---|---|
| `cuStreamCreateWithPriority` | 128 | 0 |
| `lupineStreamPoolInit` | - | 1 (1.6 ms on LAN) |
| `cuDevicePrimaryCtxRetain` | 6 | 6 (unchanged, 21.3 -> 20.5 ms/call) |
| total RPCs | 22847 | 22720 |

`gpt_bench_steps.py` (eager, no side stream) creates no streams on either build.

`gpt_bench_warm.py` phase times at 150 ms RTT:

| phase | main | this PR |
|---|---|---|
| import+device | 4.56 s | 4.72 s (+1 RTT: the pool init) |
| model init | 1.63 s | 1.59 s |
| pre-training sample (120 tokens) | 13.42 s | 13.43 s |
| 3 warm-up steps on a side stream | 33.84 s | 14.58 s |
| capture | 13.20 s | 13.18 s |
| training (500 replays, 21 loss reads) | 7.40 s | 7.41 s |
| post-training sample | 0.63 s | 0.63 s |
| total | 74.7 s | 55.5 s |

`gpt_bench_steps.py` (`NSTEPS=200`) at 150 ms RTT, no regression:

| | main | this PR |
|---|---|---|
| setup | 19.76 s | 19.83 s |
| step 0 | 12524 ms | 12521 ms |
| step 1 | 759 ms | 759 ms |
| steps 2+ median | 4.00 ms | 4.00 ms |

LAN sanity: warm-up phase 1.23 -> 1.19 s; `gpt_bench_steps.py` 7.50 -> 7.52 ms/step, step 0 653 -> 660 ms, steps 2+ median 4.21 -> 4.16 ms.

## Validation

- `ctest`: 12/12 pass (the 3 GPU-only tests skipped, as on main).
- `test/run_cuda_samples.sh` (LAN, node-008): simpleStreams, asyncAPI, StreamPriorities, simpleMultiCopy, simpleCudaGraphs all PASS.
- Driver-API probe through the shim (LAN): 44 streams over `(flags, priority)` in {(NON_BLOCKING, 0) x33, -1, -2, -3, -5, (0, 0) x2, (0, -2)} plus one `cuStreamCreate`; `cuStreamGetPriority`/`cuStreamGetFlags` match the request on every handle, all handles distinct, all 44 `cuStreamDestroy` forwarded; exactly 1 `lupineStreamPoolInit` and 6 remote `cuStreamCreateWithPriority` (the 33rd priority-0 request, the `cuStreamCreate` after the bucket emptied, priority -5, and the three flags=0 requests).

## Caveats

- 128 streams per retained primary context for every app, including ones that never create a stream (see Summary). Pools are not created for `cuCtxCreate*` contexts or for contexts the runtime shim creates implicitly.
- On a stream-creation failure during pool init the retain has already succeeded; the partial pool is used and later requests fall through to remote creates, which report the driver's error. A transport failure of the pool RPC leaves no pool; stream requests then create remotely.
- The pool mutex is held across the pool RPC so racing retains on one context cannot create two pools; only stream creation and pool teardown take that mutex.
